### PR TITLE
prevent replay attacks by requiring nonempty txins

### DIFF
--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -490,7 +490,7 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
   \begin{equation}\label{eq:utxo-inductive}
     \inference[UTxO-inductive]
     { \ttl tx \leq \var{slot}
-      & \size{\txins{tx}} \geq 1
+      & \txins{tx} \neq \emptyset
       \\
       \txins{tx} \subseteq \dom \var{utxo}
       & \minfee{pc}{tx} \leq \txfee{tx}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -490,11 +490,12 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
   \begin{equation}\label{eq:utxo-inductive}
     \inference[UTxO-inductive]
     { \ttl tx \leq \var{slot}
-        & \minfee{pc}{tx} \leq \txfee{tx}
-        & \txins{tx} \subseteq \dom \var{utxo}
-        \\
-        \created{pc}{utxo}{dallocs}{pallocs}{tx}
-          = \destroyed{pc}{tx}
+      & \size{\txins{tx}} \geq 1
+      \\
+      \txins{tx} \subseteq \dom \var{utxo}
+      & \minfee{pc}{tx} \leq \txfee{tx}
+      \\
+      \created{pc}{utxo}{dallocs}{pallocs}{tx} = \destroyed{pc}{tx}
     }
     {
       \begin{array}{l}


### PR DESCRIPTION
UTxO transactions have inherent replay protection, since the transaction inputs are unique and can only be spent once.  Other features of transactions, such as delegation certificates, do not have such inherit protection.  Such feature can piggyback off the UTxO replay protection, however, if we require that the signatures for these features include the transaction body and contain at least one transaction input.  This does exclude, however, the possibility of being able to do things like paying for something entirely with delegation certificate refunds.

This PR adds a predicate to the UTxO antecedent, requiring at least one input.

closes #52 