### PR TITLE
changing Coin to Lovelace

### DIFF
--- a/hs/src/Delegation/Certificates.hs
+++ b/hs/src/Delegation/Certificates.hs
@@ -6,7 +6,7 @@ module Delegation.Certificates
   , refund
   ) where
 
-import           Coin (Coin(..))
+import           Lovelace (Lovelace(..))
 import           Keys
 import           Slot (Duration(..), Epoch(..))
 import           PrtlConsts (PrtlConsts(..))
@@ -37,13 +37,13 @@ authDCert key cert = getRequiredSigningKey cert == key
     getRequiredSigningKey (Delegate delegation) = delegator delegation
 
 -- |Retrieve the deposit amount for a certificate
-dvalue :: DCert -> PrtlConsts -> Coin
+dvalue :: DCert -> PrtlConsts -> Lovelace
 dvalue (RegKey _) = keyDeposit
 dvalue (RegPool _) = poolDeposit
-dvalue _ = const $ Coin 0
+dvalue _ = const $ Lovelace 0
 
 -- |Compute a refund on a deposit
-refund :: DCert -> PrtlConsts -> Duration -> Coin
+refund :: DCert -> PrtlConsts -> Duration -> Lovelace
 refund cert pc dur = floor refund'
   where
     dep = fromIntegral $ dvalue cert pc

--- a/hs/src/Delegation/StakePool.hs
+++ b/hs/src/Delegation/StakePool.hs
@@ -7,14 +7,14 @@ import           Data.Map        (Map)
 import           Data.Ratio
 import           Numeric.Natural
 
-import           Coin            (Coin)
+import           Lovelace        (Lovelace)
 import           Keys
 
 -- |A stake pool.
 data StakePool = StakePool
                    { poolPubKey  :: VKey
-                   , poolPledges :: Map VKey Coin -- TODO not updated currently
-                   , poolCost    :: Coin
+                   , poolPledges :: Map VKey Lovelace -- TODO not updated currently
+                   , poolCost    :: Lovelace
                    , poolMargin  :: Ratio Natural
                    , poolAltAcnt :: Maybe HashKey
                    } deriving (Show, Eq, Ord)

--- a/hs/src/Lovelace.hs
+++ b/hs/src/Lovelace.hs
@@ -1,20 +1,20 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DerivingVia #-}
 
-module Coin
+module Lovelace
     (
-     Coin(..)
-    , splitCoin
+     Lovelace(..)
+    , splitLovelace
     ) where
 
 import           Data.Monoid (Sum(..))
 import           Numeric.Natural (Natural)
 
 -- |The amount of value held by a transaction output.
-newtype Coin = Coin Natural
+newtype Lovelace = Lovelace Natural
   deriving (Show, Eq, Ord, Num, Integral, Real, Enum)
   deriving (Semigroup, Monoid) via (Sum Natural)
 
-splitCoin :: Coin -> Natural -> (Coin, Coin)
-splitCoin (Coin n) 0 = (Coin 0, Coin n)
-splitCoin (Coin n) m = (Coin $ n `div` m, Coin $ n `rem` m)
+splitLovelace :: Lovelace -> Natural -> (Lovelace, Lovelace)
+splitLovelace (Lovelace n) 0 = (Lovelace 0, Lovelace n)
+splitLovelace (Lovelace n) m = (Lovelace $ n `div` m, Lovelace $ n `rem` m)

--- a/hs/src/PrtlConsts.hs
+++ b/hs/src/PrtlConsts.hs
@@ -6,7 +6,7 @@ module PrtlConsts
 import           Data.Ratio      (Rational)
 import           Numeric.Natural (Natural)
 
-import           Coin            (Coin (..))
+import           Lovelace        (Lovelace (..))
 
 data PrtlConsts =
   PrtlConsts
@@ -15,9 +15,9 @@ data PrtlConsts =
     -- |The constant factor for the minimum fee calculation
   , minfeeB     :: Natural
     -- |The amount of a key registration deposit
-  , keyDeposit  :: Coin
+  , keyDeposit  :: Lovelace
     -- |The amount of a pool registration deposit
-  , poolDeposit :: Coin
+  , poolDeposit :: Lovelace
     -- |The minimum percent refund guarantee
   , minRefund   :: Rational
     -- |The deposit decay rate

--- a/hs/src/UTxO.hs
+++ b/hs/src/UTxO.hs
@@ -43,7 +43,7 @@ import           Data.Set                (Set)
 import qualified Data.Set                as Set
 import           Numeric.Natural         (Natural)
 
-import           Coin                    (Coin (..))
+import           Lovelace                (Lovelace (..))
 import           Keys
 import           PrtlConsts (PrtlConsts(..))
 import           Slot (Slot(..))
@@ -66,7 +66,7 @@ data Addr = AddrTxin HashKey HashKey
 data TxIn = TxIn TxId Natural deriving (Show, Eq, Ord)
 
 -- |The output of a UTxO.
-data TxOut = TxOut Addr Coin deriving (Show, Eq, Ord)
+data TxOut = TxOut Addr Lovelace deriving (Show, Eq, Ord)
 
 -- |The unspent transaction outputs.
 newtype UTxO = UTxO (Map TxIn TxOut) deriving (Show, Eq, Ord)
@@ -75,7 +75,7 @@ newtype UTxO = UTxO (Map TxIn TxOut) deriving (Show, Eq, Ord)
 data Tx = Tx { inputs  :: !(Set TxIn)
              , outputs :: [TxOut]
              , certs   :: !(Set DCert)
-             , fee     :: Coin
+             , fee     :: Lovelace
              , ttl     :: Slot
              } deriving (Show, Eq, Ord)
 
@@ -127,15 +127,15 @@ union :: UTxO -> UTxO -> UTxO
 union (UTxO a) (UTxO b) = UTxO $ Map.union a b
 
 -- |Determine the total balance contained in the UTxO.
-balance :: UTxO -> Coin
-balance (UTxO utxo) = foldr addCoins mempty utxo
-  where addCoins (TxOut _ a) b = a <> b
+balance :: UTxO -> Lovelace
+balance (UTxO utxo) = foldr addLovelace mempty utxo
+  where addLovelace (TxOut _ a) b = a <> b
 
 -- |Determine the total deposit amount needed
-deposits :: PrtlConsts -> Map.Map HashKey Slot -> Tx -> Coin
-deposits pc stpools tx = foldl f (Coin 0) cs
+deposits :: PrtlConsts -> Map.Map HashKey Slot -> Tx -> Lovelace
+deposits pc stpools tx = foldl f (Lovelace 0) cs
   where
-    f coin cert = coin + dvalue cert pc
+    f lovelace cert = lovelace + dvalue cert pc
     notRegisteredPool (RegPool pool) = Map.notMember (hashKey $ poolPubKey pool) stpools
     notRegisteredPool _ = True
     cs = Set.filter notRegisteredPool (certs tx)

--- a/hs/test/Mutator.hs
+++ b/hs/test/Mutator.hs
@@ -8,7 +8,7 @@ data. Input values are mutated depending on their value.
 
 module Mutator
     ( mutateNat
-    , mutateCoin
+    , mutateLovelace
     , mutateTxWits
     , mutateTx
     , mutateDCert
@@ -23,7 +23,7 @@ import Hedgehog
 import qualified Hedgehog.Gen    as Gen
 import qualified Hedgehog.Range  as Range
 
-import Coin
+import Lovelace
 import           Delegation.Certificates  (DCert(..))
 import           Delegation.StakePool
 import Keys
@@ -53,9 +53,9 @@ mutateNat :: Natural -> Natural -> Natural -> Gen Natural
 mutateNat lower upper n =
   Gen.choice [mutateId n, mutateNatRange lower upper n, mutateNatSmall n]
 
--- | Mutator for 'Coin' values, based on mutation of the contained value field.
-mutateCoin :: Natural -> Natural -> Coin -> Gen Coin
-mutateCoin lower upper (Coin val) = Coin <$> mutateNat lower upper val
+-- | Mutator for 'Lovelace' values, based on mutation of the contained value field.
+mutateLovelace :: Natural -> Natural -> Lovelace -> Gen Lovelace
+mutateLovelace lower upper (Lovelace val) = Lovelace <$> mutateNat lower upper val
 
 -- | Mutator of 'TxWits' which mutates the contained transaction
 mutateTxWits :: TxWits -> Gen TxWits
@@ -100,11 +100,11 @@ mutateOutputs (txout:txouts) = do
   dropTxOut <- Gen.enumBounded
   pure $ if dropTxOut then mtxouts else mtxout:mtxouts
 
--- | Mutator for a single 'TxOut' which mutates the associated 'Coin' value of
+-- | Mutator for a single 'TxOut' which mutates the associated 'Lovelace' value of
 -- the output.
 mutateOutput :: TxOut -> Gen TxOut
 mutateOutput (TxOut addr c) = do
-  c' <- mutateCoin 0 100 c
+  c' <- mutateLovelace 0 100 c
   pure $ TxOut addr c'
 
 
@@ -117,7 +117,7 @@ mutateOutput (TxOut addr c) = do
 getAnyStakeKey :: KeyPairs -> Gen VKey
 getAnyStakeKey keys = vKey . snd <$> Gen.element keys
 
--- | Mutate 'Epoch' analogously to 'Coin' data.
+-- | Mutate 'Epoch' analogously to 'Lovelace' data.
 mutateEpoch :: Natural -> Natural -> Epoch -> Gen Epoch
 mutateEpoch lower upper (Epoch val) = Epoch <$> mutateNat lower upper val
 
@@ -140,7 +140,7 @@ mutateDCert keys _ (RetirePool _ epoch@(Epoch e)) = do
 
 mutateDCert keys _ (RegPool (StakePool _ pledges cost margin altacnt)) = do
   key'    <- getAnyStakeKey keys
-  cost'   <- mutateCoin 0 100 cost
+  cost'   <- mutateLovelace 0 100 cost
   p' <- mutateNat 0 100 (numerator margin)
   pure $ RegPool (StakePool key' pledges cost' (p' % 100) altacnt)
 


### PR DESCRIPTION
This PR changes the name `Coin` to `Lovelace`.  The name `Lovelace` is more clear, since `Coin` could refer to ada or lovelace.

I was hoping to make this change when it would not be very disruptive.  It was very quick to make this change, so if it does end up being a bad time we can abandon it until later.