### PR TITLE
adding deposits and refunds

### DIFF
--- a/hs/src/Coin.hs
+++ b/hs/src/Coin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DerivingVia #-}
 
 module Coin
@@ -11,8 +12,8 @@ import           Numeric.Natural (Natural)
 
 -- |The amount of value held by a transaction output.
 newtype Coin = Coin Natural
-  deriving (Show, Eq, Ord)
-  deriving (Semigroup, Monoid, Num) via (Sum Natural)
+  deriving (Show, Eq, Ord, Num, Integral, Real, Enum)
+  deriving (Semigroup, Monoid) via (Sum Natural)
 
 splitCoin :: Coin -> Natural -> (Coin, Coin)
 splitCoin (Coin n) 0 = (Coin 0, Coin n)

--- a/hs/src/Delegation/Certificates.hs
+++ b/hs/src/Delegation/Certificates.hs
@@ -44,8 +44,9 @@ dvalue _ = const $ Coin 0
 
 -- |Compute a refund on a deposit
 refund :: DCert -> PrtlConsts -> Duration -> Coin
-refund cert pc dur = floor (dep * (dmin + (1-dmin) * exp pow))
+refund cert pc dur = floor refund'
   where
     dep = fromIntegral $ dvalue cert pc
-    dmin = minRefund pc
-    pow = - decayRate pc * fromIntegral dur
+    dmin = fromRational $ minRefund pc
+    pow = - fromRational (decayRate pc * fromIntegral dur)
+    refund' = dep * (dmin + (1-dmin) * exp pow) :: Double

--- a/hs/src/LedgerState.hs
+++ b/hs/src/LedgerState.hs
@@ -35,6 +35,7 @@ import           Crypto.Hash             (hash)
 import           Data.List               (find)
 import qualified Data.Map                as Map
 import           Data.Maybe              (isJust, mapMaybe, fromMaybe)
+import           Numeric.Natural         (Natural)
 import qualified Data.Set                as Set
 
 import           Coin                    (Coin (..))
@@ -171,10 +172,13 @@ validInputs (TxWits tx _) l =
     else Invalid [BadInputs]
   where unspentInputs (UTxO utxo) = Map.keysSet utxo
 
+-- |Implementation of astract transaction size
+txsize :: Tx -> Natural
+txsize = toEnum . length . show
+
 -- |Minimum fee calculation
 minfee :: PrtlConsts -> Tx -> Coin
-minfee pc tx = minfeeA pc * x + minfeeB pc
-  where x = Coin $ toEnum $ length (show tx)
+minfee pc tx = Coin $ minfeeA pc * (txsize tx) + minfeeB pc
 
 -- |Determine if the fee is large enough
 validFee :: TxWits -> LedgerState -> Validity

--- a/hs/src/LedgerState.hs
+++ b/hs/src/LedgerState.hs
@@ -172,7 +172,7 @@ validInputs (TxWits tx _) l =
     else Invalid [BadInputs]
   where unspentInputs (UTxO utxo) = Map.keysSet utxo
 
--- |Implementation of astract transaction size
+-- |Implementation of abstract transaction size
 txsize :: Tx -> Natural
 txsize = toEnum . length . show
 

--- a/hs/src/PrtlConsts.hs
+++ b/hs/src/PrtlConsts.hs
@@ -11,4 +11,12 @@ data PrtlConsts =
     minfeeA :: Coin
     -- |The constant factor for the minimum fee calculation
   , minfeeB :: Coin
+    -- |The amount of a key registration deposit
+  , keyDeposit :: Coin
+    -- |The amount of a pool registration deposit
+  , poolDeposit :: Coin
+    -- |The minimum percent refund guarantee
+  , minRefund :: Float
+    -- |The deposit decay rate
+  , decayRate :: Float
   } deriving (Show, Eq)

--- a/hs/src/PrtlConsts.hs
+++ b/hs/src/PrtlConsts.hs
@@ -3,7 +3,9 @@ module PrtlConsts
      PrtlConsts(..)
     ) where
 
-import Coin (Coin(..))
+import           Data.Ratio (Rational)
+
+import           Coin (Coin(..))
 
 data PrtlConsts =
   PrtlConsts
@@ -16,7 +18,7 @@ data PrtlConsts =
     -- |The amount of a pool registration deposit
   , poolDeposit :: Coin
     -- |The minimum percent refund guarantee
-  , minRefund :: Float
+  , minRefund :: Rational
     -- |The deposit decay rate
-  , decayRate :: Float
+  , decayRate :: Rational
   } deriving (Show, Eq)

--- a/hs/src/PrtlConsts.hs
+++ b/hs/src/PrtlConsts.hs
@@ -3,22 +3,23 @@ module PrtlConsts
      PrtlConsts(..)
     ) where
 
-import           Data.Ratio (Rational)
+import           Data.Ratio      (Rational)
+import           Numeric.Natural (Natural)
 
-import           Coin (Coin(..))
+import           Coin            (Coin (..))
 
 data PrtlConsts =
   PrtlConsts
   { -- |The linear factor for the minimum fee calculation
-    minfeeA :: Coin
+    minfeeA     :: Natural
     -- |The constant factor for the minimum fee calculation
-  , minfeeB :: Coin
+  , minfeeB     :: Natural
     -- |The amount of a key registration deposit
-  , keyDeposit :: Coin
+  , keyDeposit  :: Coin
     -- |The amount of a pool registration deposit
   , poolDeposit :: Coin
     -- |The minimum percent refund guarantee
-  , minRefund :: Rational
+  , minRefund   :: Rational
     -- |The deposit decay rate
-  , decayRate :: Rational
+  , decayRate   :: Rational
   } deriving (Show, Eq)

--- a/hs/src/Slot.hs
+++ b/hs/src/Slot.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DerivingVia #-}
 
 module Slot
   ( Slot(..)
+  , Duration(..)
+  , (-*), (+*)
   , Epoch(..)
   ) where
 
@@ -10,8 +13,18 @@ import           Numeric.Natural         (Natural)
 
 -- |A Slot
 newtype Slot = Slot Natural
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Num)
   deriving (Semigroup, Monoid) via (Sum Natural)
+
+newtype Duration = Duration Natural
+  deriving (Show, Eq, Ord, Num, Integral, Real, Enum)
+  deriving (Semigroup, Monoid) via (Sum Natural)
+
+(-*) :: Slot -> Slot -> Duration
+(Slot s) -* (Slot t) = Duration (if s > t then s - t else t - s)
+
+(+*) :: Slot -> Duration -> Slot
+(Slot s) +* (Duration d) = Slot (s + d)
 
 -- |An Epoch
 newtype Epoch = Epoch Natural

--- a/hs/test/Generator.hs
+++ b/hs/test/Generator.hs
@@ -101,7 +101,7 @@ genTxOut addrs = do
 
 -- TODO generate sensible protocol constants
 defPCs :: PrtlConsts
-defPCs = PrtlConsts 0 0 (Coin 100) (Coin 100) 0 0
+defPCs = PrtlConsts 0 0 100 100 0 0
 
 -- | Generator of a non-empty genesis ledger state, i.e., at least one valid
 -- address and non-zero UTxO.

--- a/hs/test/Generator.hs
+++ b/hs/test/Generator.hs
@@ -101,7 +101,7 @@ genTxOut addrs = do
 
 -- TODO generate sensible protocol constants
 defPCs :: PrtlConsts
-defPCs = PrtlConsts 0 0
+defPCs = PrtlConsts 0 0 (Coin 100) (Coin 100) 0 0
 
 -- | Generator of a non-empty genesis ledger state, i.e., at least one valid
 -- address and non-zero UTxO.
@@ -116,8 +116,8 @@ genNonemptyGenesisState = do
 -- addresses and spends the UTxO. If 'n' addresses are selected to spent 'b'
 -- coins, the amount spent to each address is 'div b n' and the fees are set to
 -- 'rem b n'.
-genTxWits :: KeyPairs -> UTxO -> Gen (Coin, TxWits)
-genTxWits keyList (UTxO m) = do
+genTxWits :: KeyPairs -> UTxO -> Slot -> Gen (Coin, TxWits)
+genTxWits keyList (UTxO m) cslot = do
   -- select payer
   selectedInputs <- Gen.shuffle utxoInputs
   let !selectedAddr    = addr $ head selectedInputs
@@ -132,11 +132,13 @@ genTxWits keyList (UTxO m) = do
   let (perReceipient, txfee) = splitCoin selectedBalance (fromIntegral realN)
   let !receipientAddrs      = fmap
           (\(p, d) -> AddrTxin (hashKey $ vKey p) (hashKey $ vKey d)) receipients
+  txttl <- genNatural 1 100
   let !txbody = Tx
            (Map.keysSet selectedUTxO)
            ((\r -> TxOut r perReceipient) <$> receipientAddrs)
            Set.empty
            txfee
+           (cslot + (Slot txttl))
   let !txwit = makeWitness selectedKeyPair txbody
   pure (txfee, TxWits txbody $ Set.fromList [txwit])
             where utxoInputs = Map.keys m
@@ -150,8 +152,8 @@ genLedgerStateTx :: KeyPairs -> LedgerState ->
                     Gen (Coin, TxWits, Either [ValidationError] LedgerState)
 genLedgerStateTx keyList sourceState = do
   let utxo = getUtxo sourceState
-  (txfee, tx) <- genTxWits keyList utxo
   slot <- genNatural 0 1000
+  (txfee, tx) <- genTxWits keyList utxo (Slot slot)
   pure (txfee, tx, asStateTransition (Slot slot) sourceState tx)
 
 -- | Generator of a non-emtpy ledger genesis state and a random number of
@@ -260,9 +262,9 @@ genLedgerStateTx' :: KeyPairs -> LedgerState ->
                     Gen (Coin, TxWits, LedgerValidation)
 genLedgerStateTx' keyList sourceState = do
   let utxo = getUtxo sourceState
-  (txfee, tx) <- genTxWits keyList utxo
-  tx'       <- mutateTxWits tx
   slot <- genNatural 0 1000
+  (txfee, tx) <- genTxWits keyList utxo (Slot slot)
+  tx'       <- mutateTxWits tx
   pure (txfee
        , tx'
        , asStateTransition' (Slot slot) (LedgerValidation [] sourceState) tx')

--- a/hs/test/Mutator.hs
+++ b/hs/test/Mutator.hs
@@ -73,6 +73,7 @@ mutateTx tx = do
             outputs'
             (certs tx)
             (fee tx)
+            (ttl tx)
 
 -- | Mutator for a list of 'TxIn'.
 mutateInputs :: [TxIn] -> Gen [TxIn]

--- a/hs/test/Tests.hs
+++ b/hs/test/Tests.hs
@@ -51,7 +51,7 @@ bobAddr :: Addr
 bobAddr = AddrTxin (hashKey (vKey bobPay)) (hashKey (vKey bobStake))
 
 pcs :: PrtlConsts
-pcs = PrtlConsts 1 1 (Coin 100) (Coin 250) 0.25 0.001
+pcs = PrtlConsts 1 1 100 250 0.25 0.001
 
 aliceInitCoin :: Coin
 aliceInitCoin = Coin 10000
@@ -106,9 +106,9 @@ testValidDelegation txs utxo stakeKeyRegistration pool =
                      }
                      pcs)
 
-aliceGivesBobAda :: TxIn -> Coin -> Coin -> Coin -> Coin ->
+aliceGivesBobLovelace :: TxIn -> Coin -> Coin -> Coin -> Coin ->
   Set.Set DCert -> Slot -> TxWits
-aliceGivesBobAda txin coin txfee txdeps txrefs cs s = TxWits txbody wit
+aliceGivesBobLovelace txin coin txfee txdeps txrefs cs s = TxWits txbody wit
   where
     aliceCoin = aliceInitCoin + txrefs - (coin + txfee + txdeps)
     txbody = Tx
@@ -121,7 +121,7 @@ aliceGivesBobAda txin coin txfee txdeps txrefs cs s = TxWits txbody wit
     wit = Set.fromList [makeWitness alicePay txbody]
 
 tx1 :: TxWits
-tx1 = aliceGivesBobAda
+tx1 = aliceGivesBobLovelace
         (TxIn genesisId 0)
         (Coin 3000) (Coin 600) (Coin 0) (Coin 0)
         Set.empty (Slot 0)
@@ -136,7 +136,7 @@ ls1 :: Either [ValidationError] LedgerState
 ls1 = ledgerState [tx1]
 
 tx2 :: TxWits
-tx2 = aliceGivesBobAda
+tx2 = aliceGivesBobLovelace
         (TxIn genesisId 0)
         (Coin 3000) (Coin 1300) (Coin 3*100) (Coin 0)
         (Set.fromList
@@ -243,7 +243,7 @@ testsValidLedger =
 testSpendNonexistentInput :: Assertion
 testSpendNonexistentInput =
   let
-    tx = aliceGivesBobAda
+    tx = aliceGivesBobLovelace
            (TxIn genesisId 42)
            (Coin 3000) (Coin 1500) (Coin 0) (Coin 0)
            Set.empty (Slot 100)
@@ -317,7 +317,7 @@ testEmptyInputSet =
 testFeeTooSmall :: Assertion
 testFeeTooSmall =
   let
-    tx = aliceGivesBobAda
+    tx = aliceGivesBobLovelace
            (TxIn genesisId 0)
            (Coin 3000) (Coin 1) (Coin 0) (Coin 0)
            Set.empty (Slot 100)
@@ -327,7 +327,7 @@ testFeeTooSmall =
 testExpiredTx :: Assertion
 testExpiredTx =
   let
-    tx = aliceGivesBobAda
+    tx = aliceGivesBobLovelace
            (TxIn genesisId 0)
            (Coin 3000) (Coin 600) (Coin 0) (Coin 0)
            Set.empty (Slot 0)

--- a/hs/test/Tests.hs
+++ b/hs/test/Tests.hs
@@ -51,13 +51,19 @@ bobAddr :: Addr
 bobAddr = AddrTxin (hashKey (vKey bobPay)) (hashKey (vKey bobStake))
 
 pcs :: PrtlConsts
-pcs = PrtlConsts 1 1
+pcs = PrtlConsts 1 1 (Coin 100) (Coin 250) 0.25 0.001
+
+aliceInitCoin :: Coin
+aliceInitCoin = Coin 10000
+
+bobInitCoin :: Coin
+bobInitCoin = Coin 1000
 
 genesis :: LedgerState
 genesis = genesisState
             pcs
-            [ TxOut aliceAddr (Coin 10000)
-            , TxOut bobAddr (Coin 1000) ]
+            [ TxOut aliceAddr aliceInitCoin
+            , TxOut bobAddr bobInitCoin ]
 
 stakePoolKey1 :: KeyPair
 stakePoolKey1 = keyPair (Owner 5)
@@ -72,7 +78,6 @@ testLedgerValidTransactions ls utxo =
     ls @?= Right (LedgerState
                      (UTxO utxo)
                      LedgerState.emptyDelegation
-                     (Epoch 0)
                      pcs)
 
 testValidStakeKeyRegistration ::
@@ -83,12 +88,11 @@ testValidStakeKeyRegistration tx utxo stakeKeyRegistration =
   in ls2 @?= Right (LedgerState
                      (UTxO utxo)
                      stakeKeyRegistration
-                     (Epoch 0)
                      pcs)
 
 testValidDelegation ::
-  [TxWits] -> Map.Map TxIn TxOut -> DelegationState -> Assertion
-testValidDelegation txs utxo stakeKeyRegistration =
+  [TxWits] -> Map.Map TxIn TxOut -> DelegationState -> StakePool -> Assertion
+testValidDelegation txs utxo stakeKeyRegistration pool =
   let
     ls2 = ledgerState txs
     poolhk = hashKey $ vKey stakePoolKey1
@@ -97,72 +101,68 @@ testValidDelegation txs utxo stakeKeyRegistration =
                      stakeKeyRegistration
                      { getDelegations =
                          Map.fromList [(hashKey $ vKey aliceStake, poolhk)]
-                     , getStPools = Map.fromList [(poolhk, (stakePool, Slot 0))]
+                     , getStPools = Map.fromList [(poolhk, Slot 0)]
+                     , getPParams = Map.fromList [(poolhk, pool)]
                      }
-                     (Epoch 0)
                      pcs)
 
-tx1Body :: Tx
-tx1Body = Tx
-          (Set.fromList [TxIn genesisId 0])
-          [ TxOut aliceAddr (Coin 5870)
-          , TxOut bobAddr (Coin 3000) ]
-          Set.empty
-          (Coin 1130)
-
-aliceTx1Wit :: Wit
-aliceTx1Wit = makeWitness alicePay tx1Body
+aliceGivesBobAda :: TxIn -> Coin -> Coin -> Coin -> Coin ->
+  Set.Set DCert -> Slot -> TxWits
+aliceGivesBobAda txin coin txfee txdeps txrefs cs s = TxWits txbody wit
+  where
+    aliceCoin = aliceInitCoin + txrefs - (coin + txfee + txdeps)
+    txbody = Tx
+               (Set.fromList [txin])
+               [ TxOut aliceAddr aliceCoin
+               , TxOut bobAddr coin ]
+               cs
+               txfee
+               s
+    wit = Set.fromList [makeWitness alicePay txbody]
 
 tx1 :: TxWits
-tx1 = TxWits tx1Body (Set.fromList [aliceTx1Wit])
-
-tx1id :: TxId
-tx1id = txid tx1Body
+tx1 = aliceGivesBobAda
+        (TxIn genesisId 0)
+        (Coin 3000) (Coin 600) (Coin 0) (Coin 0)
+        Set.empty (Slot 0)
 
 utxo1 :: Map.Map TxIn TxOut
 utxo1 = Map.fromList
        [ (TxIn genesisId 1, TxOut bobAddr (Coin 1000))
-       , (TxIn tx1id 0, TxOut aliceAddr (Coin 5870))
-       , (TxIn tx1id 1, TxOut bobAddr (Coin 3000)) ]
+       , (TxIn (txid $ body tx1) 0, TxOut aliceAddr (Coin 6400))
+       , (TxIn (txid $ body tx1) 1, TxOut bobAddr (Coin 3000)) ]
 
 ls1 :: Either [ValidationError] LedgerState
 ls1 = ledgerState [tx1]
 
-certAlice :: DCert
-certAlice = RegKey $ vKey aliceStake
-certBob :: DCert
-certBob = RegKey $ vKey bobStake
-certPool1 :: DCert
-certPool1 = RegKey $ vKey stakePoolKey1
+tx2 :: TxWits
+tx2 = aliceGivesBobAda
+        (TxIn genesisId 0)
+        (Coin 3000) (Coin 1300) (Coin 3*100) (Coin 0)
+        (Set.fromList
+          [ RegKey $ vKey aliceStake
+          , RegKey $ vKey bobStake
+          , RegKey $ vKey stakePoolKey1
+        ])
+        (Slot 100)
 
-tx2Body :: Tx
-tx2Body = Tx
-          (Set.fromList [TxIn genesisId 0])
-          [ TxOut aliceAddr (Coin 5700)
-          , TxOut bobAddr (Coin 3000) ]
-          (Set.fromList [ certAlice
-                       , certBob
-                       , certPool1 ])
-          (Coin 1300)
 
 utxo2 :: Map.Map TxIn TxOut
 utxo2 = Map.fromList
        [ (TxIn genesisId 1, TxOut bobAddr (Coin 1000))
-       , (TxIn (txid tx2Body) 0, TxOut aliceAddr (Coin 5700))
-       , (TxIn (txid tx2Body) 1, TxOut bobAddr (Coin 3000)) ]
-
-tx2 :: TxWits
-tx2 = TxWits tx2Body (Set.fromList [makeWitness alicePay tx2Body])
+       , (TxIn (txid $ body tx2) 0, TxOut aliceAddr (Coin 5400))
+       , (TxIn (txid $ body tx2) 1, TxOut bobAddr (Coin 3000)) ]
 
 tx3Body :: Tx
 tx3Body = Tx
-          (Set.fromList [TxIn (txid tx2Body) 0])
-          [ TxOut aliceAddr (Coin 4494) ]
+          (Set.fromList [TxIn (txid $ body tx2) 0])
+          [ TxOut aliceAddr (Coin 3950) ]
           (Set.fromList
             [ RegPool stakePool
             , Delegate (Delegation (vKey aliceStake) (vKey stakePoolKey1))
             ])
-          (Coin 1206)
+          (Coin 1200)
+          (Slot 100)
 
 tx3 :: TxWits
 tx3 = TxWits tx3Body (Set.fromList [makeWitness alicePay tx3Body])
@@ -170,8 +170,8 @@ tx3 = TxWits tx3Body (Set.fromList [makeWitness alicePay tx3Body])
 utxo3 :: Map.Map TxIn TxOut
 utxo3 = Map.fromList
        [ (TxIn genesisId 1, TxOut bobAddr (Coin 1000))
-       , (TxIn (txid tx3Body) 0, TxOut aliceAddr (Coin 4494))
-       , (TxIn (txid tx2Body) 1, TxOut bobAddr (Coin 3000)) ]
+       , (TxIn (txid tx3Body) 0, TxOut aliceAddr (Coin 3950))
+       , (TxIn (txid $ body tx2) 1, TxOut bobAddr (Coin 3000)) ]
 
 stakeKeyRegistration1 :: DelegationState
 stakeKeyRegistration1 = LedgerState.emptyDelegation
@@ -196,30 +196,61 @@ stakePool = StakePool
             , poolAltAcnt = Nothing  --          or here?
             }
 
+stakePoolUpate :: StakePool
+stakePoolUpate = StakePool
+                   {
+                     poolPubKey = vKey stakePoolKey1
+                   , poolPledges = Map.empty
+                   , poolCost = Coin 100      -- TODO: what is a sensible value?
+                   , poolMargin = 1 % 2     --          or here?
+                   , poolAltAcnt = Nothing  --          or here?
+                   }
+
+tx4Body :: Tx
+tx4Body = Tx
+          (Set.fromList [TxIn (txid $ body tx3) 0])
+          [ TxOut aliceAddr (Coin 2950) ] -- Note the deposit is not charged
+          (Set.fromList [ RegPool stakePoolUpate ])
+          (Coin 1000)
+          (Slot 100)
+
+tx4 :: TxWits
+tx4 = TxWits tx4Body (Set.fromList [makeWitness alicePay tx4Body])
+
+utxo4 :: Map.Map TxIn TxOut
+utxo4 = Map.fromList
+       [ (TxIn genesisId 1, TxOut bobAddr (Coin 1000))
+       , (TxIn (txid tx4Body) 0, TxOut aliceAddr (Coin 2950))
+       , (TxIn (txid $ body tx2) 1, TxOut bobAddr (Coin 3000)) ]
+
+
+
 testsValidLedger :: TestTree
 testsValidLedger =
   testGroup "Tests with valid transactions in ledger."
-    [ testCase "Valid Ledger - Alice gives Bob 3 of her 10 coins" $
+    [ testCase "Valid Ledger - Alice gives Bob 3000 of her 10000 lovelace" $
         testLedgerValidTransactions ls1 utxo1
       , testGroup "Tests for stake delegation."
           [ testCase "Valid stake key registration." $
               testValidStakeKeyRegistration tx2 utxo2 stakeKeyRegistration1
           , testCase "Valid stake delegation from Alice to stake pool." $
-              testValidDelegation [tx2, tx3] utxo3 stakeKeyRegistration1
+              testValidDelegation [tx2, tx3] utxo3 stakeKeyRegistration1 stakePool
+          , testCase "Update stake pool parameters" $
+              testValidDelegation [tx2, tx3, tx4] utxo4 stakeKeyRegistration1 stakePoolUpate
           ]
     ]
 
 testSpendNonexistentInput :: Assertion
 testSpendNonexistentInput =
   let
-    txbody = Tx
-              (Set.fromList [TxIn genesisId 42])
-              [ TxOut aliceAddr (Coin 10000) ]
-              Set.empty
-              (Coin 1500)
-    aliceWit = makeWitness alicePay txbody
-    tx = TxWits txbody (Set.fromList [aliceWit])
-  in ledgerState [tx] @?= Left [BadInputs, ValueNotConserved, InsufficientWitnesses]
+    tx = aliceGivesBobAda
+           (TxIn genesisId 42)
+           (Coin 3000) (Coin 1500) (Coin 0) (Coin 0)
+           Set.empty (Slot 100)
+  in ledgerState [tx] @?=
+       Left [ BadInputs
+            , ValueNotConserved (Coin 0) (Coin 10000)
+            , InsufficientWitnesses]
   -- Note that BadInputs implies InsufficientWitnesses
 
 testWitnessNotIncluded :: Assertion
@@ -231,6 +262,7 @@ testWitnessNotIncluded =
               , TxOut bobAddr (Coin 3000) ]
               Set.empty
               (Coin 566)
+              (Slot 100)
     tx = TxWits txbody Set.empty
   in ledgerState [tx] @?= Left [InsufficientWitnesses]
 
@@ -242,6 +274,7 @@ testSpendNotOwnedUTxO =
               [ TxOut aliceAddr (Coin 232)]
               Set.empty
               (Coin 768)
+              (Slot 100)
     aliceWit = makeWitness alicePay txbody
     tx = TxWits txbody (Set.fromList [aliceWit])
   in ledgerState [tx] @?= Left [InsufficientWitnesses]
@@ -254,11 +287,13 @@ testInvalidTransaction =
               [ TxOut aliceAddr (Coin 230)]
               Set.empty
               (Coin 770)
+              (Slot 100)
     tx2body = Tx
               (Set.fromList [TxIn genesisId 0])
               [ TxOut aliceAddr (Coin 19230)]
               Set.empty
               (Coin 770)
+              (Slot 100)
     aliceWit = makeWitness alicePay tx2body
     tx = TxWits txbody (Set.fromList [aliceWit])
   in ledgerState [tx] @?= Left [InsufficientWitnesses]
@@ -271,9 +306,33 @@ testEmptyInputSet =
               [ TxOut aliceAddr (Coin 1)]
               Set.empty
               (Coin 584)
+              (Slot 100)
     aliceWit = makeWitness alicePay txbody
     tx = TxWits txbody (Set.fromList [aliceWit])
-  in ledgerState [tx] @?= Left [InputSetEmpty, ValueNotConserved, InsufficientWitnesses]
+  in ledgerState [tx] @?=
+       Left [ InputSetEmpty
+            , ValueNotConserved (Coin 0) (Coin 585)
+            , InsufficientWitnesses]
+
+testFeeTooSmall :: Assertion
+testFeeTooSmall =
+  let
+    tx = aliceGivesBobAda
+           (TxIn genesisId 0)
+           (Coin 3000) (Coin 1) (Coin 0) (Coin 0)
+           Set.empty (Slot 100)
+  in ledgerState [tx] @?=
+       Left [ FeeTooSmall (Coin 538) (Coin 1) ]
+
+testExpiredTx :: Assertion
+testExpiredTx =
+  let
+    tx = aliceGivesBobAda
+           (TxIn genesisId 0)
+           (Coin 3000) (Coin 600) (Coin 0) (Coin 0)
+           Set.empty (Slot 0)
+  in (asStateTransition (Slot 1) genesis tx) @?=
+       Left [ Expired (Slot 0) (Slot 1) ]
 
 testsInvalidLedger :: TestTree
 testsInvalidLedger = testGroup "Tests with invalid transactions in ledger"
@@ -282,6 +341,8 @@ testsInvalidLedger = testGroup "Tests with invalid transactions in ledger"
   , testCase "Invalid Ledger - Alice tries to spend Bob's UTxO" testSpendNotOwnedUTxO
   , testCase "Invalid Ledger - Alice provides witness of wrong UTxO" testInvalidTransaction
   , testCase "Invalid Ledger - Alice's transaction does not consume input" testEmptyInputSet
+  , testCase "Invalid Ledger - Alice's fee is too small" testFeeTooSmall
+  , testCase "Invalid Ledger - Alice's transaciton has expired" testExpiredTx
   ]
 
 unitTests :: TestTree


### PR DESCRIPTION
This PR add support for deposits and refunds.  In order to do this, transaction time-to-live was also added.

Some other small notes:

- the stake pool map in the ledger state is now split into two maps (match the spec).
- The epoch was removed from the ledger state (this lives in the environment, not the state).
- I changed the `minfee` calculation to be based on the "bytes" of the transaction body (instead of the full transaction with witnesses).
- I tried to clean up some of the boilerplate involved in the unit tests, by making a generic method for when `Alice` wants to send coin to `Bob`.

closes #86 