### PR TITLE
refund pools only at epoch

### DIFF
--- a/docs/accounting/Accounting.lhs
+++ b/docs/accounting/Accounting.lhs
@@ -93,17 +93,28 @@ A duration is the difference between two slots:
 (-*) :: Slot -> Slot -> Duration
 (Slot s) -* (Slot t) = Duration (s - t)
 
+(+*) :: Slot -> Duration -> Slot
+(Slot s) +* (Duration d) = Slot (s + d)
+
 \end{code}
 
 There are two types of certificates which create
 resources on the ledger, key registration certificates
 and pool registration certificates.
-We give them an ID in order to distinguish them.
+Each of these has a corresponding certificate
+to remove the resource.
+Key deregistration happens as soon as the ledger
+proccesses the certificate, but pool retirement
+happens after a specified duration.
+We give the certificates an ID in order to distinguish them.
 
 \begin{code}
 type CertID = Natural
 
-data Cert = KeyReg CertID | PoolReg CertID
+data Cert = KeyReg CertID
+          | KeyDeReg CertID
+          | PoolReg CertID
+          | PoolRetire CertID Duration
 \end{code}
 %if style == code
 \begin{code}
@@ -150,6 +161,7 @@ data LedgerState =
   , _rewardPool :: Coin
   , _fees :: Coin
   , _obligations :: Map Cert Slot
+  , _retiring :: Map CertID Slot
   , _pconsts :: PrtclConsts
   , _slot :: Slot
   , _lastEpoch :: Slot }
@@ -215,6 +227,8 @@ The deposit amounts are determined by the protocol constants.
 deposit :: Cert -> PrtclConsts -> Coin
 deposit (KeyReg _) = _keyRegDep
 deposit (PoolReg _) = _poolRegDep
+deposit (KeyDeReg _) = const $ Coin 0
+deposit (PoolRetire _ _) = const $ Coin 0
 
 \end{code}
 
@@ -246,8 +260,7 @@ to move between the seven categories.
 
 \begin{code}
 data Action = ActTxBody Coin
-            | ActAddCert Cert
-            | ActDelCert Cert
+            | ActCert Cert
             | ActWithdrawal Coin
             | ActEpochNoVote Float
             | ActEpochWithVote PrtclConsts Float
@@ -260,9 +273,64 @@ data Action = ActTxBody Coin
 \end{code}
 %endif
 
-We now describe how each of these actions changes the
-ledger state.
+We will describe how each of these actions changes the ledger state.
+First we define a few methods which will be used by the actions.
 
+Both key registration and pool registration certificates will be
+added to the ledger state with the following method:
+
+\begin{code}
+addCert :: LedgerState -> Cert -> LedgerState
+addCert ls cert =
+  case Map.lookup cert (ls^.obligations) of
+    (Just _) -> ls -- invalid transition, cert already registered
+    Nothing ->
+      ls & deposits +~ d
+         & circulation -~ d
+         & obligations .~ Map.insert cert (ls^.slot) (ls^.obligations)
+      where d = deposit cert (ls^.pconsts)
+
+\end{code}
+
+We can split the amount of a deposit still remaning in the deposit
+pool into the amount that is left for a refund and the amount
+that has decayed.
+
+\begin{code}
+refundPartition :: Cert -> Slot -> LedgerState -> (Coin, Coin)
+refundPartition cert s ls = (refundNow, decayed)
+  where
+    lastSettlement = max (ls^.lastEpoch) s
+    refundNow = refund cert (ls^.pconsts) ((ls^.slot) -* s)
+    refundAtSettlement = refund cert (ls^.pconsts) (lastSettlement -* s)
+    decayed = refundAtSettlement - refundNow
+
+\end{code}
+
+Pools are only retired at epoch boundaries.
+When a retirement certificate is posted to the ledger,
+the state records the upcomming retiriment in $\mathsf{\_retiring}$.
+During the epoch boundary, the pools in this map which
+are ready to retire are refunded and removed with:
+
+\begin{code}
+retirePool :: LedgerState -> CertID -> LedgerState
+retirePool ls p =
+  case Map.lookup (PoolReg p) (ls^.obligations) of
+    Nothing -> ls -- invalid transition, unknown cert
+    (Just s) ->
+      ls & deposits -~ (refundNow + decayed)
+         & rewards +~ refundNow
+         & fees +~ decayed
+         & obligations .~ Map.delete cert (ls^.obligations)
+         & retiring .~ Map.delete p (ls^.retiring)
+      where
+        cert = PoolReg p
+        (refundNow, decayed) = refundPartition cert s ls
+
+\end{code}
+
+We now define the ledger actions.
 \begin{code}
 applyAction :: LedgerState -> Action -> LedgerState
 
@@ -283,17 +351,11 @@ applyAction ls (ActTxBody fee) =
 
 New certificates can be registered, which removes \lovelace
 from circulation to the deposit pool.
-Again, we skip invalid transitions.
 
 \begin{code}
-applyAction ls (ActAddCert cert) =
-  case Map.lookup cert (ls^.obligations) of
-    (Just _) -> ls -- invalid transition, cert already registered
-    Nothing ->
-      ls & deposits +~ d
-         & circulation -~ d
-         & obligations .~ Map.insert cert (ls^.slot) (ls^.obligations)
-      where d = deposit cert (ls^.pconsts)
+applyAction ls (ActCert cert@(KeyReg _)) = addCert ls cert
+
+applyAction ls (ActCert cert@(PoolReg _)) = addCert ls cert
 
 \end{code}
 
@@ -305,19 +367,22 @@ has since decayed this epoch is given to the fee pool,
 and all else is moved to cirtulation.
 
 \begin{code}
-applyAction ls (ActDelCert cert) =
-  case Map.lookup cert (ls^.obligations) of
+applyAction ls (ActCert (KeyDeReg i)) =
+  case Map.lookup (KeyReg i) (ls^.obligations) of
     Nothing -> ls -- invalid transition, unknown cert
     (Just s) ->
-      ls & deposits -~ refundAtSettlement
+      ls & deposits -~ (refundNow + decayed)
          & circulation +~ refundNow
          & fees +~ decayed
          & obligations .~ Map.delete cert (ls^.obligations)
       where
-        lastSettlement = max (ls^.lastEpoch) s
-        refundNow = refund cert (ls^.pconsts) ((ls^.slot) -* s)
-        refundAtSettlement = refund cert (ls^.pconsts) (lastSettlement -* s)
-        decayed = refundAtSettlement - refundNow
+        cert = KeyReg i
+        (refundNow, decayed) = refundPartition cert s ls
+
+applyAction ls (ActCert (PoolRetire i d)) =
+  case Map.lookup (PoolReg i) (ls^.obligations) of
+    Nothing -> ls -- invalid transition, unknown pool
+    (Just _) -> ls & retiring .~ Map.insert i ((ls^.slot) +* d) (ls ^. retiring)
 
 \end{code}
 
@@ -358,14 +423,15 @@ in preserving ada and our rules are more general.
 
 \begin{code}
 applyAction ls (ActEpochNoVote realized) =
-  ls & deposits .~ oblg
-     & treasury +~ newTreasury
-     & reserves -~ expansion
-     & rewards +~ paidRewards
-     & rewardPool .~ availablePool - paidRewards
-     & fees .~ Coin 0
-     & lastEpoch .~ ls^.slot
+  foldl retirePool ls' retiringIds
   where
+    ls' = ls & deposits .~ oblg
+              & treasury +~ newTreasury
+              & reserves -~ expansion
+              & rewards +~ paidRewards
+              & rewardPool .~ availablePool - paidRewards
+              & fees .~ Coin 0
+              & lastEpoch .~ ls^.slot
     oblg = obligation ls
     decayed = ls^.deposits - oblg
     expansion = floor $ ls^.pconsts.rho * fromIntegral (ls^.reserves)
@@ -373,6 +439,7 @@ applyAction ls (ActEpochNoVote realized) =
     newTreasury = floor $ ls^.pconsts.tau * fromIntegral totalPool
     availablePool = totalPool - newTreasury
     paidRewards = floor $ realized * fromIntegral availablePool
+    retiringIds = Map.keys $ Map.filter (>= ls^.slot) (ls^.retiring)
 
 \end{code}
 

--- a/docs/accounting/Accounting.lhs
+++ b/docs/accounting/Accounting.lhs
@@ -91,7 +91,7 @@ newtype Coin = Coin Natural
 A duration is the difference between two slots:
 \begin{code}
 (-*) :: Slot -> Slot -> Duration
-(Slot s) -* (Slot t) = Duration (s - t)
+(Slot s) -* (Slot t) = Duration (if s > t then s - t else t - s)
 
 (+*) :: Slot -> Duration -> Slot
 (Slot s) +* (Duration d) = Slot (s + d)
@@ -255,8 +255,8 @@ obligation ls = sum
 
 \subsection{Actions}
 
-There are seven types of actions that cause \lovelace
-to move between the seven categories.
+There are six types of actions that cause \lovelace
+to move between the six categories.
 
 \begin{code}
 data Action = ActTxBody Coin
@@ -274,6 +274,8 @@ data Action = ActTxBody Coin
 %endif
 
 We will describe how each of these actions changes the ledger state.
+Note that in this model, our only form of validation is to
+skip actions which correspond to invalid transitions.
 First we define a few methods which will be used by the actions.
 
 Both key registration and pool registration certificates will be
@@ -309,8 +311,8 @@ refundPartition cert s ls = (refundNow, decayed)
 
 Pools are only retired at epoch boundaries.
 When a retirement certificate is posted to the ledger,
-the state records the upcomming retiriment in $\mathsf{\_retiring}$.
-During the epoch boundary, the pools in this map which
+the state records the upcoming retiriment in $\mathsf{\_retiring}$.
+At the epoch boundary, the pools in this map which
 are ready to retire are refunded and removed with:
 
 \begin{code}

--- a/docs/accounting/Makefile
+++ b/docs/accounting/Makefile
@@ -36,11 +36,11 @@ all: $(DOCNAME).pdf $(SRCDIR)/$(DOCNAME).hs
 # missing file reference and interactively asking you for an alternative.
 
 $(DOCNAME).pdf: $(DOCNAME).lhs
-	lhs2TeX -o $(DOCNAME).tex  $(DOCNAME).lhs
+	lhs2TeX --tt -o $(DOCNAME).tex  $(DOCNAME).lhs
 	latexmk -pdf -pdflatex="pdflatex -interaction=nonstopmode" -use-make $(DOCNAME).tex
 
 watch: $(DOCNAME).lhs
-	lhs2TeX -o $(DOCNAME).tex  $(DOCNAME).lhs
+	lhs2TeX --tt -o $(DOCNAME).tex  $(DOCNAME).lhs
 	latexmk -pvc -pdf -pdflatex="pdflatex -interaction=nonstopmode" -use-make $(DOCNAME).tex
 
 $(SRCDIR)/$(DOCNAME).hs: $(DOCNAME).lhs

--- a/docs/accounting/accounting/test/Test.hs
+++ b/docs/accounting/accounting/test/Test.hs
@@ -7,6 +7,7 @@ import Test.Tasty.HUnit
 
 import qualified Data.Map as Map
 import Lens.Micro ((&), (.~))
+import Numeric.Natural (Natural)
 
 import Accounting
 
@@ -25,22 +26,30 @@ conservationOfLovelace =
     ls <- forAll gledgerstate
     total (foldl applyAction ls actions) === fortyFiveBillionAda
 
-gcoin :: Coin -> Coin -> Gen Coin
-gcoin (Coin cmin) (Coin cmax) = Coin <$> Gen.integral (Range.linear cmin cmax)
+gnat :: Natural -> Natural -> Gen Natural
+gnat lower upper = Gen.integral (Range.linear lower upper)
 
-gslot :: Gen Slot
-gslot = Slot <$> Gen.integral (Range.linear 0 1000)
+gcoin :: Coin -> Coin -> Gen Coin
+gcoin (Coin cmin) (Coin cmax) = Coin <$> gnat cmin cmax
 
 gcert :: Gen Cert
 gcert = Gen.choice
-  [ KeyReg <$> Gen.integral (Range.linear 0 1000)
-  , PoolReg <$> Gen.integral (Range.linear 0 1000) ]
+  [ KeyReg <$> gnat 0 1000
+  , PoolReg <$> gnat 0 1000
+  , KeyDeReg <$> gnat 0 1000
+  , PoolRetire <$> gnat 0 1000 <*> (Duration <$> gnat 0 1000)]
 
 gobligations :: Gen (Cert, Slot)
 gobligations = do
   c <- gcert
-  s <- gslot
-  return (c, s)
+  s <- gnat 0 1000
+  return (c, Slot s)
+
+gretiring :: Slot -> Gen (Natural, Slot)
+gretiring cslot = do
+  certId <- gnat 0 1000
+  d <- gnat 0 1000
+  return (certId, cslot +* Duration d)
 
 gpconsts :: Gen PrtclConsts
 gpconsts = PrtclConsts
@@ -55,10 +64,11 @@ gledgerstate :: Gen LedgerState
 gledgerstate = do
   -- generate obligations and the current slot
   obl <- Gen.map (Range.linear 0 1000) gobligations
-  sl <- gslot
+  sl <- gnat 0 1000
   let
     creations = Map.elems obl
-    cslot = sl + (if Prelude.null creations then 0 else maximum creations)
+    minSlot = if Prelude.null creations then Slot 0 else maximum creations
+    cslot = Slot sl + minSlot
 
   -- protocol constants
   pc <- gpconsts
@@ -77,14 +87,15 @@ gledgerstate = do
   -- set the circulation to the remainder of the fort five billion ada
   let circ = fortyFiveBillionAda - (deps + fee + rpool + treas + reward + reserv)
 
+  -- set the retiring pools
+  ret <- Gen.map (Range.linear 0 1000) (gretiring cslot)
 
-  return (LedgerState circ deps treas reserv reward rpool fee obl pc cslot cslot)
+  return (LedgerState circ deps treas reserv reward rpool fee obl ret pc cslot cslot)
 
 gaction :: Gen Accounting.Action
 gaction = Gen.choice
   [ ActTxBody <$> gcoin (Coin 0) (Coin 1000)
-  , ActAddCert <$> gcert
-  , ActDelCert <$> gcert
+  , ActCert <$> gcert
   , ActWithdrawal <$> gcoin (Coin 0) (Coin 1000000)
   , ActEpochNoVote <$> Gen.realFloat (Range.exponentialFloat 0 1)
   , ActEpochWithVote <$> gpconsts <*> Gen.realFloat (Range.exponentialFloat 0 1)
@@ -103,14 +114,18 @@ examplePc = PrtclConsts
 
 exampleLS :: LedgerState
 exampleLS = LedgerState {
-    _circulation = Coin 29999999999999800
-  , _deposits = Coin 200
+    _circulation = Coin 29999999999998800
+  , _deposits = Coin 1200
   , _treasury = Coin 0
   , _reserves = Coin 14999999999999900
   , _rewards = Coin 100
   , _rewardPool = Coin 0
   , _fees = Coin 0
-  , _obligations = Map.singleton (KeyReg 0) (Slot 3)
+  , _obligations = Map.fromList
+      [ (KeyReg 0, Slot 3)
+      , (PoolReg 1, Slot 5)
+      , (PoolReg 2, Slot 6)]
+  , _retiring = Map.singleton 1 (Slot 100)
   , _pconsts = examplePc
   , _slot = Slot 100
   , _lastEpoch = Slot 50
@@ -118,21 +133,24 @@ exampleLS = LedgerState {
 
 epochLS :: LedgerState
 epochLS = LedgerState {
-    _circulation = Coin 29999999999999800
-  , _deposits = Coin 198
+    _circulation = Coin 29999999999998800
+  , _deposits = Coin 694
   , _treasury = Coin 300000018432
   , _reserves = Coin 14998499999973276
-  , _rewards = Coin 900000055396
-  , _rewardPool = Coin 299999952898
+  , _rewards = Coin 900000055892
+  , _rewardPool = Coin 299999952906
   , _fees = Coin 0
-  , _obligations = Map.singleton (KeyReg 0) (Slot 3)
+  , _obligations = Map.fromList
+      [ (KeyReg 0, Slot 3)
+      , (PoolReg 2, Slot 6)]
+  , _retiring = Map.empty
   , _pconsts = examplePc
   , _slot = Slot 100
   , _lastEpoch = Slot 100
   }
 
 testObligation :: Assertion
-testObligation = obligation exampleLS @?= Coin 198
+testObligation = obligation exampleLS @?= Coin 1190
 
 testPreservation :: LedgerState -> Assertion
 testPreservation ls = total ls @?= fortyFiveBillionAda
@@ -142,34 +160,57 @@ testTxPres = testPreservation $ applyAction exampleLS (ActTxBody $ Coin 2)
 
 testTxCalc :: Assertion
 testTxCalc = applyAction exampleLS (ActTxBody $ Coin 2) @?=
-  (exampleLS & circulation .~ Coin 29999999999999798
+  (exampleLS & circulation .~ Coin 29999999999998798
              & fees .~ Coin 2)
 
-testAddCertPres :: Assertion
-testAddCertPres = testPreservation $ applyAction exampleLS (ActAddCert $ KeyReg 1)
+testAddKeyCertPres :: Assertion
+testAddKeyCertPres = testPreservation $ applyAction exampleLS (ActCert $ KeyReg 1)
 
-testAddCertCalc :: Assertion
-testAddCertCalc = applyAction exampleLS (ActAddCert $ KeyReg 1) @?=
-  (exampleLS & circulation .~ Coin 29999999999999600
-             & deposits .~ Coin 400
-             & obligations .~ Map.fromList [(KeyReg 0, Slot 3), (KeyReg 1, Slot 100)])
+testAddKeyCertCalc :: Assertion
+testAddKeyCertCalc = applyAction exampleLS (ActCert $ KeyReg 10) @?=
+  (exampleLS & circulation .~ Coin 29999999999998600
+             & deposits .~ Coin 1400
+             & obligations .~ Map.fromList [ (KeyReg 0, Slot 3)
+                                           , (PoolReg 1, Slot 5)
+                                           , (PoolReg 2, Slot 6)
+                                           , (KeyReg 10, Slot 100)])
 
-testDelCertPres :: Assertion
-testDelCertPres = testPreservation $ applyAction exampleLS (ActDelCert $ KeyReg 0)
+testAddPoolCertPres :: Assertion
+testAddPoolCertPres = testPreservation $ applyAction exampleLS (ActCert $ PoolReg 1)
 
-testDelCertCalc :: Assertion
-testDelCertCalc = applyAction exampleLS (ActDelCert $ KeyReg 0) @?=
-  (exampleLS & circulation .~ Coin 29999999999999998
-             & deposits .~ Coin 1
+testAddPoolCertCalc :: Assertion
+testAddPoolCertCalc = applyAction exampleLS (ActCert $ PoolReg 11) @?=
+  (exampleLS & circulation .~ Coin 29999999999998300
+             & deposits .~ Coin 1700
+             & obligations .~ Map.fromList [ (KeyReg 0, Slot 3)
+                                           , (PoolReg 1, Slot 5)
+                                           , (PoolReg 2, Slot 6)
+                                           , (PoolReg 11, Slot 100)])
+
+testDelKeyCertPres :: Assertion
+testDelKeyCertPres = testPreservation $ applyAction exampleLS (ActCert $ KeyDeReg 0)
+
+testDelKeyCertCalc :: Assertion
+testDelKeyCertCalc = applyAction exampleLS (ActCert $ KeyDeReg 0) @?=
+  (exampleLS & circulation .~ Coin 29999999999998998
+             & deposits .~ Coin 1001
              & fees .~ Coin 1
-             & obligations .~ Map.empty)
+             & obligations .~ Map.fromList [ (PoolReg 1, Slot 5)
+                                           , (PoolReg 2, Slot 6)])
+
+testRetirePoolPres :: Assertion
+testRetirePoolPres = testPreservation $ applyAction exampleLS (ActCert $ PoolRetire 0 (Duration 5))
+
+testRetirePoolCalc :: Assertion
+testRetirePoolCalc = applyAction exampleLS (ActCert $ PoolRetire 1 (Duration 5)) @?=
+  (exampleLS & retiring .~ Map.singleton 1 (Slot 105))
 
 testWithdrawalPres :: Assertion
 testWithdrawalPres = testPreservation $ applyAction exampleLS (ActWithdrawal $ Coin 5)
 
 testWithdrawalCalc :: Assertion
 testWithdrawalCalc = applyAction exampleLS (ActWithdrawal $ Coin 5) @?=
-  (exampleLS & circulation .~ Coin 29999999999999805
+  (exampleLS & circulation .~ Coin 29999999999998805
              & rewards .~ Coin 95)
 
 testEpochPres :: Assertion
@@ -184,8 +225,8 @@ testFasterDecayPres = testPreservation $ applyAction exampleLS (ActEpochWithVote
 
 testFasterDecayCalc :: Assertion
 testFasterDecayCalc = applyAction exampleLS (ActEpochWithVote pc 0.75) @?=
-  (epochLS & deposits .~ Coin 197
-           & reserves .~ Coin 14998499999973277
+  (epochLS & deposits .~ Coin 690
+           & reserves .~ Coin 14998499999973280
            & pconsts .~ pc)
   where pc = examplePc {_decayRate = 0.0002}
 
@@ -195,15 +236,15 @@ testSlowerDecayPres = testPreservation $ applyAction exampleLS (ActEpochWithVote
 
 testSlowerDecayCalc :: Assertion
 testSlowerDecayCalc = applyAction exampleLS (ActEpochWithVote pc 0.75) @?=
-  (epochLS & deposits .~ Coin 199
-           & reserves .~ Coin 14998499999973275
+  (epochLS & deposits .~ Coin 697
+           & reserves .~ Coin 14998499999973273
            & pconsts .~ pc)
   where pc = examplePc {_decayRate = 0.00005}
 
 testDelCertAfterVote :: Assertion
 testDelCertAfterVote = total (foldl applyAction ls actions) @?= fortyFiveBillionAda
   where
-    actions = [ ActAddCert (KeyReg 147)
+    actions = [ ActCert (KeyReg 147)
               , ActNextSlot
               , ActEpochWithVote
                   PrtclConsts
@@ -215,7 +256,7 @@ testDelCertAfterVote = total (foldl applyAction ls actions) @?= fortyFiveBillion
                     , _rho = 0.0
                     }
                   0.0
-              , ActDelCert (KeyReg 147)
+              , ActCert (KeyDeReg 147)
               , ActTxBody (Coin 0)
               ]
     ls = LedgerState
@@ -227,6 +268,7 @@ testDelCertAfterVote = total (foldl applyAction ls actions) @?= fortyFiveBillion
            , _rewardPool = Coin 0
            , _fees = Coin 0
            , _obligations = Map.empty
+           , _retiring = Map.empty
            , _pconsts =
                PrtclConsts
                  { _keyRegDep = Coin 0
@@ -247,11 +289,17 @@ unitTests = testGroup "Unit Tests"
   , testCase "transaction preservation" testTxPres
   , testCase "transaction calculation" testTxCalc
 
-  , testCase "add cert preservation" testAddCertPres
-  , testCase "add cert" testAddCertCalc
+  , testCase "add key cert preservation" testAddKeyCertPres
+  , testCase "add key cert" testAddKeyCertCalc
 
-  , testCase "delete cert preservation" testDelCertPres
-  , testCase "delete cert" testDelCertCalc
+  , testCase "add pool cert preservation" testAddPoolCertPres
+  , testCase "add pool cert" testAddPoolCertCalc
+
+  , testCase "delete key cert preservation" testDelKeyCertPres
+  , testCase "delete key cert" testDelKeyCertCalc
+
+  , testCase "retire pool cert preservation" testRetirePoolPres
+  , testCase "retire pool cert" testRetirePoolCalc
 
   , testCase "reward withdrawal preservation" testWithdrawalPres
   , testCase "reward withdrawal" testWithdrawalCalc


### PR DESCRIPTION
The stand-alone accounting document has been updated so that pools are only refunded on epoch boundaries.  As such, pool retirements are now tracked by the ledger state.