### PR TITLE
Detect redundant witnesses in transactions

### DIFF
--- a/hs/test/Generator.hs
+++ b/hs/test/Generator.hs
@@ -11,11 +11,13 @@ module Generator
     , genNonemptyGenesisState
     , genStateTx
     , genValidStateTx
+    , genValidStateTxKeys
     , genDelegationData
     , genDelegation
     , genStakePool
     , genDCertRegPool
     , genDCertDelegate
+    , genKeyPairs
     ) where
 
 import qualified Data.Map        as Map
@@ -254,6 +256,12 @@ genValidStateTx = do
   (keyPairs, steps, _, ls) <- genValidLedgerState
   (txfee', entry, ls')     <- genValidSuccessorState keyPairs ls
   pure (ls, steps, txfee', entry, ls')
+
+genValidStateTxKeys :: Gen (LedgerState, Natural, Coin, TxWits, LedgerState, KeyPairs)
+genValidStateTxKeys = do
+  (keyPairs, steps, _, ls) <- genValidLedgerState
+  (txfee', entry, ls')     <- genValidSuccessorState keyPairs ls
+  pure (ls, steps, txfee', entry, ls', keyPairs)
 
 genStateTx :: Gen (LedgerState, Natural, Coin, TxWits, LedgerValidation)
 genStateTx = do

--- a/hs/test/UnitTests.hs
+++ b/hs/test/UnitTests.hs
@@ -340,7 +340,7 @@ testEmptyInputSet =
   in ledgerState [tx] @?=
        Left [ InputSetEmpty
             , ValueNotConserved (Coin 0) (Coin 585)
-            , InsufficientWitnesses]
+            , RedundantWitnesses]
 
 testFeeTooSmall :: Assertion
 testFeeTooSmall =


### PR DESCRIPTION
If a redundant signature is detected, i.e., a signature using a key which is not required to spent output, the transaction will not be validated.