### PR TITLE
Mutators for `DelegationData` transitions

### DIFF
--- a/hs/src/LedgerState.hs
+++ b/hs/src/LedgerState.hs
@@ -18,6 +18,7 @@ module LedgerState
   , Ledger
   , LedgerEntry(..)
   , LedgerValidation(..)
+  , KeyPairs
   -- * state transitions
   , applyTransaction
   , asStateTransition
@@ -55,6 +56,9 @@ data LedgerEntry =
     deriving (Show, Eq)
 
 type Ledger = [LedgerEntry]
+
+-- | Representation of a list of pairs of key pairs, e.g., pay and stake keys
+type KeyPairs = [(KeyPair, KeyPair)]
 
 -- | A ledger validation state consists of a ledger state 't' and the list of
 -- validation errors that occurred from a valid 's' to reach 't'.

--- a/hs/test/Generator.hs
+++ b/hs/test/Generator.hs
@@ -35,7 +35,8 @@ import           LedgerState     (LedgerEntry (..), LedgerState (..),
                                   LedgerValidation(..),
                                   ValidationError (..), asStateTransition,
                                   asStateTransition',
-                                  genesisState, DelegationState(..)
+                                  genesisState, DelegationState(..),
+                                  KeyPairs
                                  )
 import           Slot
 import           UTxO
@@ -43,8 +44,6 @@ import           Delegation.Certificates  (DCert(..))
 import           Delegation.StakePool  (StakePool(..), Delegation(..))
 
 import           Mutator
-
-type KeyPairs = [(KeyPair, KeyPair)]
 
 -- | Returns the number of entries of the UTxO set.
 utxoSize :: UTxO -> Int

--- a/hs/test/Mutator.hs
+++ b/hs/test/Mutator.hs
@@ -112,12 +112,21 @@ mutateOutput (TxOut addr c) = do
 -- Mutators that change the type of certificate must be implemented in
 -- 'Generator.hs' in order to prevent cyclic imports.
 
+-- | Select one random verification staking key from list of pairs of KeyPair.
 getStakeKey :: KeyPairs -> Gen VKey
 getStakeKey keys = vKey . snd <$> Gen.element keys
 
+-- | Mutate 'Epoch' analogously to 'Coin' data.
 mutateEpoch :: Natural -> Natural -> Epoch -> Gen Epoch
 mutateEpoch lower upper (Epoch val) = Epoch <$> mutateNat lower upper val
 
+-- | Mutator for delegation certificates.
+-- A 'RegKey' and 'DeRegKey' select randomly a key fomr the supplied list of
+-- keypairs.
+-- A 'RetirePool' certificate mutates the epoch and the key of the certificate.
+-- A 'RegPool' certificate mutates the staking key, the pool's cost and margin.
+-- A 'Delegate' certificates selects randomly keys for delegator and delegatee
+-- from the supplied list of keypairs.
 mutateDCert :: KeyPairs -> DelegationState -> DCert -> Gen DCert
 mutateDCert keys _ (RegKey _) = RegKey <$> vKey . snd <$> Gen.element keys
 

--- a/hs/test/Mutator.hs
+++ b/hs/test/Mutator.hs
@@ -21,8 +21,11 @@ import qualified Hedgehog.Gen    as Gen
 import qualified Hedgehog.Range  as Range
 
 import Coin
-import LedgerState (LedgerEntry(..))
+import           Delegation.Certificates  (DCert(..))
+import Keys
+import LedgerState (LedgerEntry(..), DelegationState(..), KeyPairs)
 import UTxO        (Tx(..), TxWits(..), TxIn(..), TxOut(..))
+import           Slot
 
 -- | Identity mutator that does not change the input value.
 mutateId :: a -> Gen a


### PR DESCRIPTION
This currently does only simple mutation for `StakePool`, the `poolPledged` map and the `poolAltAcnt` are not modified.