### PR TITLE
Add property and classification to check absence of double spend

### DIFF
--- a/hs/package.yaml
+++ b/hs/package.yaml
@@ -22,6 +22,7 @@ library:
   - containers
   - cryptonite
   - memory
+  - multiset
   - tasty
   - tasty-hunit
   - hedgehog
@@ -51,4 +52,5 @@ tests:
     - delegation
     - cryptonite
     - containers
+    - multiset
     - text

--- a/hs/test/Tests.hs
+++ b/hs/test/Tests.hs
@@ -299,7 +299,7 @@ propPositiveBalance =
 propPreserveBalanceInitTx :: Cover
 propPreserveBalanceInitTx =
     withCoverage $ do
-      (_, steps, fees, ls, next)  <- forAll genNonEmptyAndAdvanceTx
+      (_, steps, fees, ls, _, next)  <- forAll genNonEmptyAndAdvanceTx
       classify (steps > 1) "non-trivial number of steps"
       case next of
         Left _    -> failure

--- a/hs/test/Tests.hs
+++ b/hs/test/Tests.hs
@@ -357,10 +357,10 @@ propUniqueTxIds = withCoverage $ do
 -- transactions. Note: this is more a property of the current generator.
 propNoDoubleSpend :: Cover
 propNoDoubleSpend = Test.Tasty.Hedgehog.Coverage.withTests 1000 $ withCoverage $ do
-      (_, steps, fees, ls, txs, next)  <- forAll genNonEmptyAndAdvanceTx
+      (_, _, _, _, txs, next)  <- forAll genNonEmptyAndAdvanceTx
       case next of
-        Left _    -> failure
-        Right ls' -> do
+        Left _  -> failure
+        Right _ -> do
           let inputIndicesSet = unions $ map (\txwit -> fromSet $ inputs $ body txwit) txs
           0 === (Data.MultiSet.size $ Data.MultiSet.filter
                      (\idx -> 1 < Data.MultiSet.occur idx inputIndicesSet)
@@ -370,8 +370,8 @@ propNoDoubleSpend = Test.Tasty.Hedgehog.Coverage.withTests 1000 $ withCoverage $
 -- non-validated). This is a property of the validator, i.e., no validated
 -- transaction should ever be able to do a double spend.
 classifyInvalidDoubleSpend :: Cover
-classifyInvalidDoubleSpend = Test.Tasty.Hedgehog.Coverage.withTests 10000 $ withCoverage $ do
-      (_, steps, fees, ls, txs, LedgerValidation validationErrors ls')
+classifyInvalidDoubleSpend = Test.Tasty.Hedgehog.Coverage.withTests 1000 $ withCoverage $ do
+      (_, _, _, _, txs, LedgerValidation validationErrors _)
           <- forAll genNonEmptyAndAdvanceTx'
       let inputIndicesSet  = unions $ map (\txwit -> fromSet $ inputs $ body txwit) txs
       let multiSpentInputs = (Data.MultiSet.size $ Data.MultiSet.filter


### PR DESCRIPTION
This adds the possibility to collect all transactions and check that the multiset union of all inputs does not contain any duplicates.
This property itself depends on the way that the transactions are generated of course, therefore there is also a mutation variant that mutates transactions and classifies into validated and non-validated double-spends. Only non-validated double-spends are OK, else the property fails.