### PR TITLE
Conditional Travis Run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,11 @@ addons:
       - libgmp-dev
 
 before_install:
+# Run CI only on code changes. We use the convention that code feature branches
+# start with `haskell` and latex spec ones with `latex`.
+- if [[ ! ($TRAVIS_PULL_REQUEST_BRANCH =~ ^haskell.* ||
+           $TRAVIS_BRANCH =~ ^haskell.*)
+     ]]; then travis_terminate 0; fi
 # Download and unpack the stack executable
 - mkdir -p ~/.local/bin
 - export PATH=$HOME/.local/bin:$PATH


### PR DESCRIPTION
This activates a Travis CI run only if the feature branch has a prefix "haskell", e.g., `haskell/feature1` would build, `latex/feature1` wouldn't. The reasoning is that we only really want Travis to run on code changes. The implementation has potential to be optimized though ...
closes #43 