### PR TITLE
Latex/small edits

### DIFF
--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -174,7 +174,7 @@ $\Duration$ here by $\var{dur}$).
   \label{fig:delegation-definitons}
 \end{figure}
 
-
+\clearpage
 
 \subsection{Delegation Transitions}
 \label{sec:deleg-trans}
@@ -269,6 +269,7 @@ certificate (contained in a signal transaction).
   \label{fig:delegation-transitions}
 \end{figure}
 
+\clearpage
 
 \subsection{Delegation Rules}
 \label{sec:deleg-rules}
@@ -444,7 +445,7 @@ being delegated to.
   \label{fig:delegation-rules}
 \end{figure}
 
-
+\clearpage
 
 \subsection{Stake Pool Rules}
 \label{sec:pool-rules}

--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -375,7 +375,7 @@ being delegated to.
       \trans{deleg}{\var{c}}
       \left(
       \begin{array}{rcl}
-        \var{stkeys} & \union & \{\var{hk} \mapsto slot\}\\
+        \var{stkeysFOO} & \union & \{\var{hk} \mapsto slot\}\\
         \var{rewards} & \unionoverrideRight & \{\addrRw \var{hk} \mapsto 0\}\\
         \var{delegations} \\
         \var{pointeraddr} & \union & \{(slot,\fun{txSlotIx}~\var{tx},
@@ -403,7 +403,7 @@ being delegated to.
       \trans{deleg}{\var{c}}
       \left(
       \begin{array}{rcl}
-        \{\var{hk}\} & \subtractdom & \var{stkeys}\\
+        \{\var{hkFOO}\} & \subtractdom & \var{stkeys}\\
         \{\addrRw \var{hk}\} & \subtractdom & \var{rewards} \\
         \{\var{hk}\} & \subtractdom & \var{delegations} \\
         \{(slot,\fun{txSlotIx}~\var{tx},
@@ -433,7 +433,7 @@ being delegated to.
       \begin{array}{rcl}
         \var{stkeys} \\
         \var{rewards} \\
-        \var{delegations} & \unionoverrideRight & \{\var{hk} \mapsto \dpool c\} \\
+        \var{delegationsFOO} & \unionoverrideRight & \{\var{hk} \mapsto \dpool c\} \\
         \var{pointeraddr}
       \end{array}
       \right)
@@ -522,10 +522,10 @@ that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
       \trans{pool}{c}
       \left(
       \begin{array}{rcl}
-        \var{stpools} & \union
-                      & \{\var{hk} \mapsto \var{slot}\} \\
-        \var{pparams} & \union
-                      & \{\var{hk} \mapsto \var{stakepool}\} \\
+        \varUpdate{\var{stpools}} & \varUpdate{\union}
+                                  & \varUpdate{\{\var{hk} \mapsto \var{slot}\}} \\
+        \varUpdate{\var{pparams}} & \varUpdate{\union}
+                                  & \varUpdate{\{\var{hk} \mapsto \var{stakepool}\}} \\
        \var{retiring} \\
       \end{array}
       \right)
@@ -553,9 +553,9 @@ that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
       \left(
       \begin{array}{rcl}
         \var{stpools} \\
-        \var{pparams} & \unionoverrideRight
-                      & \{\var{hk} \mapsto \var{stakepool}\} \\
-        \{\var{hk}\} & \subtractdom & \var{retiring} \\
+        \varUpdate{\var{pparams}} & \varUpdate{\unionoverrideRight}
+                                  & \varUpdate{\{\var{hk} \mapsto \var{stakepool}\}}\\
+        \varUpdate{\{\var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{retiring}} \\
       \end{array}
       \right)
     }
@@ -585,7 +585,8 @@ that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
       \begin{array}{rcl}
         \var{stpools} \\
         \var{pparams} \\
-        \var{retiring} & \unionoverrideRight & \{\var{hk} \mapsto \var{e}\} \\
+        \varUpdate{\var{retiring}} & \varUpdate{\unionoverrideRight}
+                                   & \varUpdate{\{\var{hk} \mapsto \var{e}\}} \\
       \end{array}
     \right)
   }
@@ -669,7 +670,7 @@ and can only be applied to \textit{either} register (deregister) a key,
       \trans{delpl}{c}
       \left(
       \begin{array}{rcl}
-        \var{dstate'} \\
+        \varUpdate{\var{dstate'}} \\
         \var{pstate}
       \end{array}
       \right)
@@ -698,7 +699,7 @@ and can only be applied to \textit{either} register (deregister) a key,
       \left(
       \begin{array}{rcl}
         \var{dstate} \\
-        \var{pstate'}
+        \varUpdate{\var{pstate'}}
       \end{array}
       \right)
     }
@@ -791,7 +792,7 @@ whole transaction will be invalid.
     \vdash
       \var{dwstate}
       \trans{delegs}{\Gamma; c}
-      \var{dwstate''}
+      \varUpdate{\var{dwstate''}}
     }
     \label{eq:rule:sequence-delegation-inductive}
   \end{equation}

--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -360,7 +360,8 @@ being delegated to.
   \begin{equation}\label{eq:deleg-reg}
     \inference[Deleg-Reg]
     {
-      \var{c}\in\DCertRegKey & \cauthor{c} = hk & hk \notin \dom \var{stkeys}
+      \var{c}\in\DCertRegKey & \cauthor{c} = hk \\
+      hk \notin \dom \var{stkeys} & ptr = (slot,~\fun{txSlotIx}~\var{tx},~\fun{cIx}~\var{c})
     }
     {
       \var{slot} \vdash
@@ -375,11 +376,10 @@ being delegated to.
       \trans{deleg}{\var{c}}
       \left(
       \begin{array}{rcl}
-        \var{stkeysFOO} & \union & \{\var{hk} \mapsto slot\}\\
-        \var{rewards} & \unionoverrideRight & \{\addrRw \var{hk} \mapsto 0\}\\
+        \varUpdate{\var{stkeys}} & \varUpdate{\union} & \varUpdate{\{\var{hk} \mapsto slot\}} \\
+        \varUpdate{\var{rewards}} & \varUpdate{\unionoverrideRight} & \varUpdate{\{\addrRw \var{hk} \mapsto 0\}}\\
         \var{delegations} \\
-        \var{pointeraddr} & \union & \{(slot,\fun{txSlotIx}~\var{tx},
-          \fun{cIx}~\var{c}) \mapsto \var{hk}\}
+        \varUpdate{\var{pointeraddr}} & \varUpdate{\union} & \varUpdate{\{ptr \mapsto \var{hk}\}}
       \end{array}
       \right)
     }
@@ -388,7 +388,8 @@ being delegated to.
   \begin{equation}\label{eq:deleg-dereg}
     \inference[Deleg-Dereg]
     {
-      \var{c}\in \DCertDeRegKey  & \cauthor{c} = hk & hk \in \var{stkeys}
+      \var{c}\in \DCertDeRegKey  & \cauthor{c} = hk \\
+    hk \in \var{stkeys} & ptr = (slot,\fun{txSlotIx}~\var{tx}, \fun{cIx}~\var{c})
     }
     {
       \var{slot} \vdash
@@ -403,11 +404,10 @@ being delegated to.
       \trans{deleg}{\var{c}}
       \left(
       \begin{array}{rcl}
-        \{\var{hkFOO}\} & \subtractdom & \var{stkeys}\\
-        \{\addrRw \var{hk}\} & \subtractdom & \var{rewards} \\
-        \{\var{hk}\} & \subtractdom & \var{delegations} \\
-        \{(slot,\fun{txSlotIx}~\var{tx},
-         \fun{cIx}~\var{c})\} & \subtractdom & \var{pointeraddr} \\
+        \varUpdate{\{\var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{stkeys}} \\
+        \varUpdate{\{\addrRw \var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{rewards}} \\
+        \varUpdate{\{\var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{delegations}} \\
+        \varUpdate{\{ptr\}} & \varUpdate{\subtractdom} & \varUpdate{\var{pointeraddr}} \\
       \end{array}
       \right)
     }
@@ -433,7 +433,8 @@ being delegated to.
       \begin{array}{rcl}
         \var{stkeys} \\
         \var{rewards} \\
-        \var{delegationsFOO} & \unionoverrideRight & \{\var{hk} \mapsto \dpool c\} \\
+        \varUpdate{\var{delegations}} & \varUpdate{\unionoverrideRight}
+                                      & \varUpdate{\{\var{hk} \mapsto \dpool c\}} \\
         \var{pointeraddr}
       \end{array}
       \right)

--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -390,7 +390,7 @@ being delegated to.
     \inference[Deleg-Dereg]
     {
       \var{c}\in \DCertDeRegKey  & \cauthor{c} = hk \\
-    hk \in \var{stkeys} & ptr = (slot,\fun{txSlotIx}~\var{tx}, \fun{cIx}~\var{c})
+    hk \in \dom \var{stkeys} & ptr = (slot,\fun{txSlotIx}~\var{tx}, \fun{cIx}~\var{c})
     }
     {
       \var{slot} \vdash
@@ -417,7 +417,7 @@ being delegated to.
   \begin{equation}\label{eq:deleg-deleg}
     \inference[Deleg-Deleg]
     {
-      \var{c}\in \DCertDeleg & \cauthor{c} = hk & hk \in \var{stkeys}
+      \var{c}\in \DCertDeleg & \cauthor{c} = hk & hk \in \dom \var{stkeys}
     }
     {
       \var{slot} \vdash

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -317,11 +317,11 @@ smaller refunds for deposits than were paid upon depositing.
       \trans{accnt}{}
       \left(
         \begin{array}{rcl}
-          \varUpdate{\var{treasury}} & + & \varUpdate{\var{newTreasury}} \\
-          \varUpdate{\var{reserves}} & - & \varUpdate{\var{expansion}} \\
-          \varUpdate{\var{availablePool}} & - & \varUpdate{\var{paidRewards}} \\
+          \varUpdate{\var{treasury}} & \varUpdate{+} & \varUpdate{\var{newTreasury}} \\
+          \varUpdate{\var{reserves}} & \varUpdate{-} & \varUpdate{\var{expansion}} \\
+          \varUpdate{\var{availablePool}} & \varUpdate{-} & \varUpdate{\var{paidRewards}} \\
           \var{stkeys} \\
-          \var{rewardsFoo} & \unionoverridePlus & \var{rewards'} \\
+          \varUpdate{\var{rewards}} & \varUpdate{\unionoverridePlus} & \varUpdate{\var{rewards'}} \\
           \var{delegations} \\
           \var{pointeraddr} \\
         \end{array}

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -169,8 +169,8 @@ function), and $\var{fees}$ value on the ledger is set to 0.
       \left(
         \begin{array}{r}
           \var{utxo} \\
-          \obligation{pc}{stkeys}{stpools}{slot} \\
-          0 \\
+          \varUpdate{\obligation{pc}{stkeys}{stpools}{slot}} \\
+          \varUpdate{0} \\
         \end{array}
       \right)
     }
@@ -317,11 +317,11 @@ smaller refunds for deposits than were paid upon depositing.
       \trans{accnt}{}
       \left(
         \begin{array}{rcl}
-          \var{treasury} & + & \var{newTreasury}\\
-          \var{reserves} & - & \var{expansion} \\
-          \var{availablePool} & - & \var{paidRewards} \\
+          \varUpdate{\var{treasury}} & + & \varUpdate{\var{newTreasury}} \\
+          \varUpdate{\var{reserves}} & - & \varUpdate{\var{expansion}} \\
+          \varUpdate{\var{availablePool}} & - & \varUpdate{\var{paidRewards}} \\
           \var{stkeys} \\
-          \var{rewards} & \unionoverridePlus & \var{rewards'} \\
+          \var{rewardsFoo} & \unionoverridePlus & \var{rewards'} \\
           \var{delegations} \\
           \var{pointeraddr} \\
         \end{array}
@@ -394,9 +394,9 @@ for potential future use.
       \trans{poolclean}{}
       \left(
         \begin{array}{rcl}
-          \var{retired} & \subtractdom & \var{stpools} \\
-          \var{retired} & \subtractdom & \var{pparams} \\
-          \var{retired} & \subtractdom & \var{retiring} \\
+          \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{stpools}} \\
+          \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{pparams}} \\
+          \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{retiring}} \\
         \end{array}
       \right)
     }
@@ -497,7 +497,7 @@ for ease of reading.
         {
           \begin{array}{r}
             \var{utxo} \\
-            \var{oblgNew} \\
+            \varUpdate{oblgNew} \\
             \var{fees} \\
           \end{array}
         }
@@ -508,7 +508,7 @@ for ease of reading.
         {
           \begin{array}{r}
             \var{treasury} \\
-            \var{reserves} + \var{diff} \\
+            \varUpdate{reserves + diff} \\
             \var{rewardPool} \\
             \var{rewards} \\
           \end{array}
@@ -530,8 +530,8 @@ for ease of reading.
       \trans{newpc}{}
       \left(
         \begin{array}{rcl}
-          \var{utxoSt'}\\
-          \var{accnt'} \\
+          \varUpdate{utxoSt'}\\
+          \varUpdate{accnt'} \\
         \end{array}
       \right)
     }
@@ -714,10 +714,10 @@ be the \textit{last slot of the epoch before the boundary}.
       \trans{epoch}{}
       \left(
       \begin{array}{rcl}
-        \var{utxoSt''} \\
-        \var{accnt''} \\
-        \var{dstate'} \\
-        \var{pstate'}
+        \varUpdate{\var{utxoSt''}} \\
+        \varUpdate{\var{accnt''}} \\
+        \varUpdate{\var{dstate'}} \\
+        \varUpdate{\var{pstate'}}
       \end{array}
       \right)
     }

--- a/latex/intro.tex
+++ b/latex/intro.tex
@@ -1,7 +1,7 @@
 This document is a formal specification of the functionality of the ledger
 on the blockchain. The blockchain layer of the
 protocol and the interaction between the ledger and the blockchain
-layer is presented in a separate document, see~\cite{}. The details of the
+layer is presented in a separate document, see~\cite{shelley_consensus}. The details of the
 background and the larger context
 for the design decisions formalized in this document are presented
 in~\cite{delegation_design}

--- a/latex/intro.tex
+++ b/latex/intro.tex
@@ -12,8 +12,18 @@ Specifically, we model the following aspects
 of the functionality of the ledger on the blockchain:
 
 \begin{description}
-\item[Preservation of value] relationship between the total value of input and
-  outputs in a new transaction, and the unspent outputs.
+\item[Preservation of value] Every coin in the system is accounted for,
+  and the total amount is unchanged by every transaction and epoch change.
+  In particular, every coin is accounted for by one of the following categories:
+  \begin{itemize}
+    \item Circulation (UTxO)
+    \item Deposit pool
+    \item Fee pool
+    \item Reserves (monetary expansion)
+    \item Rewards (account addresses)
+    \item Reward Pool (undistributed)
+    \item Treasury
+  \end{itemize}
 \item[Witnesses] authentication of parts of the transaction data by means of
   cryptographic entities (such as signatures and private keys) contained in
   these transactions.

--- a/latex/iohk.sty
+++ b/latex/iohk.sty
@@ -31,7 +31,7 @@
 \newcommand{\nextdef}{\ensuremath{\\[1em]}}
 \newcommand{\where}{\ensuremath{~ ~ \mathbf{where}~ ~ }}
 
-\newcommand{\varUpdate}[1]{\color{Violet}#1}
+\newcommand{\varUpdate}[1]{\boldsymbol{\color{Violet}#1}}
 
 \newenvironment{question}
   {\begin{bclogo}[logo=\bcquestion, couleur=orange!10, arrondi=0.2]{ QUESTION}}

--- a/latex/iohk.sty
+++ b/latex/iohk.sty
@@ -31,6 +31,8 @@
 \newcommand{\nextdef}{\ensuremath{\\[1em]}}
 \newcommand{\where}{\ensuremath{~ ~ \mathbf{where}~ ~ }}
 
+\newcommand{\varUpdate}[1]{\color{Violet}#1}
+
 \newenvironment{question}
   {\begin{bclogo}[logo=\bcquestion, couleur=orange!10, arrondi=0.2]{ QUESTION}}
   {\end{bclogo}}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -311,6 +311,7 @@ it using the corresponding public key.
   \label{fig:crypto-defs}
 \end{figure}
 
+\clearpage
 
 \section{Serialization}
 \label{sec:serialization}
@@ -336,6 +337,7 @@ organization chosen for an implementation.
 \label{sec:delegation}
 \input{delegation.tex}
 
+\clearpage
 
 \section{UTxO}
 \label{sec:utxo}
@@ -656,7 +658,7 @@ Section~\cref{sec:epoch}.
   \label{fig:functions:deposits-decay}
 \end{figure}
 
-
+\clearpage
 
 \subsection{UTxO Transitions}
 \label{sec:state-trans-utxo-1}
@@ -970,6 +972,7 @@ a transaction $\var{tx}$ in the environment $\UTxOEnv$.
   \label{fig:ts-types:utxo}
 \end{figure}
 
+\clearpage
 
 \subsection{UTxO, Fees, and Deposits Ledger Update}
 \label{sec:utxo-ufd}
@@ -1146,6 +1149,7 @@ variable
   This extra condition would be added to \cref{eq:utxo-inductive}.
 \end{note}
 
+\clearpage
 
 \subsection{Rewards Ledger Update}
 \label{sec:utxo-rewards}
@@ -1334,6 +1338,7 @@ rest of the delegation state update is triggered by the cetificate list.
 \label{fig:delegation-total}
 \end{figure}
 
+\clearpage
 
 \subsection{Witnesses}
 \label{sec:witnesses}
@@ -1516,6 +1521,7 @@ being unnecessarily large and full of redundant witnessing.
   \label{fig:rules:utxow}
 \end{figure}
 
+\clearpage
 
 \subsection{Ledger State Transition}
 \label{sec:ledger}
@@ -1630,12 +1636,13 @@ by the given transaction.
   \label{fig:rules:ledger}
 \end{figure}
 
+\clearpage
 
 \section{Epoch Boundary}
 \label{sec:epoch}
 \input{epoch.tex}
 
-
+\clearpage
 
 \section{Properties}
 \label{sec:properties}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -1440,14 +1440,14 @@ Figure~\ref{fig:rules:utxow}):
 \end{itemize}
 
 The purpose of witnessing is make sure that the intended action is authorized by
-the holder of the signing key, providing replay protection as a
-consequence.
-Due to the nature
-of UTxO stype accounting and the structure of rewards accounts,
-this replay protection is needed only to prevent
-the re-application of old certificates. The way this is
-achieved by the above precondition is by requiring a valid signature
-provided by the author of every certificate in a transaction and the
+the holder of the signing key, providing replay protection as a consequence.
+Replay prevention is an inherent property of UTxO stype accounting
+since transacition IDs are unique.
+Delegation certificates and reward withdrawals do not share this property,
+though if we require all witnesses to sign at least one transaction input,
+the replay prevention of UTxO accounting is then provided to any transaction.
+This is achieved by the above precondition by requiring a valid signature
+from the author of every certificate in a transaction, the
 holder of the key for every rewards account emptied, as well as
 hash keys of each of the inputs addresses.
 

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -600,11 +600,11 @@ given slot number) and the
 full-duration decayed refund value ($\fun{currentRefund}$) calculated based on
 the given slot number.
 
-The amount
-decayed for individual keys is then computed by adding the values of $\fun{decayed}~\var{allocs}~\var{pc}~(\fun{ttl}~\var{tx})~\var{c}$
+The amount decayed for individual keys is then computed by adding the values of
+$$\fun{decayed}~\var{allocs}~\var{pc}~(\fun{ttl}~\var{tx})~\var{c}$$
 for each deregistration certificate in a given transaction, and is given by
-$\fun{decayedTx}~\var{pc}~\var{stkeys}~\var{cslot}~\var{c}$. Here, again,
-we use the $\fun{ttl}~\var{tx}$ value in the calculation instead of the current
+$$\fun{decatedTx}~\var{pc}~\var{stkeys}~\var{cslot}~\var{c}$$
+Here, again, we use the $\fun{ttl}~\var{tx}$ value in the calculation instead of the current
 slot number in order to match with the one in the $\fun{keyRefunds}$
 calculation.
 

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -458,7 +458,7 @@ refunds for any key deregistration certificates are, in fact, included in
 the $\var{tx}$ itself - meaning that the coin value of the refund must be
 explicitly specified in the outputs of the transaction. So,
 the value of the included refund must be calculated before this transaction
-is ever processed, and be the same \textit{no matter when} $\var{tx}$
+is ever processed, and be the same \textit{no matter when} the $\var{tx}$
 \textit{is actually processed} in order to for the system to continue to
 satisfy the general accounting property.
 
@@ -490,7 +490,7 @@ is a deliberate simplification choice, which does not introduce any inconsistenc
 into the system rules or properties. In particular, the general accounting
 property is not violated.
 
-Finally, note that that a refund for a resource-releasing certificate in a
+Finally, note that a refund for a resource-releasing certificate in a
 transaction can only be issued if the refund is bigger than the minimum
 transaction fee. In order to receive a refund in this case, the transaction
 body must also contain inputs onto which this refund can be added.

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -1,4 +1,4 @@
-\documentclass[11pt,a4paper]{article}
+\documentclass[11pt,a4paper,dvipsnames]{article}
 \usepackage[margin=2.5cm]{geometry}
 \usepackage{iohk}
 \usepackage{microtype}
@@ -12,7 +12,7 @@
 \usepackage{extarrows}
 \usepackage{slashed}
 \usepackage[colon]{natbib}
-\usepackage[unicode=true,pdftex,pdfa]{hyperref}
+\usepackage[unicode=true,pdftex,pdfa,colorlinks=true]{hyperref}
 \usepackage{xcolor}
 \usepackage[capitalise,noabbrev,nameinlink]{cleveref}
 \usepackage{float}
@@ -1125,9 +1125,9 @@ variable
       \trans{utxo}{tx}
       \left(
       \begin{array}{r}
-        (\txins{tx} \subtractdom \var{utxo}) \cup \txouts{tx}  \\
-        \var{deposits} + \var{depositChange} \\
-        \var{fees} + (\txfee{tx}) + \var{decayed} \\
+        \varUpdate{(\txins{tx} \subtractdom \var{utxo}) \cup \txouts{tx}}  \\
+        \varUpdate{\var{deposits} + \var{depositChange}} \\
+        \varUpdate{\var{fees} + (\txfee{tx}) + \var{decayed}} \\
       \end{array}
       \right)
     }
@@ -1231,7 +1231,7 @@ numbers datatype concern.
       \left(
       \begin{array}{rcl}
         \var{stkeys} \\
-        \fun{reapRewards}~\var{rewards}~\var{wdrls}\\
+        \varUpdate{\fun{reapRewards}~\var{rewards}~\var{wdrls}}\\
         \var{delegations} \\
         \var{pstate}
       \end{array}
@@ -1324,7 +1324,7 @@ rest of the delegation state update is triggered by the cetificate list.
         \trans{delegt}{\var{tx}}
         \left(
         \begin{array}{rcl}
-          \var{dwstate''}
+          \varUpdate{\var{dwstate''}}
         \end{array}
         \right)
       }
@@ -1509,7 +1509,7 @@ being unnecessarily large and full of redundant witnessing.
       \begin{array}{l}
         \var{utxoEnv}
       \end{array}
-      \vdash \var{utxoSt} \trans{utxow}{tx} \var{utxoSt'}
+      \vdash \var{utxoSt} \trans{utxow}{tx} \varUpdate{\var{utxoSt'}}
     }
   \end{equation}
   \caption{UTxO with witnesses inference rules}
@@ -1620,8 +1620,8 @@ by the given transaction.
       \trans{ledger}{tx}
       \left(
         \begin{array}{ll}
-          utxoSt' \\
-          dwstate' \\
+          \varUpdate{utxoSt'} \\
+          \varUpdate{dwstate'} \\
         \end{array}
       \right)
     }

--- a/latex/references.bib
+++ b/latex/references.bib
@@ -36,3 +36,9 @@ Cardano},
   journal = {??},
   year    = {2018},
 }
+
+@article{shelley_consensus,
+  author = {Formal Methods Team, IOHK},
+  title   = {?? - Shelley Consensus},
+  year    = {2018},
+}


### PR DESCRIPTION
Some small edits to the latex document:

- added color: hyper refs are blue, variables that are updated in the conclusion of a state change are violet.
- stub of a reference for a consensus formal spec
- expand preservation of value description
- putting a couple longer equations in math-mode
- rewording replay attack prevention
- couple typos

a part of #122 