### PR TITLE
Latex/accounting rules

### DIFF
--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -117,12 +117,7 @@ $\Duration$ here by $\var{dur}$).
   \begin{equation*}
   \begin{array}{r@{}c@{}l}
     \DCert &=& \DCertRegKey \uniondistinct \DCertDeRegKey \uniondistinct \DCertDeleg \\
-                &\hfill\uniondistinct\;& \DCertRegPool \uniondistinct \DCertRetirePool \\
-    \RegKey{c} \in \DCert &\iff& c \in \DCertRegKey \\
-    \DeregKey{c} \in \DCert &\iff& c \in \DCertDeRegKey \\
-    \Delegate{c} \in \DCert &\iff& c \in \DCertDeleg \\
-    \RegPool{c} \in \DCert &\iff& c \in \DCertRegPool\\
-    \RetirePool{c} \in \DCert &\iff& c \in \DCertRetirePool \\
+                &\hfill\uniondistinct\;& \DCertRegPool \uniondistinct \DCertRetirePool
   \end{array}
   \end{equation*}
   %
@@ -335,7 +330,7 @@ being delegated to.
   \begin{equation}\label{eq:deleg-reg}
     \inference[Deleg-Reg]
     {
-      \RegKey{c} & \cauthor{c} = hk & hk \notin \var{stkeys}
+      \var{c}\in\DCertRegPool & \cauthor{c} = hk & hk \notin \var{stkeys}
     }
     {
       \var{slot} \vdash

--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -98,7 +98,7 @@ $\Duration$ here by $\var{dur}$).
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       a & \AddrRWD & \text{reward address} \\
-      slot & \Slot & \text{slot}\\
+      slot & \Slot & \text{absolute slot}\\
       dur & \Duration & \text{duration}\\
       epoch & \Epoch & \text{epoch} \\
       stakepool & \StakePool & \text{stake pool constants}
@@ -108,7 +108,8 @@ $\Duration$ here by $\var{dur}$).
   \emph{Constants}
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \emax & \Epoch & \text{epoch bound on pool retirement}
+      \slotsPer & \mathbb{N} & \text{slots per epoch} \\
+      \emax & \Epoch & \text{epoch bound on pool retirement} \\
     \end{array}
   \end{equation*}
   %
@@ -253,11 +254,6 @@ of the change of the context variable $\Slot$.
       \powerset (\Slot \times \PState \times \DCert \times \PState)
   \end{equation*}
   %
-  \begin{equation*}
-    \_ \vdash \_ \trans{poolreap}{} \_ \in
-    \powerset (\Slot \times \PState \times \PState)
-  \end{equation*}
-  %
   \caption{Delegation Transitions}
   \label{fig:delegation-transitions}
 \end{figure}
@@ -330,7 +326,7 @@ being delegated to.
   \begin{equation}\label{eq:deleg-reg}
     \inference[Deleg-Reg]
     {
-      \var{c}\in\DCertRegPool & \cauthor{c} = hk & hk \notin \var{stkeys}
+      \var{c}\in\DCertRegPool & \cauthor{c} = hk & hk \notin \dom \var{stkeys}
     }
     {
       \var{slot} \vdash
@@ -528,31 +524,6 @@ of the current slot number signifies an epoch boundary.
   }
   \end{equation}
 
-  \begin{equation}\label{eq:pool-reap}
-    \inference[Pool-Reap]
-    {
-      \var{retired} = \var{retiring}^{-1}~\var{(\epoch{slot})}
-      & \var{retired} \neq \emptyset
-    }
-    {
-      \var{slot} \vdash
-      \left(
-      \begin{array}{r}
-        \var{stpools} \\
-        \var{pparams} \\
-        \var{retiring}
-      \end{array}
-      \right)
-      \trans{poolreap}{}
-      \left(
-      \begin{array}{rcl}
-        \var{retired} & \subtractdom & \var{stpools} \\
-        \var{retired} & \subtractdom & \var{pparams} \\
-        \var{retired} & \subtractdom & \var{retiring} \\
-      \end{array}
-      \right)
-    }
-  \end{equation}
   \caption{Pool Inference Rule}
   \label{fig:pool-rules}
 

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -1,0 +1,54 @@
+The pool reaping in rules are discribed in
+Figure~\ref{fig:ts-types:pool-reap} and Figure~\ref{fig:rules:pool-reap}.
+
+%%
+%% Figure - Pool Reap
+%%
+
+
+\begin{figure}
+  \emph{Pool Reap Transition}
+  \begin{equation*}
+    \_ \vdash \_ \trans{poolreap}{} \_ \in
+    \powerset (\Slot \times \PState \times \PState)
+  \end{equation*}
+  %
+  \caption{Pool Reap Transition}
+  \label{fig:ts-types:pool-reap}
+\end{figure}
+
+
+%%
+%% Figure - Pool Rules
+%%
+\begin{figure}
+
+  \begin{equation}\label{eq:pool-reap}
+    \inference[Pool-Reap]
+    {
+      \var{retired} = \var{retiring}^{-1}~\var{(\epoch{slot})}
+      & \var{retired} \neq \emptyset
+    }
+    {
+      \var{slot} \vdash
+      \left(
+      \begin{array}{r}
+        \var{stpools} \\
+        \var{pparams} \\
+        \var{retiring}
+      \end{array}
+      \right)
+      \trans{poolreap}{}
+      \left(
+      \begin{array}{rcl}
+        \var{retired} & \subtractdom & \var{stpools} \\
+        \var{retired} & \subtractdom & \var{pparams} \\
+        \var{retired} & \subtractdom & \var{retiring} \\
+      \end{array}
+      \right)
+    }
+  \end{equation}
+  \caption{Pool Reap Inference Rule}
+  \label{fig:rules:pool-reap}
+
+\end{figure}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -511,7 +511,8 @@ body must also contain inputs onto which this refund can be added.
         \end{cases}\\
       &
       \begin{array}{lr@{~=~}l}
-        \where &\fun{releasing}~\var{c} & \DeregKey{c} \lor \RetirePool{c}\\
+        \where &\fun{releasing}~\var{c}
+          & c \in \DCertDeRegKey \cup \DCertRetirePool\\
         & d_{\min},~\lambda & \fun{decay}~pc\\
         &\delta & \slotminus{slot}{(allocs~(\cauthor c))}\\
       \end{array}\\

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -34,6 +34,7 @@
 \newcommand{\TxId}{\type{TxId}}
 \newcommand{\Addr}{\type{Addr}}
 \newcommand{\UTxO}{\type{UTxO}}
+\newcommand{\Wdrl}{\type{Wdrl}}
 \newcommand{\Value}{\type{Value}}
 \newcommand{\Coin}{\type{Coin}}
 \newcommand{\PrtclConsts}{\type{PrtclConsts}}
@@ -48,6 +49,7 @@
 \newcommand{\DCertRegPool}{\type{DCert_{regpool}}}
 \newcommand{\DCertRetirePool}{\type{DCert_{retirepool}}}
 \newcommand{\StakePool}{\type{StakePool}}
+\newcommand{\UTxOState}{\ensuremath{\type{UTxOState}}}
 \newcommand{\ledgerState}{\ensuremath{\type{ledgerState}}}
 
 \newcommand{\AddrRWD}{\type{Addr_{rwd}}}
@@ -93,8 +95,10 @@
 \newcommand{\ttl}[1]{\fun{ttl}~ \var{#1}}
 \newcommand{\deposits}[2]{\fun{deposits}~ \var{#1} ~ \var{#2}}
 \newcommand{\refund}[4]{\fun{refund}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
-\newcommand{\refunds}[4]{\fun{refunds}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
-\newcommand{\created}[5]{\fun{created}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}~ \var{#5}}
+\newcommand{\decayed}[4]{\fun{decayed}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
+\newcommand{\decayedTx}[3]{\fun{decayedTx}~ \var{#1}~ \var{#2}~ \var{#3}}
+\newcommand{\keyRefunds}[3]{\fun{keyRefunds}~ \var{#1}~ \var{#2}~ \var{#3}}
+\newcommand{\created}[4]{\fun{created}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
 \newcommand{\destroyed}[2]{\fun{destroyed}~ \var{#1}~ \var{#2}}
 \newcommand{\applyFun}[2]{\fun{#1}~\var{#2}}
 
@@ -121,6 +125,7 @@
 \newcommand{\hashKey}[1]{\fun{hashKey}~ \var{#1}}
 \newcommand{\txbody}[1]{\fun{txbody}~ \var{#1}}
 \newcommand{\txfee}[1]{\fun{txfee}~ \var{#1}}
+\newcommand{\txwdrls}[1]{\fun{txwdrls}~ \var{#1}}
 \newcommand{\minfee}[2]{\fun{minfee}~ \var{#1}~ \var{#2}}
 \newcommand{\slotminus}[2]{\var{#1}~-_{s}~\var{#2}}
 \DeclarePairedDelimiter\floor{\lfloor}{\rfloor}
@@ -145,7 +150,8 @@
 \newcommand{\genesisId}{\ensuremath{Genesis_{Id}}}
 \newcommand{\genesisTxOut}{\ensuremath{Genesis_{Out}}}
 \newcommand{\genesisUTxO}{\ensuremath{Genesis_{UTxO}}}
-\newcommand{\emax}{\mathsf{E_{max}}}
+\newcommand{\emax}{\ensuremath{\mathsf{E_{max}}}}
+\newcommand{\slotsPer}{\ensuremath{\mathsf{slotsPerEpoch}}}
 
 \theoremstyle{definition}
 \newtheorem{definition}{Definition}[section]
@@ -198,7 +204,7 @@ the rest of the document.
   \begin{align*}
     \var{set} \restrictdom \var{map}
     & = \{ k \mapsto v \mid k \mapsto v \in \var{map}, ~ k \in \var{set} \}
-    & \text{domain foo restriction}
+    & \text{domain restriction}
     \\
     \var{set} \subtractdom \var{map}
     & = \{ k \mapsto v \mid k \mapsto v \in \var{map}, ~ k \notin \var{set} \}
@@ -498,12 +504,16 @@ body must also contain inputs onto which this refund can be added.
       & \text{total deposits for transaction} \\
       & \fun{deposits}~{pc}~{tx} = \sum\limits_{c \in \fun{dresource}~tx} (\fun{dvalue}~pc~c)
       \nextdef
+      & \fun{releasing} \in \DCert \to \mathsf{Bool}
+      & \text{allocates resources} \\
+      & \fun{releasing}~c = c \in \DCertDeRegKey \cup \DCertRetirePool\\
+      \nextdef
       & \fun{refund} \in \PrtclConsts \to \Allocs \to \Slot \to \DCert \to \Coin
       & \text{total refund for a certificate} \\
       & \refund{allocs}{pc}{slot}{c} =\\
       & \begin{cases}
         0 & \text{if not}~(\fun{releasing}~c)\\
-            0 & \text{if}~\cauthor c \notin allocs\\
+            0 & \text{if}~\cauthor c \notin \dom allocs\\
             \floor*{
               \left(\fun{dvalue}~pc~c\right) \cdot
             \left(d_{\min}+(1-d_{\min})\cdot e^{-\lambda\cdot\delta}\right)}
@@ -511,17 +521,43 @@ body must also contain inputs onto which this refund can be added.
         \end{cases}\\
       &
       \begin{array}{lr@{~=~}l}
-        \where &\fun{releasing}~\var{c}
-          & c \in \DCertDeRegKey \cup \DCertRetirePool\\
+        \where
         & d_{\min},~\lambda & \fun{decay}~pc\\
         &\delta & \slotminus{slot}{(allocs~(\cauthor c))}\\
       \end{array}\\
       \nextdef
-      & \fun{refunds} \in \PrtclConsts \to \Allocs \to \Allocs \to \Tx \to \Coin
-      & \text{total refunds for transaction} \\
-      & \refunds{pc}{stkeys}{stpools}{tx} =\\
+      & \fun{keyRefunds} \in \PrtclConsts \to \Allocs \to \Tx \to \Coin
+      & \text{key refunds for transaction} \\
+      & \keyRefunds{pc}{stkeys}{tx} =\\
       &   \sum\limits_{c \in \fun{dderegister}~tx} \refund{pc}{stkeys}{(\ttl{tx})}{c}\\
-      &   ~~~+ \sum\limits_{c \in \fun{dretire}~tx} \refund{pc}{stpools}{(\retire{c})}{c}
+      \nextdef
+      & \fun{lastEpoch} \in \Slot \to \Epoch
+      & \text{(abs.) slot of last epoch} \\
+      & \fun{lastEpoch}~{s} =  s - (s~\mathsf{div}~\slotsPer)
+      \nextdef
+      & \fun{decayed} \in
+      \PrtclConsts \to \Allocs \to \Slot \to \DCert \to \Coin
+      & \text{amount decayed since epoch} \\
+      & \decayed{allocs}{pc}{cslot}{c} =\\
+      & \begin{cases}
+        0 & \text{if not}~(\fun{releasing}~c)\\
+            0 & \text{if}~\cauthor c \notin \dom allocs\\
+            \var{epochRefund} - \var{currentRefund}
+            & \text{otherwise}
+        \end{cases}\\
+      &
+      \begin{array}{lr@{~=~}l}
+        \where
+          & \var{created} & \var{allocs}~\var{c} \\
+          & \var{start} & \mathsf{max}~(lastEpoch~created)~created \\
+          & \var{epochRefund} & \refund{c}{pc}{allocs}{start} \\
+          & \var{currentRefund} & \refund{c}{pc}{allocs}{cslot} \\
+      \end{array}\\
+      \nextdef
+      & \fun{decayedTx} \in \PrtclConsts \to \Allocs \to \Tx \to \Coin
+      & \text{decayed deposits portions} \\
+      & \decayedTx{pc}{stkeys}{tx} =\\
+      &   \sum\limits_{c \in \fun{dderegister}~tx} \decayed{pc}{stkeys}{(\ttl{tx})}{c}\\
   \end{align*}
   \caption{Functions used in Deposits}
   \label{fig:functions:deposits}
@@ -606,6 +642,12 @@ the contents of the transaction itself.
       & \var{txin} \mapsto \var{txout}
       & \TxIn \mapsto \TxOut
       & \text{unspent tx outputs}
+      \\
+      \var{wdrl}
+      & \Wdrl
+      & \var{txin} \mapsto \var{a}
+      & \TxIn \mapsto \AddrRWD
+      & \text{reward withdrawal}
     \end{array}
   \end{equation*}
   %
@@ -619,7 +661,9 @@ the contents of the transaction itself.
       %
       \fun{txfee} & \Tx \to \Coin & \text{transaction fee}\\
       %
-      \fun{minfee} & \PrtclConsts \to \Tx \to \Coin & \text{minimum fee}
+      \fun{minfee} & \PrtclConsts \to \Tx \to \Coin & \text{minimum fee}\\
+      %
+      \fun{txwdrls} & \Tx \to \powerset{\Wdrl} & \text{transaction withdrawals}\\
     \end{array}
   \end{equation*}
   \caption{Definitions used in the UTxO transition system}
@@ -675,8 +719,8 @@ constants).
     \nextdef
     & \fun{created} \in \PrtclConsts \to \UTxO \to \Allocs \to \Allocs \to \Tx \to \Coin
     & \text{value created} \\
-    & \created{pc}{utxo}{stkeys}{stpools}{tx} = \\
-    & ~~\balance{(\txins{tx} \restrictdom \var{utxo})} + \refunds{pc}{stkeys}{stpools}{tx}
+    & \created{pc}{utxo}{stkeys}{tx} = \\
+    & ~~\balance{(\txins{tx} \restrictdom \var{utxo})} + \keyRefunds{pc}{stkeys}{tx}
     \nextdef
     & \fun{destroyed} \in \PrtclConsts \to \Tx \to \Coin
     & \text{value destroyed} \\
@@ -730,12 +774,27 @@ signal that triggers the transition.
     \right)
   \end{equation*}
   %
+  \emph{UTxO States}
+  \begin{equation*}
+    \UTxOState =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{utxo} & \UTxO & \text{UTxO}\\
+        \var{deposits} & \Coin & \text{deposits pool}\\
+        \var{fees} & \Coin & \text{fee pool}\\
+        \var{wdrls} & \powerset{\Wdrl} &
+          \text{pending withdrawals}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
   \emph{UTxO transitions}
   \begin{equation*}
     \_ \vdash
     \var{\_} \trans{utxo}{\_} \var{\_}
-    \subseteq \powerset (\UTxOEnv \times \UTxO \times \Tx \times \UTxO)
+    \subseteq \powerset (\UTxOEnv \times \UTxOState \times \Tx \times \UTxOState)
   \end{equation*}
+  %
   \caption{UTxO transition-system types}
   \label{fig:ts-types:utxo}
 \end{figure}
@@ -804,7 +863,17 @@ UTxO, now associated with the $\var{txid}(\var{tx})$ instead.
       \txins{tx} \subseteq \dom \var{utxo}
       & \minfee{pc}{tx} \leq \txfee{tx}
       \\
-      \created{pc}{utxo}{stkeys}{stpools}{tx} = \destroyed{pc}{tx}
+      \dom{wdrls} \cap \dom{(\txwdrls{tx})} = \emptyset
+      \\
+      \created{pc}{utxo}{stkeys}{tx} = \destroyed{pc}{tx}
+      \\
+      ~
+      \\
+      \var{refunded} = \keyRefunds{pc}{stkeys}{slot}{cert}
+      \\
+      \var{decayed} = \decayedTx{pc}{stkeys}{slot}{cert}
+      \\
+      \var{depositChange} = (\deposits{pc}{tx}) - (\var{refunded} + \var{decayed})
     }
     {
       \begin{array}{l}
@@ -813,8 +882,24 @@ UTxO, now associated with the $\var{txid}(\var{tx})$ instead.
         \var{stkeys}\\
         \var{stpools}\\
       \end{array}
-      \vdash \var{utxo} \trans{utxo}{tx}
-      (\txins{tx} \subtractdom \var{utxo}) \cup \txouts{tx}
+      \vdash
+      \left(
+      \begin{array}{r}
+        \var{utxo} \\
+        \var{deposits} \\
+        \var{fees} \\
+        \var{wdrls} \\
+      \end{array}
+      \right)
+      \trans{utxo}{tx}
+      \left(
+      \begin{array}{r}
+        (\txins{tx} \subtractdom \var{utxo}) \cup \txouts{tx} \\
+        \var{deposits} + \var{depositChange} \\
+        \var{fees} + (\txfee{tx}) + \var{decayed} \\
+        \var{wdrls} \cup (\txwdrls{tx})\\
+      \end{array}
+      \right)
     }
   \end{equation}
   \caption{UTxO inference rules}
@@ -923,7 +1008,7 @@ being applied to the UTxO.
   \begin{equation*}
     \var{\_} \vdash
     \var{\_} \trans{utxow}{\_} \var{\_}
-    \subseteq \powerset (\UTxOEnv \times \UTxO \times \Tx \times \UTxO)
+    \subseteq \powerset (\UTxOEnv \times \UTxOState \times \Tx \times \UTxOState)
   \end{equation*}
   \caption{UTxO with witness transition-system types}
   \label{fig:ts-types:utxow}
@@ -941,18 +1026,24 @@ being applied to the UTxO.
         \var{pc}
         \end{array}
       }
-      \vdash \var{utxo} \trans{utxo}{tx} \var{utxo'}\\ ~ \\
-      & \forall i \in \txins{tx} \cdot \exists (\var{vk}, \sigma) \in \wits{\var{tx}}
-      \cdot
+      \vdash \var{utxoSt} \trans{utxo}{tx} \var{utxoSt'}\\
+      ~ \\
+      \forall i \in \txins{tx} \cdot \exists (\var{vk}, \sigma) \in \wits{\var{tx}}
+      \cdot \\
       \mathcal{V}_{\var{vk}}{\serialised{\txbody{tx}}}_{\sigma}
-      \wedge  \fun{addr_h}~{utxo}~i = \hashKey{vk}\\
+      \wedge  \fun{addr_h}~{utxoSt}~i = \hashKey{vk}\\
+      ~ \\
+      & \forall (a \mapsto txin) \in \txwdrls{tx} \cdot \exists (\var{vk}, \sigma) \in \wits{\var{tx}}
+      \cdot \\
+      \mathcal{V}_{\var{vk}}{\serialised{(\txbody{tx}, a)}}_{\sigma}
+      \wedge  \var{a} = \hashKey{vk}\\
     }
     {
       \begin{array}{l}
         \var{slot}\\
         \var{pc}\\
       \end{array}
-      \vdash \var{utxo} \trans{utxow}{tx} \var{utxo'}
+      \vdash \var{utxoSt} \trans{utxow}{tx} \var{utxoSt'}
     }
   \end{equation}
   \caption{UTxO with witnesses inference rules}
@@ -989,7 +1080,7 @@ we must track are the current slot number and the protocol constants.
     \LState =
     \left(
       \begin{array}{r@{~\in~}lr}
-        \var{utxo} & \UTxO & \text{UTxO}\\
+        \var{utxoSt} & \UTxOState & \text{UTxO state}\\
         \var{dwstate} & \DWState & \text{delegation witnesess state}\\
       \end{array}
     \right)
@@ -1044,7 +1135,7 @@ and stake pools.
         stpools\\
         \end{array}
       }
-      \vdash \var{utxo} \trans{utxow}{tx} \var{utxo'}\\~\\~\\
+      \vdash \var{utxoSt} \trans{utxow}{tx} \var{utxoSt'}\\~\\~\\
       %
       {
         \begin{array}{l}
@@ -1063,14 +1154,14 @@ and stake pools.
       \vdash
       \left(
         \begin{array}{ll}
-          utxo \\
+          utxoSt \\
           dwstate \\
         \end{array}
       \right)
       \trans{ledger}{tx}
       \left(
         \begin{array}{ll}
-          utxo' \\
+          utxoSt' \\
           dwstate' \\
         \end{array}
       \right)
@@ -1079,6 +1170,10 @@ and stake pools.
   \caption{Ledger inference rule}
   \label{fig:rules:ledger}
 \end{figure}
+
+\section{Epoch Boundary}
+\label{sec:epoch}
+\input{epoch.tex}
 
 \section{Properties}
 \label{sec:properties}

--- a/latex/properties.tex
+++ b/latex/properties.tex
@@ -189,8 +189,8 @@ set of $l$.
 \begin{property}[\textbf{Registered Staking Key with Zero Rewards}]
   \begin{multline*}
     \forall \var{l}, \var{l'} \in \ledgerState: \applyFun{validLedgerstate}{l}\\
-    \implies \forall \var{c} \in \DCert, \var{l} \trans{delegw}{c} \var{l'}
-    \wedge var{c}\in\DCertRegKey{c} \implies \applyFun{author}{c} = \var{hk}\\ \implies
+    \implies \forall \var{c} \in \DCertRegKey, \var{l} \trans{delegw}{c} \var{l'}
+    \implies \applyFun{author}{c} = \var{hk}\\ \implies
     \var{hk} \in \applyFun{getStKeys}{l'} \wedge
     (\applyFun{getRewards}var{rewards})[hk] = 0
   \end{multline*}
@@ -206,8 +206,8 @@ is set to 0 in $l'$.
 \begin{property}[\textbf{Deregistered Staking Key}]
   \begin{multline*}
     \forall \var{l}, \var{l'} \in \ledgerState: \applyFun{validLedgerstate}{l}\\
-    \implies \forall \var{c} \in \DCert, \var{l} \trans{delegw}{c} \var{l'}
-    \wedge \var{c}\in\DCertDeRegKey \implies \applyFun{author}{c} = \var{hk}\\ \implies
+    \implies \forall \var{c} \in \DCertDeRegKey, \var{l} \trans{delegw}{c} \var{l'}
+    \implies \applyFun{author}{c} = \var{hk}\\ \implies
     \var{hk} \not\in \applyFun{getStKeys}{l'} \wedge
     (\fun{dom}(\applyFun{getRewards}{l'}) \cup
     \fun{dom}(\applyFun{getDelegations}{l'})) \cap \{hk\} = \emptyset
@@ -224,8 +224,8 @@ of $l'$.
 \begin{property}[\textbf{Delegated Stake}]
   \begin{multline*}
     \forall \var{l}, \var{l'} \in \ledgerState: \applyFun{validLedgerstate}{l}\\
-    \implies \forall \var{c} \in \DCert, \var{l} \trans{delegw}{c} \var{l'}
-    \wedge \var{c}\in\DCertDeleg \implies \applyFun{author}{c} = \var{hk}\\ \implies
+    \implies \forall \var{c} \in \DCertDeleg, \var{l} \trans{delegw}{c} \var{l'}
+    \implies \applyFun{author}{c} = \var{hk}\\ \implies
     \var{hk} \in \applyFun{getStKeys}{l} \wedge
     (\applyFun{getDelegations}{l'})[hk] = \applyFun{pool}{c}
   \end{multline*}
@@ -245,7 +245,7 @@ certificate in $l'$.
   \begin{multline*}
     \forall \var{l}, \var{l'} \in \ledgerState: \applyFun{validLedgerstate}{l}\\
     \implies \forall \var{c} \in \DCertRegPool, \var{l} \trans{pool}{c} \var{l'}
-    \wedge \var{c}\in\DCertRegPool \implies \applyFun{author}{c} = \var{hk}\\ \implies
+    \implies \applyFun{author}{c} = \var{hk}\\ \implies
     (\applyFun{getStPools}{l'})[\var{hk}] = c \wedge \var{hk} \not\in
     \applyFun{getRetiring}{l'}
   \end{multline*}
@@ -261,8 +261,8 @@ and that $hk$ is not in the set of retiring stake pools in $l'$.
   \begin{multline*}
     \forall \var{l}, \var{l'} \in \ledgerState, \var{cepoch} \in \Epoch:
     \applyFun{validLedgerstate}{l} \\
-    \implies \forall \var{c} \in \DCertRegPool, \var{l} \trans{pool}{c} \var{l'}
-    \wedge \var{c}\in\DCertRetirePool \\ \implies e = \applyFun{retire}{c} \wedge
+    \implies \forall \var{c} \in \DCertRetirePool, \var{l} \trans{pool}{c} \var{l'}
+    \\ \implies e = \applyFun{retire}{c} \wedge
     \var{cepoch} < e < \var{cepoch} + \emax \wedge \applyFun{author}{c} =
     \var{hk}\\ \implies (\applyFun{getRetiring}{l'})[\var{hk}] = e \wedge
     \var{hk} \in \fun{dom}(\applyFun{getStPools}{l})

--- a/latex/properties.tex
+++ b/latex/properties.tex
@@ -190,7 +190,7 @@ set of $l$.
   \begin{multline*}
     \forall \var{l}, \var{l'} \in \ledgerState: \applyFun{validLedgerstate}{l}\\
     \implies \forall \var{c} \in \DCert, \var{l} \trans{delegw}{c} \var{l'}
-    \wedge \RegKey{c} \implies \applyFun{author}{c} = \var{hk}\\ \implies
+    \wedge var{c}\in\DCertRegKey{c} \implies \applyFun{author}{c} = \var{hk}\\ \implies
     \var{hk} \in \applyFun{getStKeys}{l'} \wedge
     (\applyFun{getRewards}var{rewards})[hk] = 0
   \end{multline*}
@@ -207,7 +207,7 @@ is set to 0 in $l'$.
   \begin{multline*}
     \forall \var{l}, \var{l'} \in \ledgerState: \applyFun{validLedgerstate}{l}\\
     \implies \forall \var{c} \in \DCert, \var{l} \trans{delegw}{c} \var{l'}
-    \wedge \DeregKey{c} \implies \applyFun{author}{c} = \var{hk}\\ \implies
+    \wedge \var{c}\in\DCertDeRegKey \implies \applyFun{author}{c} = \var{hk}\\ \implies
     \var{hk} \not\in \applyFun{getStKeys}{l'} \wedge
     (\fun{dom}(\applyFun{getRewards}{l'}) \cup
     \fun{dom}(\applyFun{getDelegations}{l'})) \cap \{hk\} = \emptyset
@@ -225,7 +225,7 @@ of $l'$.
   \begin{multline*}
     \forall \var{l}, \var{l'} \in \ledgerState: \applyFun{validLedgerstate}{l}\\
     \implies \forall \var{c} \in \DCert, \var{l} \trans{delegw}{c} \var{l'}
-    \wedge \Delegate{c} \implies \applyFun{author}{c} = \var{hk}\\ \implies
+    \wedge \var{c}\in\DCertDeleg \implies \applyFun{author}{c} = \var{hk}\\ \implies
     \var{hk} \in \applyFun{getStKeys}{l} \wedge
     (\applyFun{getDelegations}{l'})[hk] = \applyFun{pool}{c}
   \end{multline*}
@@ -245,7 +245,7 @@ certificate in $l'$.
   \begin{multline*}
     \forall \var{l}, \var{l'} \in \ledgerState: \applyFun{validLedgerstate}{l}\\
     \implies \forall \var{c} \in \DCertRegPool, \var{l} \trans{pool}{c} \var{l'}
-    \wedge \RegPool{c} \implies \applyFun{author}{c} = \var{hk}\\ \implies
+    \wedge \var{c}\in\DCertRegPool \implies \applyFun{author}{c} = \var{hk}\\ \implies
     (\applyFun{getStPools}{l'})[\var{hk}] = c \wedge \var{hk} \not\in
     \applyFun{getRetiring}{l'}
   \end{multline*}
@@ -262,7 +262,7 @@ and that $hk$ is not in the set of retiring stake pools in $l'$.
     \forall \var{l}, \var{l'} \in \ledgerState, \var{cepoch} \in \Epoch:
     \applyFun{validLedgerstate}{l} \\
     \implies \forall \var{c} \in \DCertRegPool, \var{l} \trans{pool}{c} \var{l'}
-    \wedge \RetirePool{c} \\ \implies e = \applyFun{retire}{c} \wedge
+    \wedge \var{c}\in\DCertRetirePool \\ \implies e = \applyFun{retire}{c} \wedge
     \var{cepoch} < e < \var{cepoch} + \emax \wedge \applyFun{author}{c} =
     \var{hk}\\ \implies (\applyFun{getRetiring}{l'})[\var{hk}] = e \wedge
     \var{hk} \in \fun{dom}(\applyFun{getStPools}{l})


### PR DESCRIPTION
This adds more accounting details for deposits to the ledger state.  In particular, we now track the total deposit pool, the total fee pool, and the pending withdrawals (which will be used on the epoch boundary).

A couple small things: I've moved the pool reap rule to a new section for the Epoch boundary.  I've also done away with the predicates for the certificate types.

closes #44 