### PR TITLE
Add Properties of transaction state transitions as Tests in executable model

### DIFF
--- a/hs/test/Tests.hs
+++ b/hs/test/Tests.hs
@@ -313,11 +313,11 @@ genTxLedgerEntry keyList (UTxO m) = do
 -- accumulated fees and a resulting ledger state or the 'ValidationError'
 -- information in case of an invalid transaction.
 genLedgerStateTx :: [(KeyPair, KeyPair)] -> LedgerState ->
-                    Gen (Coin, Either [ValidationError] LedgerState)
+                    Gen (Coin, LedgerEntry, Either [ValidationError] LedgerState)
 genLedgerStateTx keyList sourceState = do
   let utxo = getUtxo sourceState
   (fee, ledgerEntry) <- genTxLedgerEntry keyList utxo
-  pure (fee, asStateTransition sourceState ledgerEntry)
+  pure (fee, ledgerEntry, asStateTransition sourceState ledgerEntry)
 
 -- | Generator of a non-emtpy ledger genesis state and a random number of
 -- transactions applied to it. Returns the amount of accumulated fees, the
@@ -340,7 +340,7 @@ repeatTx :: Natural -> [(KeyPair, KeyPair)] -> Coin -> LedgerState ->
             Gen (Coin, Either [ValidationError] LedgerState)
 repeatTx 0 _ fees ls = pure (fees, Right ls)
 repeatTx n !keyPairs !fees !ls = do
-  (fee, next) <- genLedgerStateTx keyPairs ls
+  (fee, _, next) <- genLedgerStateTx keyPairs ls
   case next of
     Left  _   -> pure (fees, next)
     Right ls' -> repeatTx (n - 1) keyPairs (fee <> fees) ls'

--- a/hs/test/Tests.hs
+++ b/hs/test/Tests.hs
@@ -426,9 +426,7 @@ propPreserveOutputs :: Property
 propPreserveOutputs = property $ do
   (_, _, entry, l') <- forAll genValidStateTx
   let tx             = getTxOfEntry entry
-  if Map.isSubmapOf (utxoMap $ txouts tx) (utxoMap $ getUtxo l')
-    then success
-    else failure
+  True === Map.isSubmapOf (utxoMap $ txouts tx) (utxoMap $ getUtxo l')
 
 -- | Property 7.4 (Eliminate Inputs of Transaction)
 propEliminateInputs :: Property
@@ -446,11 +444,9 @@ propUniqueTxIds = property $ do
   let origTxIds      = collectIds <$> (Map.keys $ utxoMap (getUtxo l))
   let newTxIds       = collectIds <$> (Map.keys $ utxoMap (txouts tx))
   let txId           = txid tx
-  if (all (== txId) newTxIds) &&
-     (not $ any (== txId) origTxIds) &&
-     Map.isSubmapOf (utxoMap $ txouts tx) (utxoMap $ getUtxo l')
-    then success
-    else failure
+  True === ((all (== txId) newTxIds) &&
+            (not $ any (== txId) origTxIds) &&
+            Map.isSubmapOf (utxoMap $ txouts tx) (utxoMap $ getUtxo l'))
          where collectIds (TxIn txId _) = txId
 
 -- | 'TestTree' of property-based testing properties.

--- a/hs/test/Tests.hs
+++ b/hs/test/Tests.hs
@@ -418,6 +418,16 @@ propBalanceTxInTxOut = property $ do
   let inps             = txins tx
   (balance $ inps <| (getUtxo l)) === ((balance $ txouts tx) <> fee)
 
+-- | Property 7.3 (Preserve Outputs of Transaction)
+propPreserveOutputs :: Property
+propPreserveOutputs = property $ do
+  (_, _, entry, l') <- forAll genValidStateTx
+  let tx             = getTxOfEntry entry
+  if Map.isSubmapOf (utxoMap $ txouts tx) (utxoMap $ getUtxo l')
+    then success
+    else failure
+         where utxoMap (UTxO m) = m
+
 -- | 'TestTree' of property-based testing properties.
 propertyTests :: TestTree
 propertyTests = testGroup "Property-Based Testing"
@@ -432,6 +442,9 @@ propertyTests = testGroup "Property-Based Testing"
                   [testProperty
                     "preserve balance restricted to TxIns in Balance of outputs"
                     propBalanceTxInTxOut
+                  , testProperty
+                    "Preserve outputs of transaction"
+                    propPreserveOutputs
                   ]
                 ]
 


### PR DESCRIPTION
This adds properties 7.2 - 7.5. 7.1 needs rewards and deposits which currently aren't part of the executable model.