### PR TITLE
Add validation of non-empty input sets for transactions

### DIFF
--- a/hs/test/Tests.hs
+++ b/hs/test/Tests.hs
@@ -139,20 +139,26 @@ utxo2 = Map.fromList
        , (TxIn (txid tx2Body) 0, TxOut aliceAddr (Coin 7))
        , (TxIn (txid tx2Body) 1, TxOut bobAddr (Coin 3)) ]
 
+utxo3 :: Map.Map TxIn TxOut
+utxo3 = Map.fromList
+       [ (TxIn genesisId 1, TxOut bobAddr (Coin 1))
+       , (TxIn (txid tx2Body) 1, TxOut bobAddr (Coin 3))
+       , (TxIn (txid tx3Body) 0, TxOut aliceAddr (Coin 7))]
+
 tx2 :: TxWits
 tx2 = TxWits tx2Body (Set.fromList [makeWitness alicePay tx2Body])
 
 tx3Body :: Tx
 tx3Body = Tx
-          Set.empty
-          []
+          (Set.fromList [TxIn (txid tx2Body) 0])
+          [TxOut aliceAddr (Coin 7)]
           (Set.fromList
             [ RegPool stakePool
             , Delegate (Delegation (vKey aliceStake) (vKey stakePoolKey1))
             ])
 
 tx3 :: TxWits
-tx3 = TxWits tx3Body Set.empty
+tx3 = TxWits tx3Body (Set.fromList [makeWitness alicePay tx3Body])
 
 stakeKeyRegistration1 :: DelegationState
 stakeKeyRegistration1 = LedgerState.emptyDelegation
@@ -186,7 +192,7 @@ testsValidLedger =
           [ testCase "Valid stake key registration." $
               testValidStakeKeyRegistration tx2 utxo2 stakeKeyRegistration1
           , testCase "Valid stake delegation from Alice to stake pool." $
-              testValidDelegation [tx2, tx3] utxo2 stakeKeyRegistration1
+              testValidDelegation [tx2, tx3] utxo3 stakeKeyRegistration1
           ]
     ]
 

--- a/hs/test/Tests.hs
+++ b/hs/test/Tests.hs
@@ -239,12 +239,24 @@ testInvalidTransaction =
     tx = TxWits txbody (Set.fromList [aliceWit])
   in ledgerState [tx] @?= Left [InsufficientWitnesses]
 
+testEmptyInputSet :: Assertion
+testEmptyInputSet =
+  let
+    txbody = Tx
+              Set.empty
+              [ TxOut aliceAddr (Coin 1)]
+              Set.empty
+    aliceWit = makeWitness alicePay txbody
+    tx = TxWits txbody (Set.fromList [aliceWit])
+  in ledgerState [tx] @?= Left [InputSetEmpty, IncreasedTotalBalance, InsufficientWitnesses]
+
 testsInvalidLedger :: TestTree
 testsInvalidLedger = testGroup "Tests with invalid transactions in ledger"
   [ testCase "Invalid Ledger - Alice tries to spend a nonexistent input" testSpendNonexistentInput
   , testCase "Invalid Ledger - Alice does not include a witness" testWitnessNotIncluded
   , testCase "Invalid Ledger - Alice tries to spend Bob's UTxO" testSpendNotOwnedUTxO
   , testCase "Invalid Ledger - Alice provides witness of wrong UTxO" testInvalidTransaction
+  , testCase "Invalid Ledger - Alice's transaction does not consume input" testEmptyInputSet
   ]
 
 unitTests :: TestTree


### PR DESCRIPTION
In order to prevent a replay attack, i.e., applying a delegation transaction again later, it is necessary to consume an input.

This adds the above validation, a unit test for it and fixes a unit test that did apply a transaction with empty input set.