### PR TITLE
epoch rules

### DIFF
--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -448,7 +448,7 @@ Allowing pools to make retirement announcements arbitrarily far in advance
 could result in a linear (in the number of pools) growth of storage space needed
 for this datatype.
 
-The third rule, \cref{eq:pool-reap}, is invoked when the planned retirement epoch
+The third rule, \cref{eq:pool-clean}, is invoked when the planned retirement epoch
 $e$ for some non-empty set of
 stake pools in the $\var{retiring}$ set is reached. In this case, all the
 pairs associated with hash keys of pools which are scheduled to retire in this

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -1,54 +1,614 @@
-The pool reaping in rules are discribed in
-Figure~\ref{fig:ts-types:pool-reap} and Figure~\ref{fig:rules:pool-reap}.
+\newcommand{\UTxOEpEnv}{\type{UTxOEpEnv}}
+\newcommand{\UTxOEpState}{\type{UTxOEpState}}
+\newcommand{\Accnt}{\type{Accnt}}
+\newcommand{\AccntEnv}{\type{AccntEnv}}
+\newcommand{\AccntState}{\type{AccntState}}
+\newcommand{\StPlCleanEnv}{\type{StPlCleanEnv}}
+\newcommand{\StPlCleanState}{\type{StPlCleanState}}
+\newcommand{\NewProtoConstsEnv}{\type{NewProtoConstsEnv}}
+\newcommand{\NewProtoConstsState}{\type{NewProtoConstsState}}
+\newcommand{\EpochEnv}{\type{EpochEnv}}
+\newcommand{\EpochState}{\type{EpochState}}
+\newcommand{\Production}{\type{Production}}
+
+\newcommand{\obligation}[4]{\fun{obligation}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
+\newcommand{\reward}[5]{\fun{reward}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}~ \var{#5}}
+\newcommand{\poolRefunds}[3]{\fun{poolRefunds}~ \var{#1}~ \var{#2}~ \var{#3}}
 
 %%
-%% Figure - Pool Reap
+%% Figure - Epoch Abstract Types
 %%
-
-
 \begin{figure}
-  \emph{Pool Reap Transition}
-  \begin{equation*}
-    \_ \vdash \_ \trans{poolreap}{} \_ \in
-    \powerset (\Slot \times \PState \times \PState)
-  \end{equation*}
+  \emph{Abstract types}
   %
-  \caption{Pool Reap Transition}
-  \label{fig:ts-types:pool-reap}
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      \var{production} & \Production & \text{blocks produced in the epoch}\\
+    \end{array}
+  \end{equation*}
+  \caption{Epoch definitions}
+  \label{fig:epoch-defs}
+\end{figure}
+
+%%
+%% Figure - Functions for Epoch Rules
+%%
+\begin{figure}
+  \begin{align*}
+      & \fun{obligation} \in \PrtclConsts \to \Allocs \to \Allocs \to \Slot \to \Coin
+      & \text{total possible refunds} \\
+      & \obligation{pc}{stkeys}{stpools}{cslot} =\\
+      & \sum\limits_{(\_ \mapsto s) \in \var{stkeys}}
+        \refund{k_{\mathsf{val}}}{k_{\min}}{(\slotminus{cslot}{s})}{\lambda} \\
+      & + \sum\limits_{(\_ \mapsto s) \in \var{stpools}}
+        \refund{p_{\mathsf{val}}}{p_{\min}}{(\slotminus{cslot}{s})}{\lambda} \\
+      &
+        \where k_{\mathsf{val}}, k_{\min},p_{\mathsf{val}}, p_{\min}, \lambda \in pc
+      \nextdef
+      & \fun{reward} \in \Production \to \PrtclConsts \to \Coin \to DWState \to \\
+      & ~~~ (\AddrRWD \mapsto \Coin) \to (\AddrRWD \mapsto \Coin)
+      & \text{update rewards} \\
+      & \reward{prod}{pc}{availablePool}{dwstate}{rewards} = \mathsf{TBD}\\
+      \nextdef
+      & \fun{poolRefunds} \in \PrtclConsts \to \Allocs \to \Slot \to (\HashKey \mapsto \Coin)
+      & \text{pool refunds} \\
+      & \poolRefunds{pc}{retiring}{cslot} = \\
+      & \bigcup_{\var{hk}\mapsto s\in\var{retiring}}
+          \var{hk}\mapsto( \refund{p_{\mathsf{val}}}{p_{\min}}{(\slotminus{cslot}{s})}{\lambda} ) \\
+      &
+        \where p_{\mathsf{val}}, p_{\min}, \lambda \in pc
+  \end{align*}
+  \caption{Functions used in Deposits}
+  \label{fig:functions:epoch}
 \end{figure}
 
 
 %%
-%% Figure - Pool Rules
+%% Figure - UTxO Epoch Defs
 %%
 \begin{figure}
+  \emph{UTxO Epoch environment}
+  \begin{equation*}
+    \UTxOEpEnv =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{slot} & \Slot & \text{current slot}\\
+        \var{pc} & \PrtclConsts & \text{protocol constants}\\
+        \var{stkeys} & \Allocs & \text{stake key allocations}\\
+        \var{stpools} & \Allocs & \text{stake pool allocations}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
+  \emph{UTxOE transitions}
+  \begin{equation*}
+    \_ \vdash
+    \var{\_} \trans{utxoep}{} \var{\_}
+    \subseteq \powerset (\UTxOEpEnv \times \UTxOState \times \UTxOState)
+  \end{equation*}
+  %
+  \caption{UTxO Epoch transition-system types}
+  \label{fig:ts-types:utxoe}
+\end{figure}
 
-  \begin{equation}\label{eq:pool-reap}
-    \inference[Pool-Reap]
+%%
+%% Figure - UTxO Epoch Rule
+%%
+\begin{figure}
+  \begin{equation}\label{eq:utxoep}
+    \inference[UTxO-epoch]
     {
-      \var{retired} = \var{retiring}^{-1}~\var{(\epoch{slot})}
-      & \var{retired} \neq \emptyset
     }
     {
-      \var{slot} \vdash
+      \begin{array}{l}
+        \var{slot}\\
+        \var{pc}\\
+        \var{stkeys}\\
+        \var{stpools}\\
+      \end{array}
+      \vdash
+      \left(
+        \begin{array}{r}
+          \var{utxo} \\
+          \var{deposits} \\
+          \var{fees} \\
+          \var{wdrls} \\
+        \end{array}
+      \right)
+      \trans{utxoep}{}
+      \left(
+        \begin{array}{r}
+          \var{utxo} \cup \var{wdrls} \\
+          \obligation{pc}{stkeys}{stpools}{slot} \\
+          0 \\
+          \emptyset \\
+        \end{array}
+      \right)
+    }
+  \end{equation}
+  \caption{UTxO Epoch inference rules}
+  \label{fig:rules:utxoep}
+\end{figure}
+
+%%
+%% Figure - Accounting Defs
+%%
+\begin{figure}
+  \emph{Accounting Fields}
+  \begin{equation*}
+    \Accnt =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{treasury} & \Coin & \text{treasury pool}\\
+        \var{reserves} & \Coin & \text{reserve pool}\\
+        \var{rewardPool} & \Coin & \text{reward pool}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
+  \emph{Accounting environment}
+  \begin{equation*}
+    \AccntEnv =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{slot} & \Slot & \text{current slot}\\
+        \var{pc} & \PrtclConsts & \text{protocol constants}\\
+        \var{production} & \Production & \text{blocks produced in the epoch}\\
+        \var{utxoSt} & \UTxOState & \text{utxo state}\\
+        \var{pstate} & \PState & \text{pool state}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
+  \emph{Accounting States}
+  \begin{equation*}
+    \AccntState =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{accnt} & \Accnt & \text{accounting}\\
+        \var{dstate} & \DState & \text{delegation state}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
+  \emph{Accounting transitions}
+  \begin{equation*}
+    \_ \vdash
+    \var{\_} \trans{accnt}{} \var{\_}
+    \subseteq \powerset (\AccntEnv \times \AccntState \times \AccntState)
+  \end{equation*}
+  %
+  \caption{Accounting transition-system types}
+  \label{fig:ts-types:accnt}
+\end{figure}
+
+%%
+%% Figure - Accounting Rules
+%%
+\begin{figure}
+  \begin{equation}\label{eq:accnt}
+    \inference[Accounting]
+    {
+      \var{obl} = \obligation{pc}{stkeys}{stpools}{slot} \\
+      \var{decayed} = \var{deposits} - \var{obl} \\
+      \rho, \tau \in pc \\
+      \var{expansion} = \floor*{\rho \cdot \var{reserves}} \\
+      \var{totalPool} = \var{fees} + \var{decayed} + \var{rewardPool} + \var{expansion} \\
+      \var{newTreasury} = \floor*{\tau \cdot \var{totalPool}} \\
+      \var{availablePool} = \var{totalPool} - \var{newTreasury} \\
+      \var{rewards'} = \reward{production}{pc}{availablePool}{dwstate}{rewards}\\
+      \var{paidRewards} = \sum\limits_{\_\mapsto c\in\var{rewards'}}c
+    }
+    {
+      \begin{array}{l}
+        \var{production}\\
+        \var{slot}\\
+        \var{pc}\\
+        \var{utxoSt}\\
+        \var{pstate}\\
+      \end{array}
+      \vdash
+      \left(
+        \begin{array}{r}
+          \var{treasury} \\
+          \var{reserves} \\
+          \var{rewardPool} \\
+          \var{stkeys} \\
+          \var{rewards} \\
+          \var{delegations}
+        \end{array}
+      \right)
+      \trans{accnt}{}
+      \left(
+        \begin{array}{rcl}
+          \var{treasury} & + & \var{newTreasury}\\
+          \var{reserves} & - & \var{expansion} \\
+          \var{availablePool} & - & \var{paidRewards} \\
+          \var{stkeys} \\
+          \var{rewards} & \unionoverridePlus & \var{rewards'} \\
+          \var{delegations}
+        \end{array}
+      \right)
+    }
+  \end{equation}
+  \caption{Accounting Epoch inference rules}
+  \label{fig:rules:accnt}
+\end{figure}
+
+%%
+%% Figure - Pool Clean Defs
+%%
+\begin{figure}
+  \emph{Stake Pool Clean environment}
+  \begin{equation*}
+    \StPlCleanEnv =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{slot} & \Slot & \text{current slot}\\
+        \var{pc} & \PrtclConsts & \text{protocol constants}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
+  \emph{Stake Pool Clean States}
+  \begin{equation*}
+    \StPlCleanState =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{utxoSt} & \UTxOState & \text{utxo state}\\
+        \var{dstate} & \DState & \text{delegation state}\\
+        \var{pstate} & \PState & \text{pool state}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
+  \emph{Pool Clean Transition}
+  \begin{equation*}
+    \_ \vdash \_ \trans{poolclean}{} \_ \in
+    \powerset (\StPlCleanEnv \times \StPlCleanState \times \StPlCleanState)
+  \end{equation*}
+  %
+  \caption{Pool Clean Transition}
+  \label{fig:ts-types:pool-clean}
+\end{figure}
+
+%%
+%% Figure - Pool Clean Rule
+%%
+\begin{figure}
+  \begin{equation}\label{eq:pool-clean}
+    \inference[Pool-Clean]
+    {
+      \var{retired} = \var{retiring}^{-1}~\var{(\epoch{slot})}
+      & \var{retired} \neq \emptyset \\
+      \var{refunds} = \poolRefunds{pc}{(\var{retired} \restrictdom \var{stpools})}{slot} \\
+      \var{deposits'} = \var{deposits} - \left(\sum\limits_{\{\_\mapsto c\}\in\var{refunds}} c\right) \\
+      \var{rewards'} = \var{rewards} \unionoverridePlus \var{refunds} \\
+      \var{utxoSt'} =
+      \left(
+        {
+          \begin{array}{r}
+            \var{utxo} \\
+            \var{deposits'} \\
+            \var{fees} \\
+            \var{wdrls} \\
+          \end{array}
+        }
+      \right)
+      &
+      \var{dstate'} =
+      \left(
+        {
+          \begin{array}{r}
+            \var{stkeys} \\
+            \var{rewards'} \\
+            \var{delegations}
+          \end{array}
+        }
+      \right)
+    }
+    {
+      \begin{array}{l}
+        \var{slot}\\
+        \var{pc}\\
+      \end{array}
+      \vdash
+      \left(
+        \begin{array}{r}
+          \var{utxoSt} \\
+          \var{dstate} \\
+          \var{stpools} \\
+          \var{pparams} \\
+          \var{retiring}
+        \end{array}
+      \right)
+      \trans{poolclean}{}
+      \left(
+        \begin{array}{rcl}
+          \var{utxoSt'} \\
+          \var{dstate'} \\
+          \var{retired} & \subtractdom & \var{stpools} \\
+          \var{retired} & \subtractdom & \var{pparams} \\
+          \var{retired} & \subtractdom & \var{retiring} \\
+        \end{array}
+      \right)
+    }
+  \end{equation}
+  \caption{Pool Clean Inference Rule}
+  \label{fig:rules:pool-clean}
+\end{figure}
+
+%%
+%% Figure - New Proto Consts Defs
+%%
+\begin{figure}
+  \emph{New Proto Consts environment}
+  \begin{equation*}
+    \NewProtoConstsEnv =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{slot} & \Slot & \text{current slot}\\
+        \var{pcOld} & \PrtclConsts & \text{old protocol constants}\\
+        \var{pcNew} & \PrtclConsts & \text{new protocol constants}\\
+        \var{dstate} & \DState & \text{delegation state}\\
+        \var{pstate} & \PState & \text{pool state}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
+  \emph{New Proto Consts States}
+  \begin{equation*}
+    \NewProtoConstsState =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{utxoSt} & \UTxOState & \text{utxo state}\\
+        \var{accnt} & \Accnt & \text{accounting}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
+  \emph{New Proto Consts transitions}
+  \begin{equation*}
+    \_ \vdash
+    \var{\_} \trans{newpc}{} \var{\_}
+    \subseteq \powerset (\NewProtoConstsEnv \times
+    \NewProtoConstsState \times \NewProtoConstsState)
+  \end{equation*}
+  %
+  \caption{New Proto Consts transition-system types}
+  \label{fig:ts-types:new-proto-consts}
+\end{figure}
+
+%%
+%% Figure - New Proto Consts Rule
+%%
+\begin{figure}
+  \begin{equation}\label{eq:new-pc}
+    \inference[New-Proto-Consts]
+    {
+      \var{oblgOld} = \obligation{pcOld}{stkeys}{stpools}{slot} \\
+      \var{oblgNew} = \obligation{pcNew}{stkeys}{stpools}{slot} \\
+      ~\\
+      \var{reserves} + \var{oblgOld} \geq \var{oblgNew}\\
+      \var{diff} = \var{oblgOld} - \var{oblgNew} \\
+      ~\\
+      \var{utxoSt'} =
+      \left(
+        {
+          \begin{array}{r}
+            \var{utxo} \\
+            \var{oblgNew} \\
+            \var{fees} \\
+            \var{wdrls} \\
+          \end{array}
+        }
+      \right)
+      &
+      \var{accnt'} =
+      \left(
+        {
+          \begin{array}{r}
+            \var{treasury} \\
+            \var{reserves} + \var{diff} \\
+            \var{rewardPool} \\
+            \var{rewards} \\
+          \end{array}
+        }
+      \right)
+    }
+    {
+      \begin{array}{l}
+        \var{slot}\\
+        \var{pc}\\
+      \end{array}
+      \vdash
+      \left(
+        \begin{array}{r}
+          \var{utxoSt} \\
+          \var{accnt}
+        \end{array}
+      \right)
+      \trans{newpc}{}
+      \left(
+        \begin{array}{rcl}
+          \var{utxoSt'}\\
+          \var{accnt'} \\
+        \end{array}
+      \right)
+    }
+  \end{equation}
+  \caption{New Proto Consts Inference Rule}
+  \label{fig:rules:new-proto-consts}
+\end{figure}
+
+%%
+%% Figure - Epoch Defs
+%%
+\begin{figure}
+  \emph{Epoch environment}
+  \begin{equation*}
+    \EpochEnv =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{slot} & \Slot & \text{current slot}\\
+        \var{pcOld} & \PrtclConsts & \text{old protocol constants}\\
+        \var{pcNew} & \PrtclConsts & \text{new protocol constants}\\
+        \var{production} & \Production & \text{blocks produced in the epoch}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
+  \emph{Epoch States}
+  \begin{equation*}
+    \EpochEnv =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{utxoSt} & \UTxOState & \text{utxo state}\\
+        \var{accnt} & \Accnt & \text{accounting}\\
+        \var{dstate} & \DState & \text{delegation state}\\
+        \var{pstate} & \PState & \text{pool state}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
+  \emph{Epoch transitions}
+  \begin{equation*}
+    \_ \vdash
+    \var{\_} \trans{epoch}{} \var{\_}
+    \subseteq \powerset (\EpochEnv \times \EpochState \times \EpochState)
+  \end{equation*}
+  %
+  \caption{Epoch transition-system types}
+  \label{fig:ts-types:epoch}
+\end{figure}
+
+%%
+%% Figure - Epoch Rule
+%%
+\begin{figure}
+  \begin{equation}\label{eq:epoch}
+    \inference[Epoch]
+    {
+      {
+        \begin{array}{l}
+          \var{slot}\\
+          \var{pcOld}\\
+          \var{dstate}\\
+          \var{pstate}\\
+        \end{array}
+      }
+      \vdash \var{utxoSt} \trans{utxoep}{} \var{utxoSt'}
+      \\~\\~\\
+      {
+        \begin{array}{l}
+          \var{production}\\
+          \var{slot}\\
+          \var{pcOld}\\
+          \var{utxoSt'}\\
+          \var{pstate}\\
+        \end{array}
+      }
+      \vdash
+      \left(
+        {
+          \begin{array}{r}
+            \var{accnt} \\
+            \var{dstate} \\
+          \end{array}
+        }
+      \right)
+      \trans{accnt}{}
+      \left(
+      {
+        \begin{array}{rcl}
+          \var{accnt'} \\
+          \var{dstate'} \\
+        \end{array}
+      }
+      \right)
+      \\~\\~\\
+      {
+        \begin{array}{l}
+          \var{slot}\\
+          \var{pcOld}\\
+        \end{array}
+      }
+      \vdash
+      \left(
+        {
+          \begin{array}{r}
+            \var{utxoSt'} \\
+            \var{dstate'} \\
+            \var{pstate} \\
+          \end{array}
+        }
+      \right)
+      \trans{poolclean}{}
+      \left(
+      {
+        \begin{array}{rcl}
+            \var{utxoSt''} \\
+            \var{dstate''} \\
+            \var{pstate'} \\
+        \end{array}
+      }
+      \right)
+      \\~\\~\\
+      {
+        \begin{array}{l}
+          \var{slot}\\
+          \var{pcOld}\\
+          \var{pcNew}\\
+          \var{dstate''}\\
+          \var{pstate'}\\
+        \end{array}
+      }
+      \vdash
+      \left(
+        {
+          \begin{array}{r}
+            \var{utxoSt''} \\
+            \var{accnt'} \\
+          \end{array}
+        }
+      \right)
+      \trans{newpc}{}
+      \left(
+      {
+        \begin{array}{rcl}
+            \var{utxoSt'''} \\
+            \var{accnt''} \\
+        \end{array}
+      }
+      \right)
+    }
+    {
+      \begin{array}{l}
+        \var{slot}\\
+        \var{pcOld}\\
+        \var{pcNew}\\
+        \var{production}\\
+      \end{array}
+      \vdash
       \left(
       \begin{array}{r}
-        \var{stpools} \\
-        \var{pparams} \\
-        \var{retiring}
+        \var{utxoSt} \\
+        \var{accnt} \\
+        \var{dstate} \\
+        \var{pstate}
       \end{array}
       \right)
-      \trans{poolreap}{}
+      \trans{epoch}{}
       \left(
       \begin{array}{rcl}
-        \var{retired} & \subtractdom & \var{stpools} \\
-        \var{retired} & \subtractdom & \var{pparams} \\
-        \var{retired} & \subtractdom & \var{retiring} \\
+        \var{utxoSt'''} \\
+        \var{accnt''} \\
+        \var{dstate''} \\
+        \var{pstate'}
       \end{array}
       \right)
     }
   \end{equation}
-  \caption{Pool Reap Inference Rule}
-  \label{fig:rules:pool-reap}
-
+  \caption{Epoch Inference Rule}
+  \label{fig:rules:epoch}
 \end{figure}

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -18,11 +18,11 @@
 %%
 %% Figure - Epoch Abstract Types
 %%
-\begin{figure}
+\begin{figure}[htb]
   \emph{Abstract types}
   %
   \begin{equation*}
-    \begin{array}{r@{~\in~}lr}
+    \begin{array}{r@{~\in~}ll}
       \var{production} & \Production & \text{blocks produced in the epoch}\\
     \end{array}
   \end{equation*}
@@ -33,17 +33,22 @@
 %%
 %% Figure - Functions for Epoch Rules
 %%
-\begin{figure}
+\begin{figure}[htb]
   \begin{align*}
       & \fun{obligation} \in \PrtclConsts \to \Allocs \to \Allocs \to \Slot \to \Coin
       & \text{total possible refunds} \\
       & \obligation{pc}{stkeys}{stpools}{cslot} =\\
       & \sum\limits_{(\_ \mapsto s) \in \var{stkeys}}
-        \refund{k_{\mathsf{val}}}{k_{\min}}{(\slotminus{cslot}{s})}{\lambda} \\
+        \refund{k_{\mathsf{val}}}{k_{\min}}{(\slotminus{cslot}{s})}{\lambda_d} \\
       & + \sum\limits_{(\_ \mapsto s) \in \var{stpools}}
-        \refund{p_{\mathsf{val}}}{p_{\min}}{(\slotminus{cslot}{s})}{\lambda} \\
+        \refund{p_{\mathsf{val}}}{p_{\min}}{(\slotminus{cslot}{s})}{\lambda_p} \\
       &
-        \where k_{\mathsf{val}}, k_{\min},p_{\mathsf{val}}, p_{\min}, \lambda \in pc
+      %  \where k_{\mathsf{val}}, k_{\min},p_{\mathsf{val}}, p_{\min}, \lambda \in pc
+      \begin{array}{lr@{~=~}l}
+        \where
+          & (\dval,~d_{\min},~\lambda_d) & \fun{decayKey}~\var{pc}\\
+          & (p_{\mathsf{val}},~p_{\min},~\lambda_p) & \fun{decayPool}~\var{pc}\\
+      \end{array}\\
       \nextdef
       & \fun{reward} \in \Production \to \PrtclConsts \to \Coin \to DWState \to \\
       & ~~~ (\AddrRWD \mapsto \Coin) \to (\AddrRWD \mapsto \Coin)
@@ -56,22 +61,30 @@
       & \bigcup_{\var{hk}\mapsto s\in\var{retiring}}
           \var{hk}\mapsto( \refund{p_{\mathsf{val}}}{p_{\min}}{(\slotminus{cslot}{s})}{\lambda} ) \\
       &
-        \where p_{\mathsf{val}}, p_{\min}, \lambda \in pc
+        \where (p_{\mathsf{val}},~p_{\min},~\lambda_p) = \fun{decayPool}~\var{pc}\\
   \end{align*}
   \caption{Functions used in Deposits}
   \label{fig:functions:epoch}
 \end{figure}
 
+\begin{todo}
+  The delegation design document defines the $\fun{reward}$ function, but the calculation
+  depends on the leader election for the epoch being determined and known at the begining
+  of the epoch. We are currently rearching version of Ouroboros where this assumption
+  does not hold. Therefore we have marked $\fun{reward}$ as ``to be determined".
+
+  Additionally, we should aim to do calculations such as these as incrementally as possible.
+\end{todo}
 
 %%
 %% Figure - UTxO Epoch Defs
 %%
-\begin{figure}
+\begin{figure}[htb]
   \emph{UTxO Epoch environment}
   \begin{equation*}
     \UTxOEpEnv =
     \left(
-      \begin{array}{r@{~\in~}lr}
+      \begin{array}{r@{~\in~}ll}
         \var{slot} & \Slot & \text{current slot}\\
         \var{pc} & \PrtclConsts & \text{protocol constants}\\
         \var{stkeys} & \Allocs & \text{stake key allocations}\\
@@ -94,7 +107,7 @@
 %%
 %% Figure - UTxO Epoch Rule
 %%
-\begin{figure}
+\begin{figure}[htb]
   \begin{equation}\label{eq:utxoep}
     \inference[UTxO-epoch]
     {
@@ -133,12 +146,12 @@
 %%
 %% Figure - Accounting Defs
 %%
-\begin{figure}
+\begin{figure}[htb]
   \emph{Accounting Fields}
   \begin{equation*}
     \Accnt =
     \left(
-      \begin{array}{r@{~\in~}lr}
+      \begin{array}{r@{~\in~}ll}
         \var{treasury} & \Coin & \text{treasury pool}\\
         \var{reserves} & \Coin & \text{reserve pool}\\
         \var{rewardPool} & \Coin & \text{reward pool}\\
@@ -150,7 +163,7 @@
   \begin{equation*}
     \AccntEnv =
     \left(
-      \begin{array}{r@{~\in~}lr}
+      \begin{array}{r@{~\in~}ll}
         \var{slot} & \Slot & \text{current slot}\\
         \var{pc} & \PrtclConsts & \text{protocol constants}\\
         \var{production} & \Production & \text{blocks produced in the epoch}\\
@@ -164,7 +177,7 @@
   \begin{equation*}
     \AccntState =
     \left(
-      \begin{array}{r@{~\in~}lr}
+      \begin{array}{r@{~\in~}ll}
         \var{accnt} & \Accnt & \text{accounting}\\
         \var{dstate} & \DState & \text{delegation state}\\
       \end{array}
@@ -185,19 +198,23 @@
 %%
 %% Figure - Accounting Rules
 %%
-\begin{figure}
+\begin{figure}[htb]
   \begin{equation}\label{eq:accnt}
     \inference[Accounting]
     {
-      \var{obl} = \obligation{pc}{stkeys}{stpools}{slot} \\
-      \var{decayed} = \var{deposits} - \var{obl} \\
-      \rho, \tau \in pc \\
-      \var{expansion} = \floor*{\rho \cdot \var{reserves}} \\
-      \var{totalPool} = \var{fees} + \var{decayed} + \var{rewardPool} + \var{expansion} \\
-      \var{newTreasury} = \floor*{\tau \cdot \var{totalPool}} \\
-      \var{availablePool} = \var{totalPool} - \var{newTreasury} \\
-      \var{rewards'} = \reward{production}{pc}{availablePool}{dwstate}{rewards}\\
-      \var{paidRewards} = \sum\limits_{\_\mapsto c\in\var{rewards'}}c
+      {
+      \begin{array}{r@{=}l}
+        \var{obl} & \obligation{pc}{stkeys}{stpools}{slot} \\
+        \var{decayed} & \var{deposits} - \var{obl} \\
+        %\rho, \tau \in pc \\
+        \var{expansion} & \floor*{\rho \cdot \var{reserves}} \\
+        \var{totalPool} & \var{fees} + \var{decayed} + \var{rewardPool} + \var{expansion} \\
+        \var{newTreasury} & \floor*{\tau \cdot \var{totalPool}} \\
+        \var{availablePool} & \var{totalPool} - \var{newTreasury} \\
+        \var{rewards'} & \reward{production}{pc}{availablePool}{dwstate}{rewards}\\
+        \var{paidRewards} & \sum\limits_{\_\mapsto c\in\var{rewards'}}c
+      \end{array}
+      }
     }
     {
       \begin{array}{l}
@@ -238,12 +255,12 @@
 %%
 %% Figure - Pool Clean Defs
 %%
-\begin{figure}
+\begin{figure}[htb]
   \emph{Stake Pool Clean environment}
   \begin{equation*}
     \StPlCleanEnv =
     \left(
-      \begin{array}{r@{~\in~}lr}
+      \begin{array}{r@{~\in~}ll}
         \var{slot} & \Slot & \text{current slot}\\
         \var{pc} & \PrtclConsts & \text{protocol constants}\\
       \end{array}
@@ -254,7 +271,7 @@
   \begin{equation*}
     \StPlCleanState =
     \left(
-      \begin{array}{r@{~\in~}lr}
+      \begin{array}{r@{~\in~}ll}
         \var{utxoSt} & \UTxOState & \text{utxo state}\\
         \var{dstate} & \DState & \text{delegation state}\\
         \var{pstate} & \PState & \text{pool state}\\
@@ -275,15 +292,21 @@
 %%
 %% Figure - Pool Clean Rule
 %%
-\begin{figure}
+\begin{figure}[htb]
   \begin{equation}\label{eq:pool-clean}
     \inference[Pool-Clean]
     {
       \var{retired} = \var{retiring}^{-1}~\var{(\epoch{slot})}
       & \var{retired} \neq \emptyset \\
-      \var{refunds} = \poolRefunds{pc}{(\var{retired} \restrictdom \var{stpools})}{slot} \\
-      \var{deposits'} = \var{deposits} - \left(\sum\limits_{\{\_\mapsto c\}\in\var{refunds}} c\right) \\
-      \var{rewards'} = \var{rewards} \unionoverridePlus \var{refunds} \\
+      ~ \\
+      {
+        \begin{array}{r@{=}l}
+          \var{refunds} & \poolRefunds{pc}{(\var{retired} \restrictdom \var{stpools})}{slot} \\
+          \var{deposits'} & \var{deposits} -
+            \left(\sum\limits_{\{\_\mapsto c\}\in\var{refunds}} c\right) \\
+          \var{rewards'} & \var{rewards} \unionoverridePlus \var{refunds} \\
+        \end{array}
+      } \\ ~ \\ ~ \\
       \var{utxoSt'} =
       \left(
         {
@@ -341,12 +364,12 @@
 %%
 %% Figure - New Proto Consts Defs
 %%
-\begin{figure}
+\begin{figure}[htb]
   \emph{New Proto Consts environment}
   \begin{equation*}
     \NewProtoConstsEnv =
     \left(
-      \begin{array}{r@{~\in~}lr}
+      \begin{array}{r@{~\in~}ll}
         \var{slot} & \Slot & \text{current slot}\\
         \var{pcOld} & \PrtclConsts & \text{old protocol constants}\\
         \var{pcNew} & \PrtclConsts & \text{new protocol constants}\\
@@ -360,7 +383,7 @@
   \begin{equation*}
     \NewProtoConstsState =
     \left(
-      \begin{array}{r@{~\in~}lr}
+      \begin{array}{r@{~\in~}ll}
         \var{utxoSt} & \UTxOState & \text{utxo state}\\
         \var{accnt} & \Accnt & \text{accounting}\\
       \end{array}
@@ -382,7 +405,7 @@
 %%
 %% Figure - New Proto Consts Rule
 %%
-\begin{figure}
+\begin{figure}[htb]
   \begin{equation}\label{eq:new-pc}
     \inference[New-Proto-Consts]
     {
@@ -444,12 +467,12 @@
 %%
 %% Figure - Epoch Defs
 %%
-\begin{figure}
+\begin{figure}[htb]
   \emph{Epoch environment}
   \begin{equation*}
     \EpochEnv =
     \left(
-      \begin{array}{r@{~\in~}lr}
+      \begin{array}{r@{~\in~}ll}
         \var{slot} & \Slot & \text{current slot}\\
         \var{pcOld} & \PrtclConsts & \text{old protocol constants}\\
         \var{pcNew} & \PrtclConsts & \text{new protocol constants}\\
@@ -460,9 +483,9 @@
   %
   \emph{Epoch States}
   \begin{equation*}
-    \EpochEnv =
+    \EpochState =
     \left(
-      \begin{array}{r@{~\in~}lr}
+      \begin{array}{r@{~\in~}ll}
         \var{utxoSt} & \UTxOState & \text{utxo state}\\
         \var{accnt} & \Accnt & \text{accounting}\\
         \var{dstate} & \DState & \text{delegation state}\\
@@ -485,7 +508,7 @@
 %%
 %% Figure - Epoch Rule
 %%
-\begin{figure}
+\begin{figure}[htb]
   \begin{equation}\label{eq:epoch}
     \inference[Epoch]
     {

--- a/latex/iohk.sty
+++ b/latex/iohk.sty
@@ -18,6 +18,7 @@
 \newcommand{\union}{\ensuremath{\cup}}
 \newcommand{\unionoverrideRight}{\ensuremath{\mathbin{\underrightarrow\cup}}}
 \newcommand{\unionoverrideLeft}{\ensuremath{\mathbin{\underleftarrow\cup}}}
+\newcommand{\unionoverridePlus}{\ensuremath{\mathbin{\cup_{+}}}}
 \newcommand{\uniondistinct}{\ensuremath{\uplus}}
 \newcommand{\var}[1]{\ensuremath{\mathit{#1}}}
 \newcommand{\fun}[1]{\ensuremath{\mathsf{#1}}}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -94,9 +94,9 @@
 \newcommand{\balance}[1]{\fun{balance}~ \var{#1}}
 \newcommand{\ttl}[1]{\fun{ttl}~ \var{#1}}
 \newcommand{\deposits}[2]{\fun{deposits}~ \var{#1} ~ \var{#2}}
-\newcommand{\decayed}[4]{\fun{decayed}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
+\newcommand{\decayedKey}[4]{\fun{decayedKey}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
 \newcommand{\decayedTx}[3]{\fun{decayedTx}~ \var{#1}~ \var{#2}~ \var{#3}}
-\newcommand{\certRefund}[4]{\fun{certRefund}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
+\newcommand{\certRefund}[6]{\fun{certRefund}~ {#1}~{#2}~{#3}~\var{#4}~\var{#5}~\var{#6}}
 \newcommand{\refund}[4]{\fun{refund}~ \var{#1}~ \var{#2}~ {#3}~ {#4}}
 \newcommand{\keyRefunds}[3]{\fun{keyRefunds}~ \var{#1}~ \var{#2}~ \var{#3}}
 \newcommand{\created}[4]{\fun{created}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
@@ -179,6 +179,10 @@ The transition system is explained in \cite{small_step_semantics}.
 \begin{description}
 \item[Powerset] Given a set $\type{X}$, $\powerset{\type{X}}$ is the set of all
   the subsets of $X$.
+\item[Symmetric Difference] Given two sets $\type{X}$ and $\type{Y}$,
+  the symmetric difference of $\type{X}$ and $\type{Y}$,
+  denoted $\type{X}\triangle\type{Y}$, is the union of $\type{X}$ and $\type{Y}$
+  witout the intersection.
 \item[Sequences] Given a set $\type{X}$, $\seqof{\type{X}}$ is the set of
   sequences having elements taken from $\type{X}$. The empty sequence is
   denoted by $\epsilon$, and given a sequence $\Lambda$, $\Lambda; \type{x}$ is
@@ -486,8 +490,12 @@ body must also contain inputs onto which this refund can be added.
       \fun{dvalue} & \PrtclConsts \to \DCert \to \Coin
         & \text{deposit amount of a certificate}\\
 
-      \fun{decay} & \PrtclConsts \to \lbrack 0, 1\rbrack\times\mathbb{Q}^{+}
-        & \text{decay constants}\\
+      \fun{decayKey} & \PrtclConsts \to
+        \Coin\times\lbrack 0, 1\rbrack\times\mathbb{Q}^{+}
+        & \text{decay constants for key certificates}\\
+      \fun{decayPool} & \PrtclConsts \to
+        \Coin\times\lbrack 0, 1\rbrack\times\mathbb{Q}^{+}
+        & \text{decay constants for pool certificates}\\
 
       \fun{dresource} & \Tx \to \powerset{(\DCertRegKey \uniondistinct \DCertRegPool)}
         & \text{resource allocating certificates}\\
@@ -516,16 +524,17 @@ body must also contain inputs onto which this refund can be added.
       & \text{allocates resources} \\
       & \fun{releasing}~c = c \in \DCertDeRegKey \cup \DCertRetirePool\\
       \nextdef
-      & \fun{refund} \in \Coin \to [0, 1] \to \Duration \to \mathbb{Q}^{+} \to \Coin
+      & \fun{refund} \in \Coin \to [0, 1] \to \mathbb{Q}^{+} \to \Duration \to \Coin
       & \text{refund calculation} \\
-      & \refund{\dval}{d_{\min}}{\delta}{\lambda} =
+      & \refund{\dval}{d_{\min}}{\lambda}{\delta} =
             \floor*{
               \dval \cdot
             \left(d_{\min}+(1-d_{\min})\cdot e^{-\lambda\cdot\delta}\right)}
       \nextdef
-      & \fun{certRefund} \in \PrtclConsts \to \Allocs \to \Slot \to \DCert \to \Coin
+      & \fun{certRefund} \in \Coin \to [0, 1] \to \mathbb{Q}^{+} \to \\
+      & ~~~\Allocs \to \Slot \to \DCert \to \Coin
       & \text{refund for a certificate} \\
-      & \certRefund{allocs}{pc}{slot}{c} =\\
+      & \certRefund{\dval}{d_{\min}}{\lambda}{allocs}{slot}{c} =\\
       & \begin{cases}
         0 & \text{if not}~(\fun{releasing}~c)\\
             0 & \text{if}~\cauthor c \notin \dom allocs\\
@@ -535,15 +544,18 @@ body must also contain inputs onto which this refund can be added.
       &
       \begin{array}{lr@{~=~}l}
         \where
-        & \dval & \fun{dvalue}~pc~c\\
-        & d_{\min},~\lambda & \fun{decay}~pc\\
         &\delta & \slotminus{slot}{(allocs~(\cauthor c))}\\
       \end{array}\\
       \nextdef
       & \fun{keyRefunds} \in \PrtclConsts \to \Allocs \to \Tx \to \Coin
       & \text{key refunds for transaction} \\
       & \keyRefunds{pc}{stkeys}{tx} =\\
-      &   \sum\limits_{c \in \fun{dderegister}~tx} \certRefund{pc}{stkeys}{(\ttl{tx})}{c}\\
+      &   \sum\limits_{c \in \fun{dderegister}~tx} \certRefund{pc}{stkeys}{(\ttl{tx})}{c}{}{}\\
+      &
+      \begin{array}{lr@{~=~}l}
+        \where
+        & (\dval,~d_{\min},~\lambda) & \fun{decayKey}~\var{pc}\\
+      \end{array}\\
   \end{align*}
   \caption{Functions used in Deposits - Refunds}
   \label{fig:functions:deposits-refunds}
@@ -555,10 +567,10 @@ body must also contain inputs onto which this refund can be added.
       & \text{(abs.) slot of last epoch} \\
       & \fun{lastEpoch}~{s} =  s - (s~\mathsf{div}~\slotsPer)
       \nextdef
-      & \fun{decayed} \in
+      & \fun{decayedKey} \in
       \PrtclConsts \to \Allocs \to \Slot \to \DCert \to \Coin
       & \text{amount decayed since epoch} \\
-      & \decayed{allocs}{pc}{cslot}{c} =\\
+      & \decayedKey{pc}{allocs}{cslot}{c} =\\
       & \begin{cases}
         0 & \text{if not}~(\fun{releasing}~c)\\
             0 & \text{if}~\cauthor c \notin \dom allocs\\
@@ -568,16 +580,17 @@ body must also contain inputs onto which this refund can be added.
       &
       \begin{array}{lr@{~=~}l}
         \where
-          & \var{created} & \var{allocs}~\var{c} \\
-          & \var{start} & \mathsf{max}~(lastEpoch~created)~created \\
-          & \var{epochRefund} & \certRefund{c}{pc}{allocs}{start} \\
-          & \var{currentRefund} & \certRefund{c}{pc}{allocs}{cslot} \\
+          & \var{created} & \var{allocs}~(\cauthor \var{c}) \\
+          & \var{start} & \mathsf{max}~(lastEpoch~cslot)~created \\
+          & \var{epochRefund} & \certRefund{\dval}{d_{\min}}{\lambda}{allocs}{start}{c} \\
+          & \var{currentRefund} & \certRefund{\dval}{d_{\min}}{\lambda}{allocs}{cslot}{c} \\
+          & (\dval,~d_{\min},~\lambda) & \fun{decayKey}~\var{pc}\\
       \end{array}\\
       \nextdef
       & \fun{decayedTx} \in \PrtclConsts \to \Allocs \to \Tx \to \Coin
-      & \text{decayed deposits portions} \\
+      & \text{decayed key deposit portions} \\
       & \decayedTx{pc}{stkeys}{tx} =\\
-      &   \sum\limits_{c \in \fun{dderegister}~tx} \decayed{pc}{stkeys}{(\ttl{tx})}{c}\\
+      &   \sum\limits_{c \in \fun{dderegister}~tx} \decayedKey{pc}{stkeys}{(\ttl{tx})}{c}\\
   \end{align*}
   \caption{Functions used in Deposits - Decay}
   \label{fig:functions:deposits-decay}
@@ -1191,9 +1204,13 @@ and stake pools.
   \label{fig:rules:ledger}
 \end{figure}
 
+\clearpage
+
 \section{Epoch Boundary}
 \label{sec:epoch}
 \input{epoch.tex}
+
+\clearpage
 
 \section{Properties}
 \label{sec:properties}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -94,9 +94,10 @@
 \newcommand{\balance}[1]{\fun{balance}~ \var{#1}}
 \newcommand{\ttl}[1]{\fun{ttl}~ \var{#1}}
 \newcommand{\deposits}[2]{\fun{deposits}~ \var{#1} ~ \var{#2}}
-\newcommand{\refund}[4]{\fun{refund}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
 \newcommand{\decayed}[4]{\fun{decayed}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
 \newcommand{\decayedTx}[3]{\fun{decayedTx}~ \var{#1}~ \var{#2}~ \var{#3}}
+\newcommand{\certRefund}[4]{\fun{certRefund}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
+\newcommand{\refund}[4]{\fun{refund}~ \var{#1}~ \var{#2}~ {#3}~ {#4}}
 \newcommand{\keyRefunds}[3]{\fun{keyRefunds}~ \var{#1}~ \var{#2}~ \var{#3}}
 \newcommand{\created}[4]{\fun{created}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
 \newcommand{\destroyed}[2]{\fun{destroyed}~ \var{#1}~ \var{#2}}
@@ -138,6 +139,7 @@
 \newcommand{\delegates}[3]{\delegatesName~#1~#2~#3}
 \newcommand{\dwho}[1]{\fun{dwho}~\var{#1}}
 \newcommand{\depoch}[1]{\fun{depoch}~\var{#1}}
+\newcommand{\dval}{\ensuremath{d_{\mathsf{val}}}}
 %% Delegation witnesses
 \newcommand{\dbody}[1]{\fun{dbody}~\var{#1}}
 \newcommand{\dwit}[1]{\fun{dwit}~\var{#1}}
@@ -218,13 +220,19 @@ the rest of the document.
     & = \{ k \mapsto v \mid k \mapsto v \in \var{map}, ~ v \notin \var{set} \}
     & \text{range exclusion}
     \\
-    A \unionoverrideRight B
-    & = (\dom B \subtractdom A)\cup B
+    M \unionoverrideRight N
+    & = (\dom N \subtractdom M)\cup N
     & \text{union override right}
     \\
-    A \unionoverrideLeft B
-    & = A \cup (\dom A \subtractdom B)
+    M \unionoverrideLeft N
+    & = M \cup (\dom M \subtractdom N)
     & \text{union override left}
+    \\
+    M \unionoverridePlus N
+    & = (M \triangle N)
+    \cup \{k\mapsto v_1+v_2\mid {k\mapsto v_1}\in M \land {k\mapsto v_2}\in N \}
+    & \text{union override plus} \\
+    & & \text{(for monoidal values)}\\
   \end{align*}
   \caption{Non-standard map operators}
   \label{fig:notation:nonstandard}
@@ -379,13 +387,13 @@ time slot in which the validity of a given transaction will expire.
 
 The functions used to perform the calculations needed to describe the
 preservation of value
-are presented in Figure~\ref{fig:functions:deposits}.
+are presented in Figure~\ref{fig:functions:deposits-refunds}.
 The function
 $\fun{deposits}$ returns the total deposits made by a transaction. Specifically,
 it sums up the values of all the deposits made by the resource-allocating
 certificates of a given transaction.
 
-The map $\fun{refund}$, given the protocol constants, current resource allocations, and
+The map $\fun{certRefund}$, given the protocol constants, current resource allocations, and
 the current slot number, calculates the refund that will be issued
 for a given certificate.
 
@@ -455,10 +463,10 @@ body must also contain inputs onto which this refund can be added.
 
 
 \begin{note}
-  We define $\fun{refund}$ by cases on whether or not
+  We define $\fun{certRefund}$ by cases on whether or not
   the refunding certificate has a corresponding
   resource creating certificate.
-  If our rules are correct, then $\fun{refund}$
+  If our rules are correct, then $\fun{certRefund}$
   is only called in the case where such a matching
   certificate exists.
 \end{note}
@@ -478,7 +486,7 @@ body must also contain inputs onto which this refund can be added.
       \fun{dvalue} & \PrtclConsts \to \DCert \to \Coin
         & \text{deposit amount of a certificate}\\
 
-      \fun{decay} & \PrtclConsts \to \mathbb{N}\times\mathbb{Q}^{+}
+      \fun{decay} & \PrtclConsts \to \lbrack 0, 1\rbrack\times\mathbb{Q}^{+}
         & \text{decay constants}\\
 
       \fun{dresource} & \Tx \to \powerset{(\DCertRegKey \uniondistinct \DCertRegPool)}
@@ -508,20 +516,26 @@ body must also contain inputs onto which this refund can be added.
       & \text{allocates resources} \\
       & \fun{releasing}~c = c \in \DCertDeRegKey \cup \DCertRetirePool\\
       \nextdef
-      & \fun{refund} \in \PrtclConsts \to \Allocs \to \Slot \to \DCert \to \Coin
-      & \text{total refund for a certificate} \\
-      & \refund{allocs}{pc}{slot}{c} =\\
+      & \fun{refund} \in \Coin \to [0, 1] \to \Duration \to \mathbb{Q}^{+} \to \Coin
+      & \text{refund calculation} \\
+      & \refund{\dval}{d_{\min}}{\delta}{\lambda} =
+            \floor*{
+              \dval \cdot
+            \left(d_{\min}+(1-d_{\min})\cdot e^{-\lambda\cdot\delta}\right)}
+      \nextdef
+      & \fun{certRefund} \in \PrtclConsts \to \Allocs \to \Slot \to \DCert \to \Coin
+      & \text{refund for a certificate} \\
+      & \certRefund{allocs}{pc}{slot}{c} =\\
       & \begin{cases}
         0 & \text{if not}~(\fun{releasing}~c)\\
             0 & \text{if}~\cauthor c \notin \dom allocs\\
-            \floor*{
-              \left(\fun{dvalue}~pc~c\right) \cdot
-            \left(d_{\min}+(1-d_{\min})\cdot e^{-\lambda\cdot\delta}\right)}
+            \refund{\dval}{d_{\min}}{\delta}{\lambda}
             & \text{otherwise}
         \end{cases}\\
       &
       \begin{array}{lr@{~=~}l}
         \where
+        & \dval & \fun{dvalue}~pc~c\\
         & d_{\min},~\lambda & \fun{decay}~pc\\
         &\delta & \slotminus{slot}{(allocs~(\cauthor c))}\\
       \end{array}\\
@@ -529,8 +543,14 @@ body must also contain inputs onto which this refund can be added.
       & \fun{keyRefunds} \in \PrtclConsts \to \Allocs \to \Tx \to \Coin
       & \text{key refunds for transaction} \\
       & \keyRefunds{pc}{stkeys}{tx} =\\
-      &   \sum\limits_{c \in \fun{dderegister}~tx} \refund{pc}{stkeys}{(\ttl{tx})}{c}\\
-      \nextdef
+      &   \sum\limits_{c \in \fun{dderegister}~tx} \certRefund{pc}{stkeys}{(\ttl{tx})}{c}\\
+  \end{align*}
+  \caption{Functions used in Deposits - Refunds}
+  \label{fig:functions:deposits-refunds}
+\end{figure}
+
+\begin{figure}
+  \begin{align*}
       & \fun{lastEpoch} \in \Slot \to \Epoch
       & \text{(abs.) slot of last epoch} \\
       & \fun{lastEpoch}~{s} =  s - (s~\mathsf{div}~\slotsPer)
@@ -550,8 +570,8 @@ body must also contain inputs onto which this refund can be added.
         \where
           & \var{created} & \var{allocs}~\var{c} \\
           & \var{start} & \mathsf{max}~(lastEpoch~created)~created \\
-          & \var{epochRefund} & \refund{c}{pc}{allocs}{start} \\
-          & \var{currentRefund} & \refund{c}{pc}{allocs}{cslot} \\
+          & \var{epochRefund} & \certRefund{c}{pc}{allocs}{start} \\
+          & \var{currentRefund} & \certRefund{c}{pc}{allocs}{cslot} \\
       \end{array}\\
       \nextdef
       & \fun{decayedTx} \in \PrtclConsts \to \Allocs \to \Tx \to \Coin
@@ -559,8 +579,8 @@ body must also contain inputs onto which this refund can be added.
       & \decayedTx{pc}{stkeys}{tx} =\\
       &   \sum\limits_{c \in \fun{dderegister}~tx} \decayed{pc}{stkeys}{(\ttl{tx})}{c}\\
   \end{align*}
-  \caption{Functions used in Deposits}
-  \label{fig:functions:deposits}
+  \caption{Functions used in Deposits - Decay}
+  \label{fig:functions:deposits-decay}
 \end{figure}
 
 


### PR DESCRIPTION
This PR introduces a new section for the rules needed for transitioning from one epoch to the next.

The main rule, `EPOCH`, combines four rules together: `UTXOEP`, `ACCNT`, `POOLCLEAN`, and `NEWPC`.

The `UTXOEP` rule is responsible for processing the reward withdrawals (moving them from a pending state to spendable UTxO), zeroing out the fee pool, and setting the deposit pool to the minimum needed.

The `ACCNT` rule handles moving value between the treasury, reserves, reward pool, and the current reward accounts.  Note that the actual reward function, based on the actual blocks produced during the epoch, is left unspecified.  There are still some details there to be worked out by the researchers.

The `POOLCLEAN` rule pays out pool retirement certificate refunds and retires pools.

The `NEWPC` rule handles accounting details needed when changing the protocol constants.  In particular, in difference in the deposit obligations that result from changing the constants are balanced out with the reserve pool.

With the new state that has been added to the ledger, we can now state a conservation of lovelace property for the entire system:

```
45B ADA == balance utxo + balance rewards + deposits + treasury + reserves + rewardPool + fees
```

closes #16 #41 