### PR TITLE
using delegation certs inside transaction

### DIFF
--- a/hs/src/LedgerState.hs
+++ b/hs/src/LedgerState.hs
@@ -16,11 +16,9 @@ module LedgerState
   , mkRwdAcnt
   , DelegationState(..)
   , Ledger
-  , LedgerEntry(..)
   , LedgerValidation(..)
   , KeyPairs
   -- * state transitions
-  , applyTransaction
   , asStateTransition
   , asStateTransition'
   , delegatedStake
@@ -33,6 +31,7 @@ module LedgerState
   , ValidationError (..)
   ) where
 
+import           Control.Monad           (foldM)
 import           Crypto.Hash             (hash)
 import           Data.List               (find)
 import qualified Data.Map                as Map
@@ -50,12 +49,7 @@ import           Delegation.StakePool    (Delegation (..), StakePool (..))
 -- | A ledger consists of a list of entries where each such entry is either a
 -- stake delegation step or a transaction.
 
-data LedgerEntry =
-    TransactionData !TxWits
-  | DelegationData !DCert
-    deriving (Show, Eq)
-
-type Ledger = [LedgerEntry]
+type Ledger = [TxWits]
 
 -- | Representation of a list of pairs of key pairs, e.g., pay and stake keys
 type KeyPairs = [(KeyPair, KeyPair)]
@@ -219,9 +213,8 @@ validKeyDeregistration cert (LedgerState _ ds _) =
 validStakeDelegation :: DCert -> LedgerState -> Validity
 validStakeDelegation cert (LedgerState _ ds _) =
   case cert of
-    Delegate (Delegation source target)
-      -> if Map.member (hashKey source) (getStKeys ds) &&
-            Map.member (hashKey target) (getStPools ds)
+    Delegate (Delegation source _)
+      -> if Map.member (hashKey source) (getStKeys ds)
          then Valid else Invalid [StakeDelegationImpossible]
     _ -> Valid
 
@@ -244,24 +237,25 @@ validDelegation cert l =
   <> validStakePoolRegister cert l
   <> validStakePoolRetire cert l
 
--- |Apply a raw transaction body as a state transition function on the ledger state.
-applyTx :: LedgerState -> Tx -> LedgerState
-applyTx ls tx =
-    LedgerState (txins tx </| getUtxo ls `union` txouts tx)
-                (getDelegationState ls)
-                (getEpoch ls)
-
 -- |In the case where a transaction is valid for a given ledger state,
 -- apply the transaction as a state transition function on the ledger state.
 -- Otherwise, return a list of validation errors.
 asStateTransition
-  :: Slot -> LedgerState -> LedgerEntry -> Either [ValidationError] LedgerState
-asStateTransition _ ls (TransactionData tx) =
+  :: Slot -> LedgerState -> TxWits -> Either [ValidationError] LedgerState
+asStateTransition slot ls tx =
   case valid tx ls of
     Invalid errors -> Left errors
-    Valid          -> Right $ applyTx ls (body tx)
+    Valid          -> foldM (certAsStateTransition slot) ls' cs
+      where
+        ls' = applyTxBody ls (body tx)
+        cs = certs . body $ tx
 
-asStateTransition slot ls (DelegationData cert) =
+-- |In the case where a certificate is valid for a given ledger state,
+-- apply the certificate as a state transition function on the ledger state.
+-- Otherwise, return a list of validation errors.
+certAsStateTransition
+  :: Slot -> LedgerState -> DCert -> Either [ValidationError] LedgerState
+certAsStateTransition slot ls cert =
   case validDelegation cert ls of
     Invalid errors -> Left errors
     Valid          -> Right $ applyDCert slot cert ls
@@ -269,16 +263,10 @@ asStateTransition slot ls (DelegationData cert) =
 -- | Apply transition independent of validity, collect validation errors on the
 -- way.
 asStateTransition'
-  :: Slot -> LedgerValidation -> LedgerEntry -> LedgerValidation
-asStateTransition' _ (LedgerValidation valErrors ls) (TransactionData tx) =
-    let ls' = applyTx ls (body tx) in
+  :: Slot -> LedgerValidation -> TxWits -> LedgerValidation
+asStateTransition' _ (LedgerValidation valErrors ls) tx =
+    let ls' = applyTxBody ls (body tx) in
     case valid tx ls of
-      Invalid errors -> LedgerValidation (valErrors ++ errors) ls'
-      Valid          -> LedgerValidation valErrors ls'
-
-asStateTransition' slot (LedgerValidation valErrors ls) (DelegationData cert) =
-    let ls' = applyDCert slot cert ls in
-    case validDelegation cert ls of
       Invalid errors -> LedgerValidation (valErrors ++ errors) ls'
       Valid          -> LedgerValidation valErrors ls'
 
@@ -342,16 +330,6 @@ applyDCert _ (RetirePool key epoch) ls@(LedgerState _ ds _) = ls
     { getRetiring = retiring}}
   where retiring = Map.insert hk_sp epoch (getRetiring ds)
         hk_sp = hashKey key
-
--- |Apply an ordered collection of certificates as a state transition function
--- on the ledger state.
-applyDCerts :: Slot -> LedgerState -> Set.Set DCert -> LedgerState
-applyDCerts slot = Set.fold (applyDCert slot)
-
--- |Apply a transaction as a state transition function on the ledger state.
-applyTransaction :: Slot -> LedgerState -> TxWits -> LedgerState
-applyTransaction slot ls tx = applyTxBody (applyDCerts slot ls cs) (body tx)
-  where cs = (certs . body) tx
 
 -- |Compute how much stake each active stake pool controls.
 delegatedStake :: LedgerState -> Map.Map HashKey Coin

--- a/hs/src/UTxO.hs
+++ b/hs/src/UTxO.hs
@@ -29,13 +29,6 @@ module UTxO
   -- , verify
   , union
   , makeWitness
-  -- * Signing and Verifying
-  -- , Owner(..)
-  -- , SKey(..)
-  -- , VKey(..)
-  -- , KeyPair(..)
-  -- , keyPair
-  -- , Sig(..)
   , Wit(..)
   , TxWits(..)
   ) where

--- a/hs/test/Mutator.hs
+++ b/hs/test/Mutator.hs
@@ -9,7 +9,7 @@ data. Input values are mutated depending on their value.
 module Mutator
     ( mutateNat
     , mutateCoin
-    , mutateLedgerEntry
+    , mutateTxWits
     , mutateTx
     , mutateDCert
     , getAnyStakeKey
@@ -27,7 +27,7 @@ import Coin
 import           Delegation.Certificates  (DCert(..))
 import           Delegation.StakePool
 import Keys
-import LedgerState (LedgerEntry(..), DelegationState(..), KeyPairs)
+import LedgerState (DelegationState(..), KeyPairs)
 import UTxO        (Tx(..), TxWits(..), TxIn(..), TxOut(..))
 import           Slot
 
@@ -57,13 +57,11 @@ mutateNat lower upper n =
 mutateCoin :: Natural -> Natural -> Coin -> Gen Coin
 mutateCoin lower upper (Coin val) = Coin <$> mutateNat lower upper val
 
--- | Mutator of 'LedgerEntry' which mutates the contained transaction of a
--- 'DelegationData' entry.
-mutateLedgerEntry :: LedgerEntry -> Gen LedgerEntry
-mutateLedgerEntry d@(DelegationData _) = mutateId d
-mutateLedgerEntry (TransactionData txwits) = do
+-- | Mutator of 'TxWits' which mutates the contained transaction
+mutateTxWits :: TxWits -> Gen TxWits
+mutateTxWits txwits = do
   body' <- mutateTx $ body txwits
-  pure $ TransactionData $ TxWits body' (witnessSet txwits)
+  pure $ TxWits body' (witnessSet txwits)
 
 -- | Mutator for Transaction which mutates the set of inputs and the set of
 -- unspent outputs.

--- a/hs/test/Tests.hs
+++ b/hs/test/Tests.hs
@@ -19,7 +19,7 @@ import           Generator
 import           Coin
 import           Slot
 import           Keys
-import           LedgerState             (DelegationState (..), Ledger,
+import           LedgerState             (DelegationState (..),
                                           LedgerState (..),
                                           ValidationError (..),
                                           LedgerValidation(..),
@@ -56,7 +56,7 @@ genesis = genesisState
 stakePoolKey1 :: KeyPair
 stakePoolKey1 = keyPair (Owner 5)
 
-ledgerState :: Ledger -> Either [ValidationError] LedgerState
+ledgerState :: [TxWits] -> Either [ValidationError] LedgerState
 ledgerState = foldM (asStateTransition (Slot 0)) genesis
 
 


### PR DESCRIPTION
In this PR the `LedgerEntry` type is removed, so that a ledger is just a list of transactions, and the transactions contain delegation certificates.