### PR TITLE
splitting stpools into two maps [skip ci]

### DIFF
--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -411,10 +411,40 @@ are given in Figure~\ref{fig:defs:delegationw}.
 \begin{figure}
   \emph{Delegation with witness rule}
   \begin{equation}
-    \label{eq:deleg-witnesses}
-    \inference[Deleg-wit]
+    \label{eq:deleg-witnesses-keys}
+    \inference[Deleg-wit-keys]
     { \dwit{c} = (\var{vk_s}, \sigma)
       & \var{slot} \vdash \var{dstate} \trans{deleg}{c} \var{dstate'}
+      \\ ~ \\
+      \verify{vk_s}{\serialised{(\dbody{c},~\txbody \var{tx})}}{\sigma}
+    }
+    { \left(
+      \begin{array}{r}
+        \var{tx} \\
+        \var{slot}
+      \end{array}
+      \right)
+      \vdash
+      \left(
+      \begin{array}{r}
+        \var{dstate} \\
+        \var{pstate}
+      \end{array}
+      \right)
+      \trans{delegw}{c}
+      \left(
+      \begin{array}{rcl}
+        \var{dstate'} \\
+        \var{pstate'}
+      \end{array}
+      \right)
+    }
+  \end{equation}
+
+  \begin{equation}
+    \label{eq:deleg-witnesses-pools}
+    \inference[Deleg-wit-pools]
+    { \dwit{c} = (\var{vk_s}, \sigma)
       & \var{slot} \vdash \var{pstate} \trans{pool}{c} \var{pstate'}
       \\ ~ \\
       \verify{vk_s}{\serialised{(\dbody{c},~\txbody \var{tx})}}{\sigma}

--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -85,7 +85,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
       \var{allocs}
       & \Allocs
       & hkeys \mapsto slot
-      & \HashKey \to \Slot
+      & \HashKey \mapsto \Slot
       & \text{resource allocations}
     \end{array}
   \end{equation*}

--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -79,6 +79,17 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
   \end{array}
   \end{equation*}
   %
+  \emph{Derived types}
+  \begin{equation*}
+    \begin{array}{r@{~\in~}l@{\qquad=\qquad}r@{~\in~}lr}
+      \var{allocs}
+      & \Allocs
+      & hkeys \mapsto slot
+      & \HashKey \to \Slot
+      & \text{resource allocations}
+    \end{array}
+  \end{equation*}
+  %
   \emph{Abstract functions}
   %
   \begin{equation*}
@@ -124,7 +135,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
     \begin{array}{l}
     \DState =
     \left(\begin{array}{r@{~\in~}lr}
-      \var{stkeys} & \HashKey \mapsto \Slot & \text{registered stake keys to creation time}\\
+      \var{stkeys} & \Allocs & \text{registered stake keys to creation time}\\
       \var{rewards} & \AddrRWD \mapsto \Coin & \text{rewards}\\
       \var{delegations} & \HashKey \mapsto \HashKey & \text{delegations}\\
     \end{array}\right)
@@ -132,7 +143,9 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
     \\
     \PState =
     \left(\begin{array}{r@{~\in~}lr}
-      \var{stpools} & \HashKey \mapsto (\StakePool \times \Slot) & \text{registered pools to creation time}\\
+      \var{stpools} & \Allocs & \text{registered pools to creation time}\\
+      \var{pparams} & \HashKey \mapsto \StakePool
+        & \text{registered pools to pool parameters}\\
       \var{retiring} & \HashKey \mapsto \Epoch & \text{retiring stake pools}\\
     \end{array}\right)
     \end{array}
@@ -181,7 +194,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
       \left(
       \begin{array}{rcl}
         \var{stkeys} & \union & \{\var{hk} \mapsto slot\}\\
-        \var{rewards} & \unionoverride & \{\addrRw \var{hk} \mapsto 0\}\\
+        \var{rewards} & \unionoverrideRight & \{\addrRw \var{hk} \mapsto 0\}\\
         \var{delegations}
       \end{array}
       \right)
@@ -232,7 +245,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
       \begin{array}{rcl}
         \var{stkeys} \\
         \var{rewards} \\
-        \var{delegations} & \unionoverride & \{\var{hk} \mapsto \dpool c\}
+        \var{delegations} & \unionoverrideRight & \{\var{hk} \mapsto \dpool c\}
       \end{array}
       \right)
     }
@@ -251,24 +264,23 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
       \RegPool{c}
       & \cauthor{c} = \var{hk}
       & \stakepool{c} = \var{stakepool}
-      \\
-      \var{slot'} = \mathsf{if}~(hk \mapsto (\_, s))\in\var{stpools}
-                    ~\mathsf{then}~ s
-                    ~\mathsf{else}~ slot
     }
     {
       \var{slot} \vdash
       \left(
       \begin{array}{r}
         \var{stpools} \\
+        \var{pparams} \\
         \var{retiring}
       \end{array}
       \right)
       \trans{pool}{c}
       \left(
       \begin{array}{rcl}
-        \var{stpools} & \unionoverride
-                      & \{\var{hk} \mapsto \var{(stakepool, slot')}\} \\
+        \var{stpools} & \unionoverrideLeft
+                      & \{\var{hk} \mapsto \var{slot}\} \\
+        \var{pparams} & \unionoverrideRight
+                      & \{\var{hk} \mapsto \var{stakepool}\} \\
         \{\var{hk}\} & \subtractdom & \var{retiring} \\
       \end{array}
       \right)
@@ -291,6 +303,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
     \left(
       \begin{array}{r}
         \var{stpools} \\
+        \var{pparams} \\
         \var{retiring}
       \end{array}
     \right)
@@ -298,7 +311,8 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
     \left(
       \begin{array}{rcl}
         \var{stpools} \\
-        \var{retiring} & \unionoverride & \{\var{hk} \mapsto \var{e}\} \\
+        \var{pparams} \\
+        \var{retiring} & \unionoverrideRight & \{\var{hk} \mapsto \var{e}\} \\
       \end{array}
     \right)
   }
@@ -315,6 +329,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
       \left(
       \begin{array}{r}
         \var{stpools} \\
+        \var{pparams} \\
         \var{retiring}
       \end{array}
       \right)
@@ -322,6 +337,7 @@ The rules for registering stake pools are given in \cref{fig:pool-rules}.
       \left(
       \begin{array}{rcl}
         \var{retired} & \subtractdom & \var{stpools} \\
+        \var{retired} & \subtractdom & \var{pparams} \\
         \var{retired} & \subtractdom & \var{retiring} \\
       \end{array}
       \right)

--- a/latex/iohk.sty
+++ b/latex/iohk.sty
@@ -16,7 +16,8 @@
 \newcommand{\restrictrange}{\ensuremath{\rhd}}
 \newcommand{\subtractrange}{\ensuremath{\mathbin{\slashed{\restrictrange}}}}
 \newcommand{\union}{\ensuremath{\cup}}
-\newcommand{\unionoverride}{\ensuremath{\mathbin{\underrightarrow\cup}}}
+\newcommand{\unionoverrideRight}{\ensuremath{\mathbin{\underrightarrow\cup}}}
+\newcommand{\unionoverrideLeft}{\ensuremath{\mathbin{\underleftarrow\cup}}}
 \newcommand{\uniondistinct}{\ensuremath{\uplus}}
 \newcommand{\var}[1]{\ensuremath{\mathit{#1}}}
 \newcommand{\fun}[1]{\ensuremath{\mathsf{#1}}}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -714,7 +714,7 @@ different order). The choice here is arbitrary.
           dwstate \\
         \end{array}
       \right)
-      \trans{ledger}{certs}
+      \trans{ledger}{tx}
       \left(
         \begin{array}{ll}
           utxo' \\

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -186,7 +186,40 @@ The transition system is explained in \cite{small_step_semantics}.
     function} from $A$ to $B$, which can be seen as a map (dictionary) with
   keys in $A$ and values in $B$. Given a map $m \in A \mapsto B$, notation
   $a \mapsto b \in m$ is equivalent to $m~ a = b$.
+\item[Map Operations] Figure \ref{fig:notation:nonstandard}
+  describes some non-standard map operations.
+
 \end{description}
+
+\begin{figure}
+  \begin{align*}
+    \var{set} \restrictdom \var{map}
+    & = \{ k \mapsto v \mid k \mapsto v \in \var{map}, ~ k \in \var{set} \}
+    & \text{domain foo restriction}
+    \\
+    \var{set} \subtractdom \var{map}
+    & = \{ k \mapsto v \mid k \mapsto v \in \var{map}, ~ k \notin \var{set} \}
+    & \text{domain exclusion}
+    \\
+    \var{map} \restrictrange \var{set}
+    & = \{ k \mapsto v \mid k \mapsto v \in \var{map}, ~ v \in \var{set} \}
+    & \text{range restriction}
+    \\
+    \var{map} \subtractrange \var{set}
+    & = \{ k \mapsto v \mid k \mapsto v \in \var{map}, ~ v \notin \var{set} \}
+    & \text{range exclusion}
+    \\
+    A \unionoverrideRight B
+    & = (\dom B \subtractdom A)\cup B
+    & \text{union override right}
+    \\
+    A \unionoverrideLeft B
+    & = A \cup (\dom A \subtractdom B)
+    & \text{union override left}
+  \end{align*}
+  \caption{Non-standard map operators}
+  \label{fig:notation:nonstandard}
+\end{figure}
 
 \section{Cryptographic primitives}
 \label{sec:crypto-primitives}
@@ -282,17 +315,6 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
     \end{array}
   \end{equation*}
   %
-  \emph{Derived types}
-  \begin{equation*}
-    \begin{array}{r@{~\in~}l@{\qquad=\qquad}r@{~\in~}lr}
-      \var{allocs}
-      & \Allocs
-      & hkeys \mapsto slot
-      & \HashKey \to \Slot
-      & \text{resource allocations}
-    \end{array}
-  \end{equation*}
-  %
   \emph{Abstract Functions}
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
@@ -325,11 +347,6 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
       & \text{total deposits for transaction} \\
       & \fun{deposits}~{pc}~{tx} = \sum\limits_{c \in \fun{dresource}~tx} (\fun{d}~pc~c)
       \nextdef
-      & \fun{poolAllocs} \in (\HashKey \mapsto (\DCertRegPool \times \Slot)) \to \Allocs
-      & \text{pool allocations} \\
-      & \fun{poolAllocs}~\var{stpool} =
-          \{hashKey \mapsto slot \mid hashKey \mapsto (\_, slot) \in \var{stpool}\}
-      \nextdef
       & \fun{refund} \in \PrtclConsts \to \Allocs \to \Slot \to \DCert \to \Coin
       & \text{total refund for a certificate} \\
       & \refund{allocs}{pc}{slot}{c} =\\
@@ -350,9 +367,9 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
       \nextdef
       & \fun{refunds} \in \PrtclConsts \to \Allocs \to \Allocs \to \Tx \to \Coin
       & \text{total refunds for transaction} \\
-      & \refunds{pc}{dallocs}{pallocs}{tx} =\\
-      &   \sum\limits_{c \in \fun{dderegister}~tx} \refund{pc}{dallocs}{(\ttl{tx})}{c}\\
-      &   ~~~+ \sum\limits_{c \in \fun{dretire}~tx} \refund{pc}{pallocs}{(\retire{c})}{c}
+      & \refunds{pc}{stkeys}{stpools}{tx} =\\
+      &   \sum\limits_{c \in \fun{dderegister}~tx} \refund{pc}{stkeys}{(\ttl{tx})}{c}\\
+      &   ~~~+ \sum\limits_{c \in \fun{dretire}~tx} \refund{pc}{stpools}{(\retire{c})}{c}
   \end{align*}
   \caption{Functions used in Deposits}
   \label{fig:functions:deposits}
@@ -438,8 +455,8 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
     \nextdef
     & \fun{created} \in \PrtclConsts \to \UTxO \to \Allocs \to \Allocs \to \Tx \to \Coin
     & \text{value created} \\
-    & \created{pc}{utxo}{dallocs}{pallocs}{tx} = \\
-    & ~~\balance{(\txins{tx} \restrictdom \var{utxo})} + \refunds{pc}{dallocs}{pallocs}{tx}
+    & \created{pc}{utxo}{stkeys}{stpools}{tx} = \\
+    & ~~\balance{(\txins{tx} \restrictdom \var{utxo})} + \refunds{pc}{stkeys}{stpools}{tx}
     \nextdef
     & \fun{destroyed} \in \PrtclConsts \to \Tx \to \Coin
     & \text{value destroyed} \\
@@ -472,8 +489,8 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
       \begin{array}{r@{~\in~}lr}
         \var{slot} & \Slot & \text{current slot}\\
         \var{pc} & \PrtclConsts & \text{protocol constants}\\
-        \var{dallocs} & \Allocs & \text{stake key allocations}\\
-        \var{pallocs} & \Allocs & \text{stake pool allocations}\\
+        \var{stkeys} & \Allocs & \text{stake key allocations}\\
+        \var{stpools} & \Allocs & \text{stake pool allocations}\\
       \end{array}
     \right)
   \end{equation*}
@@ -497,14 +514,14 @@ Functions on these types are defined in Figure~\ref{fig:derived-defs:utxo}.
       \txins{tx} \subseteq \dom \var{utxo}
       & \minfee{pc}{tx} \leq \txfee{tx}
       \\
-      \created{pc}{utxo}{dallocs}{pallocs}{tx} = \destroyed{pc}{tx}
+      \created{pc}{utxo}{stkeys}{stpools}{tx} = \destroyed{pc}{tx}
     }
     {
       \begin{array}{l}
         \var{slot}\\
         \var{pc}\\
-        \var{dallocs}\\
-        \var{pallocs}\\
+        \var{stkeys}\\
+        \var{stpools}\\
       \end{array}
       \vdash \var{utxo} \trans{utxo}{tx}
       (\txins{tx} \subtractdom \var{utxo}) \cup \txouts{tx}
@@ -665,14 +682,13 @@ different order). The choice here is arbitrary.
     \label{eq:ledger}
     \inference[ledger]
     {
-      \Gamma = \dcerts{tx}
-      & pallocs = \fun{poolAllocs}~stpools\\~\\
+      \Gamma = \dcerts{tx} \\ ~ \\
       {
         \begin{array}{r}
         slot\\
         pc\\
         stkeys\\
-        pallocs\\
+        stpools\\
         \end{array}
       }
       \vdash \var{utxo} \trans{utxow}{tx} \var{utxo'}\\~\\~\\


### PR DESCRIPTION
The map `stpools` which has type `HashKey -> (StakePool, Slot)` makes the notation confusing and awkward in several places in the latex spec.  This PR separates it into two maps and cleans up the notation.

additionally, the PR splits the `DELEGW` rule into two rules, so that now it conforms to the small step semantics.

closes #58  closes #64 