### PR TITLE
Haskell/sync latex

### DIFF
--- a/hs/src/Coin.hs
+++ b/hs/src/Coin.hs
@@ -1,20 +1,18 @@
+{-# LANGUAGE DerivingVia #-}
+
 module Coin
     (
      Coin(..)
     , splitCoin
     ) where
 
+import           Data.Monoid (Sum(..))
 import           Numeric.Natural (Natural)
 
 -- |The amount of value held by a transaction output.
-newtype Coin = Coin Natural deriving (Show, Eq, Ord)
-
-instance Semigroup Coin where
-  (Coin a) <> (Coin b) = Coin (a + b)
-
-instance Monoid Coin where
-  mempty = Coin 0
-  mappend = (<>)
+newtype Coin = Coin Natural
+  deriving (Show, Eq, Ord)
+  deriving (Semigroup, Monoid) via (Sum Natural)
 
 splitCoin :: Coin -> Natural -> (Coin, Coin)
 splitCoin (Coin n) 0 = (Coin 0, Coin n)

--- a/hs/src/Delegation/Certificates.hs
+++ b/hs/src/Delegation/Certificates.hs
@@ -4,9 +4,8 @@ module Delegation.Certificates
   , authDCert
   ) where
 
-import           Numeric.Natural      (Natural)
-
 import           Keys
+import           Slot (Epoch(..))
 
 import           Delegation.StakePool
 
@@ -18,7 +17,7 @@ data DCert = -- | A stake key registration certificate.
             -- | A stake pool registration certificate.
           | RegPool StakePool
             -- | A stake pool retirement certificate.
-          | RetirePool VKey Natural
+          | RetirePool VKey Epoch
             -- | A stake delegation certificate.
           | Delegate Delegation
   deriving (Show, Eq, Ord)

--- a/hs/src/Delegation/Certificates.hs
+++ b/hs/src/Delegation/Certificates.hs
@@ -1,7 +1,7 @@
 module Delegation.Certificates
   (
-    Cert(..)
-  , authCert
+    DCert(..)
+  , authDCert
   ) where
 
 import           Numeric.Natural      (Natural)
@@ -11,7 +11,7 @@ import           Keys
 import           Delegation.StakePool
 
 -- | A heavyweight certificate.
-data Cert = -- | A stake key registration certificate.
+data DCert = -- | A stake key registration certificate.
             RegKey VKey
             -- | A stake key deregistration certificate.
           | DeRegKey VKey --TODO this is actually HashKey on page 13, is that what we want?
@@ -24,8 +24,8 @@ data Cert = -- | A stake key registration certificate.
   deriving (Show, Eq, Ord)
 
 -- |Determine if a certificate is authorized by the given key.
-authCert :: VKey -> Cert -> Bool
-authCert key cert = getRequiredSigningKey cert == key
+authDCert :: VKey -> DCert -> Bool
+authDCert key cert = getRequiredSigningKey cert == key
   where
     getRequiredSigningKey (RegKey k)            = k
     getRequiredSigningKey (DeRegKey k)          = k

--- a/hs/src/Delegation/Validation.hs
+++ b/hs/src/Delegation/Validation.hs
@@ -1,6 +1,5 @@
 module Delegation.Validation
   ( ValidationError(..)
-  , Validity(..)
   ) where
 
 -- Specific validation errors for transactions.
@@ -24,16 +23,3 @@ data ValidationError =
                      -- | The transaction contains an invalid pool retirement certificate.
                      | BadPoolRetirement
                      deriving (Show, Eq)
-
--- |The validity of a transaction, where an invalid transaction
--- is represented by list of errors.
-data Validity = Valid | Invalid [ValidationError] deriving (Show, Eq)
-
-instance Semigroup Validity where
-  Valid <> b                 = b
-  a <> Valid                 = a
-  (Invalid a) <> (Invalid b) = Invalid (a ++ b)
-
-instance Monoid Validity where
-  mempty = Valid
-  mappend = (<>)

--- a/hs/src/LedgerState.hs
+++ b/hs/src/LedgerState.hs
@@ -321,6 +321,5 @@ delegatedStake ls@(LedgerState _ ds _) = Map.fromListWith mappend delegatedOutpu
     addStake delegations (TxOut (AddrTxin _ hsk) c) = do
       pool <- Map.lookup hsk delegations
       return (pool, c)
-    addStake _ _ = Nothing
     outs = getOutputs . getUtxo $ ls
     delegatedOutputs = mapMaybe (addStake (getDelegations ds)) outs

--- a/hs/src/LedgerState.hs
+++ b/hs/src/LedgerState.hs
@@ -13,7 +13,7 @@ as specified in /A Simplified Formal Specification of a UTxO Ledger/.
 module LedgerState
   ( LedgerState(..)
   , RewardAcnt(..)
-  , getRwdAcnt
+  , mkRwdAcnt
   , DelegationState(..)
   , Ledger
   , LedgerEntry(..)
@@ -90,8 +90,8 @@ instance Monoid Validity where
 newtype RewardAcnt = RewardAcnt HashKey
   deriving (Show, Eq, Ord)
 
-getRwdAcnt :: KeyPair -> RewardAcnt
-getRwdAcnt keys = RewardAcnt $ hashKey $ vKey keys
+mkRwdAcnt :: KeyPair -> RewardAcnt
+mkRwdAcnt keys = RewardAcnt $ hashKey $ vKey keys
 
 -- |The state associated with the current stake delegation.
 data DelegationState =

--- a/hs/src/Slot.hs
+++ b/hs/src/Slot.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DerivingVia #-}
+
+module Slot
+  ( Slot(..)
+  , Epoch(..)
+  ) where
+
+import           Data.Monoid             (Sum(..))
+import           Numeric.Natural         (Natural)
+
+-- |A Slot
+newtype Slot = Slot Natural
+  deriving (Show, Eq, Ord)
+  deriving (Semigroup, Monoid) via (Sum Natural)
+
+-- |An Epoch
+newtype Epoch = Epoch Natural
+  deriving (Show, Eq, Ord)
+  deriving (Semigroup, Monoid) via (Sum Natural)
+

--- a/hs/src/UTxO.hs
+++ b/hs/src/UTxO.hs
@@ -61,10 +61,8 @@ type Hash = Digest SHA256
 newtype TxId = TxId { getTxId :: Hash }
   deriving (Show, Eq, Ord)
 
--- |An address for UTxO.  It can be either an account based
--- address for rewards sharing or a UTxO address.
+-- |An address for UTxO.
 data Addr = AddrTxin HashKey HashKey
-          | AddrAccount Hash Hash
           deriving (Show, Eq, Ord)
 
 -- |The input of a UTxO.

--- a/hs/src/UTxO.hs
+++ b/hs/src/UTxO.hs
@@ -52,7 +52,7 @@ import           Numeric.Natural         (Natural)
 import           Coin                    (Coin (..))
 import           Keys
 
-import           Delegation.Certificates (Cert (..))
+import           Delegation.Certificates (DCert (..))
 
 -- |A hash
 type Hash = Digest SHA256
@@ -81,7 +81,7 @@ newtype UTxO = UTxO (Map TxIn TxOut) deriving (Show, Eq, Ord)
 -- |A raw transaction
 data Tx = Tx { inputs  :: !(Set TxIn)
              , outputs :: [TxOut]
-             , certs   :: !(Set Cert)
+             , certs   :: !(Set DCert)
              } deriving (Show, Eq, Ord)
 
 -- |Compute the id of a transaction.

--- a/hs/stack.yaml
+++ b/hs/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-12.10
+resolver: nightly-2018-11-07
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/hs/test/Tests.hs
+++ b/hs/test/Tests.hs
@@ -16,10 +16,11 @@ import qualified Hedgehog.Gen            as Gen
 import qualified Hedgehog.Range          as Range
 
 import           Coin
+import           Slot
 import           Keys
 import           LedgerState             (DelegationState (..), Ledger,
                                           LedgerEntry (..), LedgerState (..),
-                                          Slot (..), ValidationError (..),
+                                          ValidationError (..),
                                           asStateTransition, emptyDelegation,
                                           getRwdAcnt, genesisId, genesisState)
 import           UTxO
@@ -64,7 +65,7 @@ testLedgerValidTransactions ::
 testLedgerValidTransactions ls utxo =
     ls @?= Right (LedgerState
                      (UTxO utxo)
-                     LedgerState.emptyDelegation 0)
+                     LedgerState.emptyDelegation (Epoch 0))
 
 testValidStakeKeyRegistration ::
   [LedgerEntry] -> Map.Map TxIn TxOut -> DelegationState -> Assertion
@@ -74,7 +75,7 @@ testValidStakeKeyRegistration sd utxo stakeKeyRegistration =
   in ls2 @?= Right (LedgerState
                      (UTxO utxo)
                      stakeKeyRegistration
-                     0)
+                     (Epoch 0))
 
 testValidDelegation ::
   [LedgerEntry] -> Map.Map TxIn TxOut -> DelegationState -> StakePool -> Assertion
@@ -94,7 +95,7 @@ testValidDelegation sd utxo stakeKeyRegistration sp =
                                         hashKey $ vKey stakePoolKey1)]
                      , getStPools = Set.fromList [sp]
                      }
-                     0)
+                     (Epoch 0))
 
 tx1Body :: Tx
 tx1Body = Tx

--- a/hs/test/Tests.hs
+++ b/hs/test/Tests.hs
@@ -352,7 +352,6 @@ repeatTx n !keyPairs !fees !ls = do
 findAddrKeyPair :: Addr -> KeyPairs -> KeyPair
 findAddrKeyPair (AddrTxin addr _) keyList =
      fst $ head $ filter (\(pay, _) -> addr == (hashKey $ vKey pay)) keyList
-findAddrKeyPair (AddrAccount _ _) _ = undefined
 
 -- | Returns the hashed 'addr' part of a 'TxOut'.
 getTxOutAddr :: TxOut -> Addr

--- a/hs/test/Tests.hs
+++ b/hs/test/Tests.hs
@@ -21,7 +21,7 @@ import           LedgerState             (DelegationState (..), Ledger,
                                           LedgerEntry (..), LedgerState (..),
                                           ValidationError (..),
                                           asStateTransition, emptyDelegation,
-                                          genesisId, genesisState)
+                                          getRwdAcnt, genesisId, genesisState)
 import           UTxO
 
 import           Delegation.Certificates (DCert (..))
@@ -137,9 +137,9 @@ stakeKeyRegistration1 :: DelegationState
 stakeKeyRegistration1 = LedgerState.emptyDelegation
   {
     getAccounts =
-      Map.fromList [ (hashKey $ vKey aliceStake, Coin 0)
-                   , (hashKey $ vKey bobStake, Coin 0)
-                   , (hashKey $ vKey stakePoolKey1, Coin 0)]
+      Map.fromList [ (getRwdAcnt aliceStake, Coin 0)
+                   , (getRwdAcnt bobStake, Coin 0)
+                   , (getRwdAcnt stakePoolKey1, Coin 0)]
   , getStKeys =
       Set.fromList [ hashKey $ vKey aliceStake
                    , hashKey $ vKey bobStake

--- a/hs/test/Tests.hs
+++ b/hs/test/Tests.hs
@@ -24,7 +24,7 @@ import           LedgerState             (DelegationState (..), Ledger,
                                           genesisId, genesisState)
 import           UTxO
 
-import           Delegation.Certificates (Cert (..))
+import           Delegation.Certificates (DCert (..))
 import           Delegation.StakePool    (Delegation (..), StakePool (..))
 
 type KeyPairs = [(KeyPair, KeyPair)]
@@ -121,11 +121,11 @@ utxo1 = Map.fromList
 ls1 :: Either [ValidationError] LedgerState
 ls1 = ledgerState [tx1]
 
-certAlice :: Cert
+certAlice :: DCert
 certAlice = RegKey $ vKey aliceStake
-certBob :: Cert
+certBob :: DCert
 certBob = RegKey $ vKey bobStake
-certPool1 :: Cert
+certPool1 :: DCert
 certPool1 = RegKey $ vKey stakePoolKey1
 
 sd1 :: [LedgerEntry]

--- a/hs/test/Tests.hs
+++ b/hs/test/Tests.hs
@@ -85,15 +85,15 @@ testValidDelegation sd utxo stakeKeyRegistration sp =
     ls2 = ledgerState $ sd ++ [ DelegationData poolRegistration
                                , DelegationData stakeDelegation]
     poolRegistration = RegPool sp
+    poolhk = hashKey $ vKey stakePoolKey1
 
   in ls2 @?= Right (LedgerState
                      (UTxO utxo)
                      stakeKeyRegistration
                      {
                        getDelegations =
-                         Map.fromList [(hashKey $ vKey aliceStake,
-                                        hashKey $ vKey stakePoolKey1)]
-                     , getStPools = Set.fromList [sp]
+                         Map.fromList [(hashKey $ vKey aliceStake, poolhk)]
+                     , getStPools = Map.fromList [(poolhk, (sp, Slot 0))]
                      }
                      (Epoch 0))
 

--- a/hs/test/Tests.hs
+++ b/hs/test/Tests.hs
@@ -22,7 +22,7 @@ import           LedgerState             (DelegationState (..), Ledger,
                                           LedgerEntry (..), LedgerState (..),
                                           ValidationError (..),
                                           asStateTransition, emptyDelegation,
-                                          getRwdAcnt, genesisId, genesisState)
+                                          mkRwdAcnt, genesisId, genesisState)
 import           UTxO
 
 import           Delegation.Certificates (DCert (..))
@@ -138,9 +138,9 @@ stakeKeyRegistration1 :: DelegationState
 stakeKeyRegistration1 = LedgerState.emptyDelegation
   {
     getAccounts =
-      Map.fromList [ (getRwdAcnt aliceStake, Coin 0)
-                   , (getRwdAcnt bobStake, Coin 0)
-                   , (getRwdAcnt stakePoolKey1, Coin 0)]
+      Map.fromList [ (mkRwdAcnt aliceStake, Coin 0)
+                   , (mkRwdAcnt bobStake, Coin 0)
+                   , (mkRwdAcnt stakePoolKey1, Coin 0)]
   , getStKeys =
       Map.fromList [ (hashKey $ vKey aliceStake, Slot 0)
                    , (hashKey $ vKey bobStake, Slot 0)
@@ -258,10 +258,6 @@ addrTxins keyPairs = uncurry AddrTxin <$> hashKeyPairs keyPairs
 genNatural :: Natural -> Natural -> Gen Natural
 genNatural lower upper = Gen.integral $ Range.linear lower upper
 
--- | Generator for a Slot between 'lower' and 'upper'.
-genSlot :: Natural -> Natural -> Gen Slot
-genSlot lower upper = Slot <$> Gen.integral (Range.linear lower upper)
-
 -- | Generator for List of 'Coin' values. Generates between 'lower' and 'upper'
 -- coins, with values between 'minCoin' and 'maxCoin'.
 genCoinList :: Natural -> Natural -> Int -> Int -> Gen [Coin]
@@ -324,8 +320,8 @@ genLedgerStateTx :: KeyPairs -> LedgerState ->
 genLedgerStateTx keyList sourceState = do
   let utxo = getUtxo sourceState
   (fee, ledgerEntry) <- genTxLedgerEntry keyList utxo
-  slot <- genSlot 0 1000
-  pure (fee, ledgerEntry, asStateTransition slot sourceState ledgerEntry)
+  slot <- genNatural 0 1000
+  pure (fee, ledgerEntry, asStateTransition (Slot slot) sourceState ledgerEntry)
 
 -- | Generator of a non-emtpy ledger genesis state and a random number of
 -- transactions applied to it. Returns the amount of accumulated fees, the

--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -53,7 +53,8 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
       a & \AddrRWD & \text{reward address} \\
       slot & \Slot & \text{slot}\\
       dur & \Duration & \text{duration}\\
-      epoch & \Epoch & \text{epoch}
+      epoch & \Epoch & \text{epoch} \\
+      stakepool & \StakePool & \text{stake pool constants}
     \end{array}
   \end{equation*}
   %
@@ -91,8 +92,11 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
   \fun{author} & \DCert \to \HashKey
   & \text{certificate author}
   \\
-  \fun{pool} & \DCertDeleg \to \HashKey
+  \fun{dpool} & \DCertDeleg \to \HashKey
   & \text{pool being delegated to}
+  \\
+  \fun{stakepool} & \DCertRegPool \to \StakePool
+  & \text{stake pool constants}
   \\
   \fun{retire} & \DCertRetirePool \to \Epoch
   & \text{epoch of pool retirement}
@@ -100,7 +104,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
   \fun{epoch} & \Slot \to \Epoch
   & \text{epoch of a slot}
   \\
-    () & \Slot \to \Slot \to \Duration
+    (\slotminus{}{}) & \Slot \to \Slot \to \Duration
   & \text{slot duration}
   \end{array}
   \end{equation*}
@@ -128,7 +132,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
     \\
     \PState =
     \left(\begin{array}{r@{~\in~}lr}
-      \var{stpools} & \HashKey \mapsto (\DCertRegPool \times \Slot) & \text{registered stake pools to creation time}\\
+      \var{stpools} & \HashKey \mapsto (\StakePool \times \Slot) & \text{registered pools to creation time}\\
       \var{retiring} & \HashKey \mapsto \Epoch & \text{retiring stake pools}\\
     \end{array}\right)
     \end{array}
@@ -228,7 +232,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
       \begin{array}{rcl}
         \var{stkeys} \\
         \var{rewards} \\
-        \var{delegations} & \unionoverride & \{\var{hk} \mapsto \pool c\}
+        \var{delegations} & \unionoverride & \{\var{hk} \mapsto \dpool c\}
       \end{array}
       \right)
     }
@@ -244,7 +248,13 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
   \begin{equation}\label{eq:pool-reg}
     \inference[Pool-Reg]
     {
-      \RegPool{c} & \cauthor{c} = hk
+      \RegPool{c}
+      & \cauthor{c} = \var{hk}
+      & \stakepool{c} = \var{stakepool}
+      \\
+      \var{slot'} = \mathsf{if}~(hk \mapsto (\_, s))\in\var{stpools}
+                    ~\mathsf{then}~ s
+                    ~\mathsf{else}~ slot
     }
     {
       \var{slot} \vdash
@@ -257,7 +267,8 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
       \trans{pool}{c}
       \left(
       \begin{array}{rcl}
-        \var{stpools} & \unionoverride & \{\var{hk} \mapsto c\} \\
+        \var{stpools} & \unionoverride
+                      & \{\var{hk} \mapsto \var{(stakepool, slot')}\} \\
         \{\var{hk}\} & \subtractdom & \var{retiring} \\
       \end{array}
       \right)

--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -82,16 +82,16 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
   %
   \begin{equation*}
   \begin{array}{r@{~\in~}lr}
-  \fun{hash} & \VKey \to \Hash
+  \fun{hash} & \VKey \to \HashKey
   & \text{hashing a key}
   \\
-  \fun{addr_{rwd}} & \Hash \to \AddrRWD
+  \fun{addr_{rwd}} & \HashKey \to \AddrRWD
   & \text{address of a hashkey}
   \\
-  \fun{author} & \DCert \to \Hash
+  \fun{author} & \DCert \to \HashKey
   & \text{certificate author}
   \\
-  \fun{pool} & \DCertDeleg \to \Hash
+  \fun{pool} & \DCertDeleg \to \HashKey
   & \text{pool being delegated to}
   \\
   \fun{retire} & \DCertRetirePool \to \Epoch
@@ -120,16 +120,16 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
     \begin{array}{l}
     \DState =
     \left(\begin{array}{r@{~\in~}lr}
-      \var{stkeys} & \Hash \mapsto \Slot & \text{registered stake keys to creation time}\\
+      \var{stkeys} & \HashKey \mapsto \Slot & \text{registered stake keys to creation time}\\
       \var{rewards} & \AddrRWD \mapsto \Coin & \text{rewards}\\
-      \var{delegations} & \Hash \mapsto \Hash & \text{delegations}\\
+      \var{delegations} & \HashKey \mapsto \HashKey & \text{delegations}\\
     \end{array}\right)
     \\
     \\
     \PState =
     \left(\begin{array}{r@{~\in~}lr}
-      \var{stpools} & \Hash \mapsto (\DCertRegPool \times \Slot) & \text{registered stake pools to creation time}\\
-      \var{retiring} & \Hash \mapsto \Epoch & \text{retiring stake pools}\\
+      \var{stpools} & \HashKey \mapsto (\DCertRegPool \times \Slot) & \text{registered stake pools to creation time}\\
+      \var{retiring} & \HashKey \mapsto \Epoch & \text{retiring stake pools}\\
     \end{array}\right)
     \end{array}
   \end{equation*}

--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -82,11 +82,11 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
   %
   \begin{equation*}
   \begin{array}{r@{~\in~}lr}
-  \fun{hash} & \VKey \to \HashKey
-  & \text{hashing a key}
+  \fun{hashKey} & \VKey \to \HashKey
+  & \text{hashKeying a key}
   \\
   \fun{addr_{rwd}} & \HashKey \to \AddrRWD
-  & \text{address of a hashkey}
+  & \text{address of a hashKeykey}
   \\
   \fun{author} & \DCert \to \HashKey
   & \text{certificate author}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -47,6 +47,7 @@
 \newcommand{\DCertDeleg}{\type{DCert_{delegate}}}
 \newcommand{\DCertRegPool}{\type{DCert_{regpool}}}
 \newcommand{\DCertRetirePool}{\type{DCert_{retirepool}}}
+\newcommand{\StakePool}{\type{StakePool}}
 \newcommand{\ledgerState}{\ensuremath{\type{ledgerState}}}
 
 \newcommand{\AddrRWD}{\type{Addr_{rwd}}}
@@ -104,7 +105,8 @@
 \newcommand{\RegPool}[1]{\textsc{RegPool}(#1)}
 \newcommand{\RetirePool}[1]{\textsc{RetirePool}(#1)}
 \newcommand{\cauthor}[1]{\fun{author}~ \var{#1}}
-\newcommand{\pool}[1]{\fun{pool}~ \var{#1}}
+\newcommand{\dpool}[1]{\fun{dpool}~ \var{#1}}
+\newcommand{\stakepool}[1]{\fun{stakepool}~ \var{#1}}
 \newcommand{\retire}[1]{\fun{retire}~ \var{#1}}
 \newcommand{\addrRw}[1]{\fun{addr_{rwd}}~ \var{#1}}
 \newcommand{\epoch}[1]{\fun{epoch}~ \var{#1}}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -62,7 +62,8 @@
 \newcommand{\TxOut}{\type{TxOut}}
 \newcommand{\VKey}{\type{VKey}}
 \newcommand{\SKey}{\type{SKey}}
-\newcommand{\Hash}{\type{Hash}}
+\newcommand{\HashKey}{\type{HashKey}}
+\newcommand{\Hash}{\type{Foo}}
 \newcommand{\SkVk}{\type{SkVk}}
 \newcommand{\Sig}{\type{Sig}}
 \newcommand{\Data}{\type{Data}}
@@ -199,7 +200,7 @@ this document.
     \begin{array}{r@{~\in~}lr}
       \var{vk} & \SKey & \text{private signing key}\\
       \var{vk} & \VKey & \text{public verifying key}\\
-      \var{hk} & \Hash & \text{hash of a key}\\
+      \var{hk} & \HashKey & \text{hash of a key}\\
       \sigma & \Sig  & \text{signature}\\
       \var{d} & \Data  & \text{data}\\
     \end{array}
@@ -214,7 +215,7 @@ this document.
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \hash{} & \VKey \to \Hash
+      \hash{} & \VKey \to \HashKey
       & \text{hash function} \\
       %
       \fun{verify} & \powerset{\left(\VKey \times \Data \times \Sig\right)}
@@ -286,7 +287,7 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
       \var{allocs}
       & \Allocs
       & hkeys \mapsto slot
-      & \Hash \to \Slot
+      & \HashKey \to \Slot
       & \text{resource allocations}
     \end{array}
   \end{equation*}
@@ -323,7 +324,7 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
       & \text{total deposits for transaction} \\
       & \fun{deposits}~{pc}~{tx} = \sum\limits_{c \in \fun{dresource}~tx} (\fun{d}~pc~c)
       \nextdef
-      & \fun{poolAllocs} \in (\Hash \mapsto (\DCertRegPool \times \Slot)) \to \Allocs
+      & \fun{poolAllocs} \in (\HashKey \mapsto (\DCertRegPool \times \Slot)) \to \Allocs
       & \text{pool allocations} \\
       & \fun{poolAllocs}~\var{stpool} =
           \{hash \mapsto slot \mid hash \mapsto (\_, slot) \in \var{stpool}\}
@@ -564,7 +565,7 @@ different order). The choice here is arbitrary.
     \begin{array}{r@{~\in~}lr}
       \fun{wits} & \Tx \to \powerset{(\VKey \times \Sig)}
       & \text{witnesses of a transaction}\\
-      \fun{hash_{spend}} & \Addr \mapsto \Hash
+      \fun{hash_{spend}} & \Addr \mapsto \HashKey
       & \text{hash of a spending key in an address}\\
     \end{array}
   \end{equation*}
@@ -577,7 +578,7 @@ different order). The choice here is arbitrary.
     & \addr{}{} \in \UTxO \to \TxIn \mapsto \Addr & \text{address of an input}\\
     & \addr{utxo} = \{ i \mapsto a \mid i \mapsto (a, \wcard) \in \var{utxo} \} \\
     \nextdef
-    & \fun{addr_h} \in \UTxO \to \TxIn \mapsto \Hash & \text{hash of an input address}\\
+    & \fun{addr_h} \in \UTxO \to \TxIn \mapsto \HashKey & \text{hash of an input address}\\
     & \fun{addr_h}~utxo = \{ i \mapsto h \mid i \mapsto (a, \wcard) \in \var{utxo}
       \wedge a \mapsto h \in \fun{hash_{spend}} \}
   \end{align*}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -117,7 +117,7 @@
 \newcommand{\sign}[2]{\fun{sign} ~ #1 ~ #2}
 \newcommand{\serialised}[1]{\llbracket \var{#1} \rrbracket}
 \newcommand{\addr}[1]{\fun{addr}~ \var{#1}}
-\newcommand{\hash}[1]{\fun{hash}~ \var{#1}}
+\newcommand{\hashKey}[1]{\fun{hashKey}~ \var{#1}}
 \newcommand{\txbody}[1]{\fun{txbody}~ \var{#1}}
 \newcommand{\txfee}[1]{\fun{txfee}~ \var{#1}}
 \newcommand{\minfee}[2]{\fun{minfee}~ \var{#1}~ \var{#2}}
@@ -200,7 +200,7 @@ this document.
     \begin{array}{r@{~\in~}lr}
       \var{vk} & \SKey & \text{private signing key}\\
       \var{vk} & \VKey & \text{public verifying key}\\
-      \var{hk} & \HashKey & \text{hash of a key}\\
+      \var{hk} & \HashKey & \text{hashKey of a key}\\
       \sigma & \Sig  & \text{signature}\\
       \var{d} & \Data  & \text{data}\\
     \end{array}
@@ -215,8 +215,8 @@ this document.
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \hash{} & \VKey \to \HashKey
-      & \text{hash function} \\
+      \hashKey{} & \VKey \to \HashKey
+      & \text{hashKey function} \\
       %
       \fun{verify} & \powerset{\left(\VKey \times \Data \times \Sig\right)}
       & \text{verification relation}\\
@@ -327,7 +327,7 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
       & \fun{poolAllocs} \in (\HashKey \mapsto (\DCertRegPool \times \Slot)) \to \Allocs
       & \text{pool allocations} \\
       & \fun{poolAllocs}~\var{stpool} =
-          \{hash \mapsto slot \mid hash \mapsto (\_, slot) \in \var{stpool}\}
+          \{hashKey \mapsto slot \mid hashKey \mapsto (\_, slot) \in \var{stpool}\}
       \nextdef
       & \fun{refund} \in \PrtclConsts \to \Allocs \to \Slot \to \DCert \to \Coin
       & \text{total refund for a certificate} \\
@@ -565,8 +565,8 @@ different order). The choice here is arbitrary.
     \begin{array}{r@{~\in~}lr}
       \fun{wits} & \Tx \to \powerset{(\VKey \times \Sig)}
       & \text{witnesses of a transaction}\\
-      \fun{hash_{spend}} & \Addr \mapsto \HashKey
-      & \text{hash of a spending key in an address}\\
+      \fun{hashKey_{spend}} & \Addr \mapsto \HashKey
+      & \text{hashKey of a spending key in an address}\\
     \end{array}
   \end{equation*}
   \caption{Definitions used in the UTxO transition system with witnesses}
@@ -578,9 +578,9 @@ different order). The choice here is arbitrary.
     & \addr{}{} \in \UTxO \to \TxIn \mapsto \Addr & \text{address of an input}\\
     & \addr{utxo} = \{ i \mapsto a \mid i \mapsto (a, \wcard) \in \var{utxo} \} \\
     \nextdef
-    & \fun{addr_h} \in \UTxO \to \TxIn \mapsto \HashKey & \text{hash of an input address}\\
+    & \fun{addr_h} \in \UTxO \to \TxIn \mapsto \HashKey & \text{hashKey of an input address}\\
     & \fun{addr_h}~utxo = \{ i \mapsto h \mid i \mapsto (a, \wcard) \in \var{utxo}
-      \wedge a \mapsto h \in \fun{hash_{spend}} \}
+      \wedge a \mapsto h \in \fun{hashKey_{spend}} \}
   \end{align*}
   \caption{Functions used in rules witnesses}
   \label{fig:derived-defs:utxow}
@@ -612,7 +612,7 @@ different order). The choice here is arbitrary.
       & \forall i \in \txins{tx} \cdot \exists (\var{vk}, \sigma) \in \wits{\var{tx}}
       \cdot
       \mathcal{V}_{\var{vk}}{\serialised{\txbody{tx}}}_{\sigma}
-      \wedge  \fun{addr_h}~{utxo}~i = \hash{vk}\\
+      \wedge  \fun{addr_h}~{utxo}~i = \hashKey{vk}\\
     }
     {
       \begin{array}{l}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -65,7 +65,7 @@
 \newcommand{\SKey}{\type{SKey}}
 \newcommand{\HashKey}{\type{HashKey}}
 \newcommand{\Hash}{\type{Foo}}
-\newcommand{\SkVk}{\type{SkVk}}
+\newcommand{\KeyPair}{\type{KeyPair}}
 \newcommand{\Sig}{\type{Sig}}
 \newcommand{\Data}{\type{Data}}
 %% Adding delegation
@@ -210,7 +210,7 @@ this document.
   \emph{Derived types}
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      (sk, vk) & \SkVk & \text{signing-verifying key pairs}
+      (sk, vk) & \KeyPair & \text{signing-verifying key pairs}
     \end{array}
   \end{equation*}
   \emph{Abstract functions}
@@ -226,7 +226,7 @@ this document.
   \end{equation*}
   \emph{Constraints}
   \begin{align*}
-    & \forall (sk, vk) \in \SkVk,~ m \in \Data,~ \sigma \in \Sig \cdot
+    & \forall (sk, vk) \in \KeyPair,~ m \in \Data,~ \sigma \in \Sig \cdot
       \verify{vk}{m}{\sigma} \iff \sign{sk}{m} = \sigma
   \end{align*}
   \emph{Notation for serialized and verified data}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -64,7 +64,6 @@
 \newcommand{\VKey}{\type{VKey}}
 \newcommand{\SKey}{\type{SKey}}
 \newcommand{\HashKey}{\type{HashKey}}
-\newcommand{\Hash}{\type{Foo}}
 \newcommand{\KeyPair}{\type{KeyPair}}
 \newcommand{\Sig}{\type{Sig}}
 \newcommand{\Data}{\type{Data}}

--- a/latex/properties.tex
+++ b/latex/properties.tex
@@ -160,7 +160,7 @@ set of $l$.
 \begin{figure}[ht]
   \centering
   \begin{align*}
-    \fun{getStKeys} & \in & \ledgerState \to \powerset \Hash \\
+    \fun{getStKeys} & \in & \ledgerState \to \powerset \HashKey \\
     \fun{getStKeys} & \coloneqq & (\wcard, (\var{stKeys}, \wcard, \wcard),
                                   \wcard) \to \var{stkeys} \\
                     &&\\
@@ -168,16 +168,16 @@ set of $l$.
     \fun{getRewards} & \coloneqq & (\wcard, (\wcard, \var{rewards}, \wcard),
                                    \wcard) \to \var{rewards} \\
                     &&\\
-    \fun{getDelegations} & \in & \ledgerState \to \Hash \mapsto \Hash \\
+    \fun{getDelegations} & \in & \ledgerState \to \HashKey \mapsto \HashKey \\
     \fun{getDelegations} & \coloneqq & (\wcard, (\wcard, \wcard,
                                        \var{delegations}), \wcard) \to
                                        \var{delegations} \\
                     &&\\
-    \fun{getStPools} & \in & \ledgerState \to \Hash \mapsto \DCertRegPool \\
+    \fun{getStPools} & \in & \ledgerState \to \HashKey \mapsto \DCertRegPool \\
     \fun{getStPools} & \coloneqq & (\wcard, \wcard,
                                    (\var{stpools}, \wcard)) \to \var{stpools} \\
                     &&\\
-    \fun{getRetiring} & \in & \ledgerState \to \Hash \mapsto \Epoch \\
+    \fun{getRetiring} & \in & \ledgerState \to \HashKey \mapsto \Epoch \\
     \fun{getRetiring} & \coloneqq & (\wcard, \wcard,
                                     (\wcard, \var{retiring})) \to \var{retiring} \\
   \end{align*}


### PR DESCRIPTION
This is a first pass at getting the haskell model in sync with the recent changes to the LaTeX document.

Changes to the Haskell Model:

- Cert to DCert (naming)
- remove reward addr from Addr
- use reward accounts (so now they are a separate type)
- removing stale code
- deriving via, new nightly resolver (removing boilerplate)
- stkeys map to slot
- make Epoch a type
- stpool maps from hashkey

Changes to the LaTeX spec:
- Hash to HaskKey (naming)
- hash to haskKey (naming)
- Store pool state instead of cert (I think this makes the types more clear). Additionally, do not override pool registration slot when re-registering
- SkVk to KeyPair (naming)