### PR TITLE
adding deposits, refunds, and time-to-live

### DIFF
--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -3,14 +3,10 @@
 %%
 \newcommand{\AddrRWD}{\type{Addr_{rwd}}}
 \newcommand{\DState}{\type{DState}}
+\newcommand{\DWState}{\type{DWState}}
+\newcommand{\DWEnv}{\type{DWEnv}}
 \newcommand{\PState}{\type{PState}}
-
-\newcommand{\DCert}{\type{DCert}}
-\newcommand{\DCertRegKey}{\type{DCert_{regkey}}}
-\newcommand{\DCertDeRegKey}{\type{DCert_{deregkey}}}
-\newcommand{\DCertDeleg}{\type{DCert_{delegate}}}
-\newcommand{\DCertRegPool}{\type{DCert_{regpool}}}
-\newcommand{\DCertRetirePool}{\type{DCert_{retirepool}}}
+\newcommand{\DCertBody}{\type{DCertBody}}
 
 %%
 %% Functions
@@ -341,21 +337,51 @@ Figure~\ref{fig:rules:delegationw}. The new definitions introduced in this rule
 are given in Figure~\ref{fig:defs:delegationw}.
 
 \begin{figure}
+  \emph{Abstract types}
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      tx & \Tx & \text{transaction}\\
+      cb & \DCertBody & \text{certificate body}\\
+    \end{array}
+  \end{equation*}
+  %
   \emph{Abstract functions}
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \fun{dbody} & \DCert \mapsto \VKey
+      \fun{dbody} & \DCert \mapsto \DCertBody
       & \text{body of the delegation certificate}\\
       \fun{dwit} & \DCert \mapsto (\VKey \times \Sig)
       & \text{witness for the delegation certificate}
     \end{array}
   \end{equation*}
   %
+  \emph{Delegation Witnesses environment}
+  \begin{equation*}
+    \DWEnv =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{tx} & \Tx & \text{transaction}\\
+        \var{epoch} & \Epoch & \text{epoch}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
+  \emph{Delegation Witnesses state}
+  \begin{equation*}
+    \DWState =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{dstate} & \DState & \text{delegation state}\\
+        \var{pstate} & \PState & \text{pool state}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
   \emph{Delegation Witnesses Transition}
   \begin{equation*}
     \_ \vdash \_ \trans{delegw}{\_} \_ \in
       \powerset (
-        (\Tx \times \Epoch) \times \DState \times \DCert \times \DState)
+        \DWEnv \times \DWState \times \DCert \times \DWState)
   \end{equation*}
   \caption{Delegation witnesses definitions}
   \label{fig:defs:delegationw}

--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -20,6 +20,7 @@
 \newcommand{\pool}[1]{\fun{pool}~ \var{#1}}
 \newcommand{\retire}[1]{\fun{retire}~ \var{#1}}
 \newcommand{\addrRw}[1]{\fun{addr_{rwd}}~ \var{#1}}
+\newcommand{\epoch}[1]{\fun{epoch}~ \var{#1}}
 
 %%
 %% Constants
@@ -79,6 +80,8 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       a & \AddrRWD & \text{reward address} \\
+      slot & \Slot & \text{slot}\\
+      dur & \Duration & \text{Duration}\\
       epoch & \Epoch & \text{epoch}
     \end{array}
   \end{equation*}
@@ -122,6 +125,12 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
   \\
   \fun{retire} & \DCertRetirePool \to \Epoch
   & \text{epoch of pool retirement}
+  \\
+  \fun{epoch} & \Slot \to \Epoch
+  & \text{epoch of a slot}
+  \\
+    \fun{(-)} & \Slot \to \Slot \to \Duration
+  & \text{slot duration}
   \end{array}
   \end{equation*}
   %
@@ -140,7 +149,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
     \begin{array}{l}
     \DState =
     \left(\begin{array}{r@{~\in~}lr}
-      \var{stkeys} & \powerset (\Hash) & \text{registered stake keys}\\
+      \var{stkeys} & \Hash \mapsto \Slot & \text{registered stake keys to creation time}\\
       \var{rewards} & \AddrRWD \mapsto \Coin & \text{rewards}\\
       \var{delegations} & \Hash \mapsto \Hash & \text{delegations}\\
     \end{array}\right)
@@ -148,7 +157,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
     \\
     \PState =
     \left(\begin{array}{r@{~\in~}lr}
-      \var{stpools} & \Hash \mapsto \DCertRegPool & \text{registered stake pools}\\
+      \var{stpools} & \Hash \mapsto (\DCertRegPool \times \Slot) & \text{registered stake pools to creation time}\\
       \var{retiring} & \Hash \mapsto \Epoch & \text{retiring stake pools}\\
     \end{array}\right)
     \end{array}
@@ -156,13 +165,13 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
   %
   \emph{Delegation Transitions}
   \begin{equation*}
-    \_ \trans{deleg}{\_} \_ \in
-      \powerset (\DState \times \DCert \times \DState)
+    \_ \vdash \_ \trans{deleg}{\_} \_ \in
+      \powerset (\Slot \times \DState \times \DCert \times \DState)
   \end{equation*}
   %
   \begin{equation*}
     \_ \vdash \_ \trans{pool}{\_} \_ \in
-      \powerset (\Epoch \times \DState \times \DCert \times \DState)
+      \powerset (\Slot \times \DState \times \DCert \times \DState)
   \end{equation*}
   %
   \caption{Delegation Transitions}
@@ -180,6 +189,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
       \RegKey{c} & \cauthor{c} = hk & hk \notin \var{stkeys}
     }
     {
+      \var{slot} \vdash
       \left(
       \begin{array}{r}
         \var{stkeys} \\
@@ -190,7 +200,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
       \trans{deleg}{\var{c}}
       \left(
       \begin{array}{rcl}
-        \var{stkeys} & \union & \{\var{hk}\}\\
+        \var{stkeys} & \union & \{\var{hk} \mapsto slot\}\\
         \var{rewards} & \unionoverride & \{\addrRw \var{hk} \mapsto 0\}\\
         \var{delegations}
       \end{array}
@@ -204,6 +214,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
       \DeregKey{c} & \cauthor{c} = hk & hk \in \var{stkeys}
     }
     {
+      \var{slot} \vdash
       \left(
       \begin{array}{r}
         \var{stkeys} \\
@@ -214,7 +225,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
       \trans{deleg}{\var{c}}
       \left(
       \begin{array}{rcl}
-        \var{stkeys} & \setminus & \{\var{hk}\}\\
+        \{\var{hk}\} & \subtractdom & \var{stkeys}\\
         \{\addrRw \var{hk}\} & \subtractdom & \var{rewards} \\
         \{\var{hk}\} & \subtractdom & \var{delegations}
       \end{array}
@@ -228,6 +239,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
       \Delegate{c} & \cauthor{c} = hk & hk \in \var{stkeys}
     }
     {
+      \var{slot} \vdash
       \left(
       \begin{array}{r}
         \var{stkeys} \\
@@ -259,7 +271,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
       \RegPool{c} & \cauthor{c} = hk
     }
     {
-      \var{cepoch} \vdash
+      \var{slot} \vdash
       \left(
       \begin{array}{r}
         \var{stpools} \\
@@ -280,11 +292,15 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
   \begin{equation}\label{eq:pool-ret}
     \inference[Pool-Retire]
     {
-    \RetirePool{c} & \cauthor{c} = hk & \var{hk} \in \dom \var{stpools} \\
-    \var{e} = \retire{c} & \var{cepoch} < \var{e} < \var{cepoch} + \emax
+    \RetirePool{c}
+    & \cauthor{c} = hk
+    & \var{hk} \in \dom \var{stpools} \\
+    \var{e} = \retire{c}
+    & \var{cepoch} = \epoch{slot}
+    & \var{cepoch} < \var{e} < \var{cepoch} + \emax
   }
   {
-    \var{cepoch} \vdash
+    \var{slot} \vdash
     \left(
       \begin{array}{r}
         \var{stpools} \\
@@ -304,11 +320,11 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
   \begin{equation}\label{eq:pool-reap}
     \inference[Pool-Reap]
     {
-      \var{retired} = \var{retiring}^{-1}~\var{cepoch}
+      \var{retired} = \var{retiring}^{-1}~\var{(\epoch{slot})}
       & \var{retired} \neq \emptyset
     }
     {
-      \var{cepoch} \vdash
+      \var{slot} \vdash
       \left(
       \begin{array}{r}
         \var{stpools} \\
@@ -341,7 +357,7 @@ are given in Figure~\ref{fig:defs:delegationw}.
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       tx & \Tx & \text{transaction}\\
-      cb & \DCertBody & \text{certificate body}\\
+      dcb & \DCertBody & \text{certificate body}\\
     \end{array}
   \end{equation*}
   %
@@ -361,7 +377,7 @@ are given in Figure~\ref{fig:defs:delegationw}.
     \left(
       \begin{array}{r@{~\in~}lr}
         \var{tx} & \Tx & \text{transaction}\\
-        \var{epoch} & \Epoch & \text{epoch}\\
+        \var{slot} & \Slot & \text{slot}\\
       \end{array}
     \right)
   \end{equation*}
@@ -393,16 +409,15 @@ are given in Figure~\ref{fig:defs:delegationw}.
     \label{eq:deleg-witnesses}
     \inference[Deleg-wit]
     { \dwit{c} = (\var{vk_s}, \sigma)
-      & \var{dstate} \trans{deleg}{c} \var{dstate'}
-      & \var{cepoch} \vdash \var{pstate}
-      \trans{pool}{c} \var{pstate'}
+      & \var{slot} \vdash \var{dstate} \trans{deleg}{c} \var{dstate'}
+      & \var{slot} \vdash \var{pstate} \trans{pool}{c} \var{pstate'}
       \\ ~ \\
       \verify{vk_s}{\serialised{(\dbody{c},~\txbody \var{tx})}}{\sigma}
     }
     { \left(
       \begin{array}{r}
         \var{tx} \\
-        \var{cepoch}
+        \var{slot}
       \end{array}
       \right)
       \vdash

--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -81,7 +81,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
     \begin{array}{r@{~\in~}lr}
       a & \AddrRWD & \text{reward address} \\
       slot & \Slot & \text{slot}\\
-      dur & \Duration & \text{Duration}\\
+      dur & \Duration & \text{duration}\\
       epoch & \Epoch & \text{epoch}
     \end{array}
   \end{equation*}

--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -452,19 +452,10 @@ are given in Figure~\ref{fig:defs:delegationw}.
         \var{tx}\\
         \var{slot}
       \end{array}
-      \vdash \left(
-        \begin{array}{r}
-          \var{dstate}\\
-          \var{pstate}
-        \end{array}
-      \right)
-        \trans{delegs}{\epsilon}
-      \left(
-        \begin{array}{r}
-          \var{dstate}\\
-          \var{pstate}
-        \end{array}
-      \right)
+      \vdash
+      \var{dwstate}
+      \trans{delegs}{\epsilon}
+      \var{dwstate'}
     }
     \label{eq:rule:sequence-delegation-base}
   \end{equation}
@@ -479,19 +470,9 @@ are given in Figure~\ref{fig:defs:delegationw}.
         \end{array}
       }
       \vdash
-      {\left(
-        \begin{array}{r}
-          \var{dstate}\\
-          \var{pstate}
-        \end{array}
-      \right)}
+      \var{dwstate}
       \trans{delegs}{\Gamma}
-      {\left(
-        \begin{array}{r}
-          \var{dstate'}\\
-          \var{pstate'}
-        \end{array}
-      \right)}
+      \var{dwstate'}
     \\ ~ \\
     {
       \begin{array}{r}
@@ -500,33 +481,14 @@ are given in Figure~\ref{fig:defs:delegationw}.
       \end{array}
     }
     \vdash
-    {\left(
-        \begin{array}{r}
-          \var{dstate'}\\
-          \var{pstate'}
-        \end{array}
-      \right)}
+      \var{dwstate'}
       \trans{delegw}{c}
-      {\left(
-        \begin{array}{r}
-          \var{dstate''}\\
-          \var{pstate''}
-        \end{array}
-      \right)}
+      \var{dwstate''}
     }
-    { \left(
-        \begin{array}{r}
-          \var{dstate}\\
-          \var{pstate}
-        \end{array}
-      \right)
+    {
+      \var{dwstate}
       \trans{delegs}{\Gamma; c}
-      \left(
-        \begin{array}{r}
-          \var{dstate''}\\
-          \var{pstate''}
-        \end{array}
-      \right)
+      \var{dwstate''}
     }
     \label{eq:rule:sequence-delegation-inductive}
   \end{equation}

--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -21,6 +21,7 @@
 \newcommand{\retire}[1]{\fun{retire}~ \var{#1}}
 \newcommand{\addrRw}[1]{\fun{addr_{rwd}}~ \var{#1}}
 \newcommand{\epoch}[1]{\fun{epoch}~ \var{#1}}
+\newcommand{\dcerts}[1]{\fun{dcerts}~ \var{#1}}
 
 %%
 %% Constants
@@ -129,7 +130,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
   \fun{epoch} & \Slot \to \Epoch
   & \text{epoch of a slot}
   \\
-    \fun{(-)} & \Slot \to \Slot \to \Duration
+    () & \Slot \to \Slot \to \Duration
   & \text{slot duration}
   \end{array}
   \end{equation*}
@@ -171,7 +172,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
   %
   \begin{equation*}
     \_ \vdash \_ \trans{pool}{\_} \_ \in
-      \powerset (\Slot \times \DState \times \DCert \times \DState)
+      \powerset (\Slot \times \PState \times \DCert \times \PState)
   \end{equation*}
   %
   \caption{Delegation Transitions}
@@ -367,7 +368,9 @@ are given in Figure~\ref{fig:defs:delegationw}.
       \fun{dbody} & \DCert \mapsto \DCertBody
       & \text{body of the delegation certificate}\\
       \fun{dwit} & \DCert \mapsto (\VKey \times \Sig)
-      & \text{witness for the delegation certificate}
+      & \text{witness for the delegation certificate}\\
+      \fun{dcerts} & \Tx \to \DCert
+      & \text{delegation certificate in a transaction}\\
     \end{array}
   \end{equation*}
   %
@@ -438,5 +441,96 @@ are given in Figure~\ref{fig:defs:delegationw}.
   \end{equation}
   \caption{Delegation witnesses inference rules}
   \label{fig:rules:delegationw}
+\end{figure}
+
+\begin{figure}
+  \begin{equation}
+    \inference[Seq-delg-base]
+    {}
+    {
+      \begin{array}{r}
+        \var{tx}\\
+        \var{slot}
+      \end{array}
+      \vdash \left(
+        \begin{array}{r}
+          \var{dstate}\\
+          \var{pstate}
+        \end{array}
+      \right)
+        \trans{delegs}{\epsilon}
+      \left(
+        \begin{array}{r}
+          \var{dstate}\\
+          \var{pstate}
+        \end{array}
+      \right)
+    }
+    \label{eq:rule:sequence-delegation-base}
+  \end{equation}
+
+  \begin{equation}
+    \inference[Seq-delg-ind]
+    {
+      {
+        \begin{array}{r}
+          \var{tx}\\
+          \var{slot}\\
+        \end{array}
+      }
+      \vdash
+      {\left(
+        \begin{array}{r}
+          \var{dstate}\\
+          \var{pstate}
+        \end{array}
+      \right)}
+      \trans{delegs}{\Gamma}
+      {\left(
+        \begin{array}{r}
+          \var{dstate'}\\
+          \var{pstate'}
+        \end{array}
+      \right)}
+    \\ ~ \\
+    {
+      \begin{array}{r}
+        \var{tx}\\
+        \var{slot}\\
+      \end{array}
+    }
+    \vdash
+    {\left(
+        \begin{array}{r}
+          \var{dstate'}\\
+          \var{pstate'}
+        \end{array}
+      \right)}
+      \trans{delegw}{c}
+      {\left(
+        \begin{array}{r}
+          \var{dstate''}\\
+          \var{pstate''}
+        \end{array}
+      \right)}
+    }
+    { \left(
+        \begin{array}{r}
+          \var{dstate}\\
+          \var{pstate}
+        \end{array}
+      \right)
+      \trans{delegs}{\Gamma; c}
+      \left(
+        \begin{array}{r}
+          \var{dstate''}\\
+          \var{pstate''}
+        \end{array}
+      \right)
+    }
+    \label{eq:rule:sequence-delegation-inductive}
+  \end{equation}
+  \caption{Delegation sequence rules}
+  \label{fig:rules:delegation-sequence}
 \end{figure}
 

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -257,7 +257,7 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
   \emph{Abstract Functions}
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \fun{d} & \PrtclConsts \to \DCert \to \Coin
+      \fun{dvalue} & \PrtclConsts \to \DCert \to \Coin
         & \text{deposit amount of a certificate}\\
 
       \fun{decay} & \PrtclConsts \to \mathbb{N}\times\mathbb{Q}^{+}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -95,6 +95,7 @@
 \newcommand{\txbody}[1]{\fun{txbody}~ \var{#1}}
 \newcommand{\txfee}[1]{\fun{txfee}~ \var{#1}}
 \newcommand{\minfee}[2]{\fun{minfee}~ \var{#1}~ \var{#2}}
+\newcommand{\slotminus}[2]{\var{#1}~-_{s}~\var{#2}}
 \DeclarePairedDelimiter\floor{\lfloor}{\rfloor}
 % wildcard parameter
 \newcommand{\wcard}[0]{\underline{\phantom{a}}}
@@ -295,17 +296,19 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
       & \text{total refund for a certificate} \\
       & \refund{allocs}{pc}{slot}{c} =\\
       & \begin{cases}
+        0 & \text{if not}~(\fun{releasing}~c)\\
             0 & \text{if}~\cauthor c \notin allocs\\
             \floor*{
               \left(\fun{d}~pc~c\right) \cdot
             \left(d_{\min}+(1-d_{\min})\cdot e^{-\lambda\cdot\delta}\right)}
             & \text{otherwise}
         \end{cases}\\
-      & \where
-        \begin{array}{r@{~=~}l}
-          \fun{decay}~pc & d_{\min},~\lambda\\
-          \delta & slot - (allocs~(\cauthor c))
-        \end{array}\\
+      &
+      \begin{array}{lr@{~=~}l}
+        \where &\fun{releasing}~\var{c} & \DeregKey{c} \lor \RetirePool{c}\\
+        & d_{\min},~\lambda & \fun{decay}~pc\\
+        &\delta & \slotminus{slot}{(allocs~(\cauthor c))}\\
+      \end{array}\\
       \nextdef
       & \fun{refunds} \in \PrtclConsts \to \Allocs \to \Allocs \to \Tx \to \Coin
       & \text{total refunds for transaction} \\
@@ -603,8 +606,7 @@ different order). The choice here is arbitrary.
     \left(
       \begin{array}{r@{~\in~}lr}
         \var{utxo} & \UTxO & \text{UTxO}\\
-        \var{dstate} & \DState & \text{delegation state}\\
-        \var{pstate} & \PState & \text{pool state}\\
+        \var{dwstate} & \DWState & \text{delegation witnesess state}\\
       \end{array}
     \right)
   \end{equation*}
@@ -624,7 +626,8 @@ different order). The choice here is arbitrary.
     \label{eq:ledger}
     \inference[ledger]
     {
-      pallocs = \fun{poolAllocs}~stpools\\~\\
+      \Gamma = \dcerts{tx}
+      & pallocs = \fun{poolAllocs}~stpools\\~\\
       {
         \begin{array}{r}
         slot\\
@@ -642,13 +645,7 @@ different order). The choice here is arbitrary.
         \end{array}
       }
       \vdash
-      {\left( \begin{array}{ll}
-        dstate \\ pstate
-      \end{array} \right) }
-      \trans{delegs}{tx}
-      {\left( \begin{array}{ll}
-        dstate' \\ pstate'
-      \end{array} \right) }
+      dwstate \trans{delegs}{\Gamma} dwstate'
     }
     {
       \begin{array}{l}
@@ -659,16 +656,14 @@ different order). The choice here is arbitrary.
       \left(
         \begin{array}{ll}
           utxo \\
-          dstate \\
-          pstate \\
+          dwstate \\
         \end{array}
       \right)
-      \trans{ledger}{tx}
+      \trans{ledger}{certs}
       \left(
         \begin{array}{ll}
           utxo' \\
-          dstate' \\
-          pstate' \\
+          dwstate' \\
         \end{array}
       \right)
     }
@@ -676,12 +671,6 @@ different order). The choice here is arbitrary.
   \caption{Ledger inference rule}
   \label{fig:rules:ledger}
 \end{figure}
-
-\begin{todo}
-  Implement $\mathsf{DELEGS}$ by applying $\mathsf{DELEGW}$
-  over the certs in a transaction.
-\end{todo}
-
 
 \addcontentsline{toc}{section}{References}
 \bibliographystyle{plainnat}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -37,6 +37,8 @@
 \newcommand{\Coin}{\type{Coin}}
 \newcommand{\PrtclConsts}{\type{PrtclConsts}}
 \newcommand{\Slot}{\type{Slot}}
+\newcommand{\Duration}{\type{Duration}}
+\newcommand{\Allocs}{\type{Allocs}}
 
 \newcommand{\DCert}{\type{DCert}}
 \newcommand{\DCertRegKey}{\type{DCert_{regkey}}}
@@ -65,6 +67,8 @@
 \newcommand{\CEState}{\type{CEState}}
 \newcommand{\BDEnv}{\type{BDEnv}}
 \newcommand{\BDState}{\type{BDState}}
+\newcommand{\LEnv}{\type{LEnv}}
+\newcommand{\LState}{\type{LState}}
 
 %%
 %% Functions
@@ -76,8 +80,9 @@
 \newcommand{\balance}[1]{\fun{balance}~ \var{#1}}
 \newcommand{\ttl}[1]{\fun{ttl}~ \var{#1}}
 \newcommand{\deposits}[2]{\fun{deposits}~ \var{#1} ~ \var{#2}}
-\newcommand{\refunds}[2]{\fun{refunds}~ \var{#1}~ \var{#2}}
-\newcommand{\created}[4]{\fun{created}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
+\newcommand{\refund}[4]{\fun{refund}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
+\newcommand{\refunds}[4]{\fun{refunds}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
+\newcommand{\created}[5]{\fun{created}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}~ \var{#5}}
 \newcommand{\destroyed}[2]{\fun{destroyed}~ \var{#1}~ \var{#2}}
 %% UTxO witnesses
 \newcommand{\inputs}[1]{\fun{inputs}~ \var{#1}}
@@ -214,6 +219,15 @@ In order to define the \textit{preservation of value} conditon,
 we define the calculations for deposits and refunds in
 Figure~\ref{fig:defs:deposits}.
 
+\begin{note}
+  We define $\fun{refund}$ by cases on whether or not
+  the refunding certificate has a corresponding
+  resource creating certificate.
+  If our rules are correct, then $\fun{refund}$
+  is only called in the case where such a matching
+  certificate exists.
+\end{note}
+
 The transition rules for unspent outputs are presented in
 Figure~\ref{fig:rules:utxo}. The states of the UTxO transition system,
 along with their types are defined in Figure~\ref{fig:defs:utxo}.
@@ -229,6 +243,17 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
     \end{array}
   \end{equation*}
   %
+  \emph{Derived types}
+  \begin{equation*}
+    \begin{array}{r@{~\in~}l@{\qquad=\qquad}r@{~\in~}lr}
+      \var{allocs}
+      & \Allocs
+      & hkeys \mapsto slot
+      & \Hash \to \Slot
+      & \text{resource allocations}
+    \end{array}
+  \end{equation*}
+  %
   \emph{Abstract Functions}
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
@@ -238,9 +263,15 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
       \fun{decay} & \PrtclConsts \to \mathbb{N}\times\mathbb{Q}^{+}
         & \text{decay constants}\\
 
-      \fun{certs} & \Tx \to \powerset{\DCert}
-        & \text{certificates}\\
-      %
+      \fun{dresource} & \Tx \to \powerset{(\DCertRegKey \uniondistinct \DCertRegPool)}
+        & \text{resource allocating certificates}\\
+
+      \fun{dderegister} & \Tx \to \powerset{\DCertDeRegKey}
+        & \text{resource releasing certificates}\\
+
+      \fun{dretire} & \Tx \to \powerset{\DCertRetirePool}
+        & \text{resource releasing certificates}\\
+
       \fun{ttl} & \Tx \to \Slot
         & \text{time to live}\\
     \end{array}
@@ -253,22 +284,37 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
   \begin{align*}
       & \fun{deposits} \in \PrtclConsts \to \Tx \to \Coin
       & \text{total deposits for transaction} \\
-      & \fun{deposits}~{pc}~{tx} = \sum\limits_{c \in \fun{certs}~tx} (\fun{d}~pc~c)
+      & \fun{deposits}~{pc}~{tx} = \sum\limits_{c \in \fun{dresource}~tx} (\fun{d}~pc~c)
       \nextdef
-      & \fun{refund} \in \PrtclConsts \to \Slot \to \DCert \to \Coin
+      & \fun{poolAllocs} \in (\Hash \mapsto (\DCertRegPool \times \Slot)) \to \Allocs
+      & \text{pool allocations} \\
+      & \fun{poolAllocs}~\var{stpool} =
+          \{hash \mapsto slot \mid hash \mapsto (\_, slot) \in \var{stpool}\}
+      \nextdef
+      & \fun{refund} \in \PrtclConsts \to \Allocs \to \Slot \to \DCert \to \Coin
       & \text{total refund for a certificate} \\
-      & \fun{refund}~{pc}~{slot}~{c} =
-      \floor*{
-        \left(\fun{d}~pc~c\right) \cdot
-      \left(d_{\min}+(1-d_{\min})\cdot e^{-\lambda\cdot\var{slot}}\right)}\\
-      & \where \fun{decay}~pc = d_{\min},~\lambda
+      & \refund{allocs}{pc}{slot}{c} =\\
+      & \begin{cases}
+            0 & \text{if}~\cauthor c \notin allocs\\
+            \floor*{
+              \left(\fun{d}~pc~c\right) \cdot
+            \left(d_{\min}+(1-d_{\min})\cdot e^{-\lambda\cdot\delta}\right)}
+            & \text{otherwise}
+        \end{cases}\\
+      & \where
+        \begin{array}{r@{~=~}l}
+          \fun{decay}~pc & d_{\min},~\lambda\\
+          \delta & slot - (allocs~(\cauthor c))
+        \end{array}\\
       \nextdef
-      & \fun{refunds} \in \PrtclConsts \to \Tx \to \Coin
+      & \fun{refunds} \in \PrtclConsts \to \Allocs \to \Allocs \to \Tx \to \Coin
       & \text{total refunds for transaction} \\
-      & \refunds{pc}{tx} = \sum\limits_{c \in \fun{certs}~tx} \fun{refund}~pc~(\ttl{tx})~c
+      & \refunds{pc}{dallocs}{pallocs}{tx} =\\
+      &   \sum\limits_{c \in \fun{dderegister}~tx} \refund{pc}{dallocs}{(\ttl{tx})}{c}\\
+      &   ~~~+ \sum\limits_{c \in \fun{dretire}~tx} \refund{pc}{pallocs}{(\retire{c})}{c}
   \end{align*}
   \caption{Functions used in Deposits}
-  \label{fig:derived-defs:utxo}
+  \label{fig:functions:deposits}
 \end{figure}
 
 
@@ -349,10 +395,10 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
     & \text{UTxO balance} \\
     & \fun{balance} ~ utxo = \sum_{(~\wcard ~ \mapsto (\wcard, ~c)) \in \var{utxo}} c
     \nextdef
-    & \fun{created} \in \PrtclConsts \to \UTxO \to \Tx \to \Coin
+    & \fun{created} \in \PrtclConsts \to \UTxO \to \Allocs \to \Allocs \to \Tx \to \Coin
     & \text{value created} \\
-    & \fun{created} ~ pc ~ utxo ~ tx =
-    \balance{(\txins{tx} \restrictdom \var{utxo})} + \refunds{pc}{slot}{tx}
+    & \created{pc}{utxo}{dallocs}{pallocs}{tx} = \\
+    & ~~\balance{(\txins{tx} \restrictdom \var{utxo})} + \refunds{pc}{dallocs}{pallocs}{tx}
     \nextdef
     & \fun{destroyed} \in \PrtclConsts \to \Tx \to \Coin
     & \text{value destroyed} \\
@@ -385,6 +431,8 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
       \begin{array}{r@{~\in~}lr}
         \var{slot} & \Slot & \text{current slot}\\
         \var{pc} & \PrtclConsts & \text{protocol constants}\\
+        \var{dallocs} & \Allocs & \text{stake key allocations}\\
+        \var{pallocs} & \Allocs & \text{stake pool allocations}\\
       \end{array}
     \right)
   \end{equation*}
@@ -404,15 +452,17 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
     \inference[UTxO-inductive]
     { \ttl tx \leq \var{slot}
         & \minfee{pc}{tx} \leq \txfee{tx}
-      \\
-        \txins{tx} \subseteq \dom \var{utxo}
-        &
-        \created{pc}{utxo}{tx} = \destroyed{pc}{tx}
+        & \txins{tx} \subseteq \dom \var{utxo}
+        \\
+        \created{pc}{utxo}{dallocs}{pallocs}{tx}
+          = \destroyed{pc}{tx}
     }
     {
       \begin{array}{l}
         \var{slot}\\
         \var{pc}\\
+        \var{dallocs}\\
+        \var{pallocs}\\
       \end{array}
       \vdash \var{utxo} \trans{utxo}{tx}
       (\txins{tx} \subtractdom \var{utxo}) \cup \txouts{tx}
@@ -534,6 +584,104 @@ different order). The choice here is arbitrary.
   \caption{UTxO with witnesses inference rules}
   \label{fig:rules:utxow}
 \end{figure}
+
+\begin{figure}
+  \emph{Ledger environment}
+  \begin{equation*}
+    \LEnv =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{slot} & \Slot & \text{current slot}\\
+        \var{pc} & \PrtclConsts & \text{protocol constants}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
+  \emph{Ledger state}
+  \begin{equation*}
+    \LState =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{utxo} & \UTxO & \text{UTxO}\\
+        \var{dstate} & \DState & \text{delegation state}\\
+        \var{pstate} & \PState & \text{pool state}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
+  \emph{Ledger transitions}
+  \begin{equation*}
+    \_ \vdash
+    \var{\_} \trans{ledger}{\_} \var{\_}
+    \subseteq \powerset (\LEnv \times \LState \times \Tx \times \LState)
+  \end{equation*}
+  \caption{UTxO transition-system types}
+  \label{fig:ts-types:ledger}
+\end{figure}
+
+\begin{figure}
+  \begin{equation}
+    \label{eq:ledger}
+    \inference[ledger]
+    {
+      pallocs = \fun{poolAllocs}~stpools\\~\\
+      {
+        \begin{array}{r}
+        slot\\
+        pc\\
+        stkeys\\
+        pallocs\\
+        \end{array}
+      }
+      \vdash \var{utxo} \trans{utxow}{tx} \var{utxo'}\\~\\~\\
+      %
+      {
+        \begin{array}{l}
+          tx \\
+          slot \\
+        \end{array}
+      }
+      \vdash
+      {\left( \begin{array}{ll}
+        dstate \\ pstate
+      \end{array} \right) }
+      \trans{delegs}{tx}
+      {\left( \begin{array}{ll}
+        dstate' \\ pstate'
+      \end{array} \right) }
+    }
+    {
+      \begin{array}{l}
+        \var{slot}\\
+        \var{pc}\\
+      \end{array}
+      \vdash
+      \left(
+        \begin{array}{ll}
+          utxo \\
+          dstate \\
+          pstate \\
+        \end{array}
+      \right)
+      \trans{ledger}{tx}
+      \left(
+        \begin{array}{ll}
+          utxo' \\
+          dstate' \\
+          pstate' \\
+        \end{array}
+      \right)
+    }
+  \end{equation}
+  \caption{Ledger inference rule}
+  \label{fig:rules:ledger}
+\end{figure}
+
+\begin{todo}
+  Implement $\mathsf{DELEGS}$ by applying $\mathsf{DELEGW}$
+  over the certs in a transaction.
+\end{todo}
+
 
 \addcontentsline{toc}{section}{References}
 \bibliographystyle{plainnat}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -615,7 +615,7 @@ different order). The choice here is arbitrary.
     \var{\_} \trans{ledger}{\_} \var{\_}
     \subseteq \powerset (\LEnv \times \LState \times \Tx \times \LState)
   \end{equation*}
-  \caption{UTxO transition-system types}
+  \caption{Ledger transition-system types}
   \label{fig:ts-types:ledger}
 \end{figure}
 

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -36,6 +36,14 @@
 \newcommand{\Value}{\type{Value}}
 \newcommand{\Coin}{\type{Coin}}
 \newcommand{\PrtclConsts}{\type{PrtclConsts}}
+\newcommand{\Slot}{\type{Slot}}
+
+\newcommand{\DCert}{\type{DCert}}
+\newcommand{\DCertRegKey}{\type{DCert_{regkey}}}
+\newcommand{\DCertDeRegKey}{\type{DCert_{deregkey}}}
+\newcommand{\DCertDeleg}{\type{DCert_{delegate}}}
+\newcommand{\DCertRegPool}{\type{DCert_{regpool}}}
+\newcommand{\DCertRetirePool}{\type{DCert_{retirepool}}}
 %% Adding witnesses
 \newcommand{\TxIn}{\type{TxIn}}
 \newcommand{\TxOut}{\type{TxOut}}
@@ -52,6 +60,7 @@
 \newcommand{\Gkeys}{\var{G_{keys}}}
 \newcommand{\Block}{\type{Block}}
 \newcommand{\SlotId}{\type{SlotId}}
+\newcommand{\UTxOEnv}{\type{UTxOEnv}}
 \newcommand{\CEEnv}{\type{CEEnv}}
 \newcommand{\CEState}{\type{CEState}}
 \newcommand{\BDEnv}{\type{BDEnv}}
@@ -65,6 +74,11 @@
 \newcommand{\txouts}[1]{\fun{txouts}~ \var{#1}}
 \newcommand{\values}[1]{\fun{values}~ #1}
 \newcommand{\balance}[1]{\fun{balance}~ \var{#1}}
+\newcommand{\ttl}[1]{\fun{ttl}~ \var{#1}}
+\newcommand{\deposits}[2]{\fun{deposits}~ \var{#1} ~ \var{#2}}
+\newcommand{\refunds}[2]{\fun{refunds}~ \var{#1}~ \var{#2}}
+\newcommand{\created}[4]{\fun{created}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
+\newcommand{\destroyed}[2]{\fun{destroyed}~ \var{#1}~ \var{#2}}
 %% UTxO witnesses
 \newcommand{\inputs}[1]{\fun{inputs}~ \var{#1}}
 \newcommand{\wits}[1]{\fun{wits}~ \var{#1}}
@@ -76,6 +90,7 @@
 \newcommand{\txbody}[1]{\fun{txbody}~ \var{#1}}
 \newcommand{\txfee}[1]{\fun{txfee}~ \var{#1}}
 \newcommand{\minfee}[2]{\fun{minfee}~ \var{#1}~ \var{#2}}
+\DeclarePairedDelimiter\floor{\lfloor}{\rfloor}
 % wildcard parameter
 \newcommand{\wcard}[0]{\underline{\phantom{a}}}
 %% Adding ledgers...
@@ -106,6 +121,8 @@
 \input{intro.tex}
 
 \section{Notation}\label{sec:notation}
+
+The transition system is explained in \cite{small_step_semantics}.
 
 \begin{description}
 \item[Powerset] Given a set $\type{X}$, $\powerset{\type{X}}$ is the set of all
@@ -158,7 +175,7 @@ this document.
       \hash{} & \VKey \to \Hash
       & \text{hash function} \\
       %
-      \fun{verify} & \VKey \times \Data \times \Sig
+      \fun{verify} & \powerset{\left(\VKey \times \Data \times \Sig\right)}
       & \text{verification relation}\\
     \end{array}
   \end{equation*}
@@ -186,16 +203,77 @@ this document.
     serialization}
 \end{todo}
 
+\section{Delegation}
+\label{sec:delegation}
+\input{delegation.tex}
+
 \section{UTxO}
 \label{sec:state-trans-utxo-1}
+
+In order to define the \textit{preservation of value} conditon,
+we define the calculations for deposits and refunds in
+Figure~\ref{fig:defs:deposits}.
 
 The transition rules for unspent outputs are presented in
 Figure~\ref{fig:rules:utxo}. The states of the UTxO transition system,
 along with their types are defined in Figure~\ref{fig:defs:utxo}.
 Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
 
+
+
 \begin{figure*}
-  \emph{Primitive types}
+  \emph{Abstract types}
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      pc & \PrtclConsts & \text{protocol constants}
+    \end{array}
+  \end{equation*}
+  %
+  \emph{Abstract Functions}
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      \fun{d} & \PrtclConsts \to \DCert \to \Coin
+        & \text{deposit amount of a certificate}\\
+
+      \fun{decay} & \PrtclConsts \to \mathbb{N}\times\mathbb{Q}^{+}
+        & \text{decay constants}\\
+
+      \fun{certs} & \Tx \to \powerset{\DCert}
+        & \text{certificates}\\
+      %
+      \fun{ttl} & \Tx \to \Slot
+        & \text{time to live}\\
+    \end{array}
+  \end{equation*}
+  \caption{Definitions used in Deposits}
+  \label{fig:defs:deposits}
+\end{figure*}
+
+\begin{figure}
+  \begin{align*}
+      & \fun{deposits} \in \PrtclConsts \to \Tx \to \Coin
+      & \text{total deposits for transaction} \\
+      & \fun{deposits}~{pc}~{tx} = \sum\limits_{c \in \fun{certs}~tx} (\fun{d}~pc~c)
+      \nextdef
+      & \fun{refund} \in \PrtclConsts \to \Slot \to \DCert \to \Coin
+      & \text{total refund for a certificate} \\
+      & \fun{refund}~{pc}~{slot}~{c} =
+      \floor*{
+        \left(\fun{d}~pc~c\right) \cdot
+      \left(d_{\min}+(1-d_{\min})\cdot e^{-\lambda\cdot\var{slot}}\right)}\\
+      & \where \fun{decay}~pc = d_{\min},~\lambda
+      \nextdef
+      & \fun{refunds} \in \PrtclConsts \to \Tx \to \Coin
+      & \text{total refunds for transaction} \\
+      & \refunds{pc}{tx} = \sum\limits_{c \in \fun{certs}~tx} \fun{refund}~pc~(\ttl{tx})~c
+  \end{align*}
+  \caption{Functions used in Deposits}
+  \label{fig:derived-defs:utxo}
+\end{figure}
+
+
+\begin{figure*}
+  \emph{Abstract types}
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
@@ -207,7 +285,7 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
       %
       c & \Coin & \text{currency value}\\
       %
-      pc & \PrtclConsts & \text{protocol constants}
+      slot & \Slot & \text{slot}
     \end{array}
   \end{equation*}
   \emph{Derived types}
@@ -231,13 +309,6 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
       & \var{txin} \mapsto \var{txout}
       & \TxIn \mapsto \TxOut
       & \text{unspent tx outputs}
-    \end{array}
-  \end{equation*}
-  %
-  \emph{Abstract types}
-  \begin{equation*}
-    \begin{array}{r@{~\in~}lr}
-      \var{tx} & \Tx & \text{transaction}\\
     \end{array}
   \end{equation*}
   %
@@ -277,6 +348,16 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
     & \fun{balance} \in \UTxO \to \Coin
     & \text{UTxO balance} \\
     & \fun{balance} ~ utxo = \sum_{(~\wcard ~ \mapsto (\wcard, ~c)) \in \var{utxo}} c
+    \nextdef
+    & \fun{created} \in \PrtclConsts \to \UTxO \to \Tx \to \Coin
+    & \text{value created} \\
+    & \fun{created} ~ pc ~ utxo ~ tx =
+    \balance{(\txins{tx} \restrictdom \var{utxo})} + \refunds{pc}{slot}{tx}
+    \nextdef
+    & \fun{destroyed} \in \PrtclConsts \to \Tx \to \Coin
+    & \text{value destroyed} \\
+    & \fun{destroyed} ~ pc ~ tx =
+      \balance{(\txouts{tx})}  + \txfee{tx} + \deposits{pc}{tx}\\
   \end{align*}
 
   \begin{align*}
@@ -297,11 +378,22 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
 \end{figure}
 
 \begin{figure}
+  \emph{UTxO environment}
+  \begin{equation*}
+    \UTxOEnv =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{slot} & \Slot & \text{current slot}\\
+        \var{pc} & \PrtclConsts & \text{protocol constants}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
   \emph{UTxO transitions}
   \begin{equation*}
     \_ \vdash
     \var{\_} \trans{utxo}{\_} \var{\_}
-    \subseteq \powerset (\PrtclConsts \times \UTxO \times \Tx \times \UTxO)
+    \subseteq \powerset (\UTxOEnv \times \UTxO \times \Tx \times \UTxO)
   \end{equation*}
   \caption{UTxO transition-system types}
   \label{fig:ts-types:utxo}
@@ -310,11 +402,19 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
 \begin{figure}
   \begin{equation}\label{eq:utxo-inductive}
     \inference[UTxO-inductive]
-    { \txins{tx} \subseteq \dom \var{utxo} & \minfee{pc}{tx} \leq \txfee{tx}\\
-      \balance{(\txouts{tx})}  + \txfee{tx} =
-        \balance{(\txins{tx} \restrictdom \var{utxo})}
+    { \ttl tx \leq \var{slot}
+        & \minfee{pc}{tx} \leq \txfee{tx}
+      \\
+        \txins{tx} \subseteq \dom \var{utxo}
+        &
+        \created{pc}{utxo}{tx} = \destroyed{pc}{tx}
     }
-    {\var{pc} \vdash \var{utxo} \trans{utxo}{tx}
+    {
+      \begin{array}{l}
+        \var{slot}\\
+        \var{pc}\\
+      \end{array}
+      \vdash \var{utxo} \trans{utxo}{tx}
       (\txins{tx} \subtractdom \var{utxo}) \cup \txouts{tx}
     }
   \end{equation}
@@ -400,7 +500,7 @@ different order). The choice here is arbitrary.
   \begin{equation*}
     \var{\_} \vdash
     \var{\_} \trans{utxow}{\_} \var{\_}
-    \subseteq \powerset (\PrtclConsts \times \UTxO \times \Tx \times \UTxO)
+    \subseteq \powerset (\UTxOEnv \times \UTxO \times \Tx \times \UTxO)
   \end{equation*}
   \caption{UTxO with witness transition-system types}
   \label{fig:ts-types:utxow}
@@ -410,21 +510,30 @@ different order). The choice here is arbitrary.
   \begin{equation}
     \label{eq:utxo-witness-inductive}
     \inference[UTxO-wit]
-    { \var{pc} \vdash \var{utxo} \trans{utxo}{tx} \var{utxo'}\\ ~ \\
+    {
+      {
+        \begin{array}{l}
+        \var{slot}\\
+        \var{pc}
+        \end{array}
+      }
+      \vdash \var{utxo} \trans{utxo}{tx} \var{utxo'}\\ ~ \\
       & \forall i \in \txins{tx} \cdot \exists (\var{vk}, \sigma) \in \wits{\var{tx}}
       \cdot
       \mathcal{V}_{\var{vk}}{\serialised{\txbody{tx}}}_{\sigma}
       \wedge  \fun{addr_h}~{utxo}~i = \hash{vk}\\
     }
-    {\var{pc} \vdash \var{utxo} \trans{utxow}{tx} \var{utxo'}}
+    {
+      \begin{array}{l}
+        \var{slot}\\
+        \var{pc}\\
+      \end{array}
+      \vdash \var{utxo} \trans{utxow}{tx} \var{utxo'}
+    }
   \end{equation}
   \caption{UTxO with witnesses inference rules}
   \label{fig:rules:utxow}
 \end{figure}
-
-\section{Delegation}
-\label{sec:delegation}
-\input{delegation.tex}
 
 \addcontentsline{toc}{section}{References}
 \bibliographystyle{plainnat}

--- a/latex/references.bib
+++ b/latex/references.bib
@@ -1,3 +1,11 @@
+@misc{small_step_semantics,
+  author = {Formal Methods Team, IOHK},
+  title  = {Small Step Semantics for Cardano},
+  year   = {2018},
+  url   = {https://github.com/input-output-hk/cardano-chain/blob/master/specs/semantics/latex/small-step-semantics.tex},
+}
+
+
 @misc{delegation_design,
   author = {Philipp Kant and Lars Br\"unjes and Duncan Coutts},
   title  = {Design Specification for Delegation and Incentives in

--- a/latex/references.bib
+++ b/latex/references.bib
@@ -11,7 +11,7 @@
   title  = {Design Specification for Delegation and Incentives in
 Cardano},
   year   = {2018},
-  url   = {https://github.com/input-output-hk/cardano-sl/blob/philipp/cdec-147/docs/delegation_design_spec.tex},
+  url   = {https://github.com/input-output-hk/fm-ledger-rules/tree/master/docs/delegation_design_spec},
 }
 
 @article{chimeric,


### PR DESCRIPTION
This PR adds certificate deposits and refunds to the latex spec.  It also adds a transaction time-to-live, which was needed for refunds.

The UTxO ledger rules are now less separated from delegation. This is due to the fact that the preservation of value condition now takes certificate refunds into account.  The caused a few things to be reordered.  Delegation is now defined first, and some of the abstract types are grouped differently.

closes #25 
