### PR TITLE
Pointer addresses

### DIFF
--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -69,8 +69,13 @@ allocated, and the corresponding slot number in which this allocation
 (registration) was made. Here we also introduce pointer address structure
 $\PtrAddr$, which
 we will store associated to every key on the ledger. It is these pointer
-addresses that will will use to retrieve a key associated to an address
-(for example, to check a signature). A variable of this type consists of
+addresses that will will use to retrieve a key associated to an address.
+
+\begin{todo}
+explain what calculations these pointer addresses will be used
+\end{todo}
+
+A variable of this type consists of
 the slot number when transaction (which carried the key registration certificate)
 was processed, the index of the transaction inside that slot, and the index
 of the certificate inside the transaction (i.e. its position in the list of

--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -29,19 +29,6 @@ the registered stake pools, and upcoming stake pool retirements.
 Additionally, the blockchain protocol rewards eligible stake, and so we must
 also include a mapping from active stake keys to rewards.
 
-
-
-\begin{note}
-  The current rules allow for delegation to a non-existent pool.
-  Such stake is not eligible for leader election.
-  This allows for a clean separation between the rules in
-  \cref{fig:delegation-rules} and \cref{fig:pool-rules}.
-  We may, however, later choose to enforce that delegation certificates
-  target a registered pool. It would then make sense to remove
-  mappings in $\var{delegations}$ when stake pools retire.
-\end{note}
-
-
 \subsection{Delegation Definitions}
 \label{sec:deleg-defs}
 
@@ -323,12 +310,25 @@ As a result of this rule, the author's key must be removed from the $\var{stkeys
 and all the rewards, pointer address, and delegations associated with this key must be removed
 from the $\var{rewards}$, $\var{pointeraddr}$, and $\var{delegations}$ parameters also.
 
+Note that we must only allow performing a key deregistration when there
+are no active stake pools associated with this key. This check requires additional
+environment variables. For this reason
+it (and several other checks that need
+additional environment variables to specify a valid delegation state transition)
+are performed in the DELEGT rule, discussed in Section~\ref{sec:utxo-rewards}.
+
 Finally, for creating a delegation (the \cref{eq:deleg-deleg} rule),
 given that the certificate $c$ is of the correct type, we add to the
 $\var{delegations}$ finite map the pair of
 the author's hash key and hash key of the pool being delegated to.
 Again, we require the author's key be a registered key, as it does not make
 sense to allow delegation otherwise.
+
+There is another check which we perform when processing a delegation certificate:
+we must check that the certificate is for delegating to an
+existing stake pool. This, again, is verified in the DELEGT rule, see
+Section~\ref{sec:utxo-rewards}.
+
 The $\var{stkeys}$, $\var{rewards}$, and $\var{pointeraddr}$ parameters are kept constant by
 this rule. The use of union override here allows us to use the same rule
 to perform an update on an existing delegation while keeping the rewards
@@ -468,7 +468,7 @@ in $\var{pparams}$. The author's hash key and associated data
 are also removed from the $\var{retiring}$ parameter to cancel any pending
 retirement for that key.
 
-The second rule, \cref{eq:pool-ret}, starts the pool retirement process. Given a
+The third rule, \cref{eq:pool-ret}, starts the pool retirement process. Given a
 slot number $\var{slot}$, the application of this rule requires that the
 planned retirement epoch $\var{e}$ stated in the certificate is in the future,
 i.e. after

--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -67,13 +67,8 @@ The type $\Allocs$ is a general datatype used to represent both individual and s
 pool resource allocations. It stores, as a finite map, the hash key to which the resource is
 allocated, and the corresponding slot number in which this allocation
 (registration) was made. Here we also introduce pointer address structure
-$\PtrAddr$, which
-we will store associated to every key on the ledger. It is these pointer
-addresses that will will use to retrieve a key associated to an address.
-
-\begin{todo}
-explain what calculations these pointer addresses will be used
-\end{todo}
+$\PtrAddr$, which we will use to index stake keys based on
+when and by what transaction they were registered.
 
 A variable of this type consists of
 the slot number when transaction (which carried the key registration certificate)
@@ -204,9 +199,10 @@ key to which this address is associated. The third
 variable in $\DState$ stores currently registered delegations.
 Delegations ($\var{delegations}$) are also expressed by a finite map, which
 associates a stake key with the hash key of the pool to which it delegates.
-Finally, there a record of which pointer address is associated with which
-registered key is stored in the $\var{pointeraddr}$ variable, also as finite
-map (indexed by the pointer addresses).
+Finally, the finite map $\var{pointeraddr}$ variable stores,
+indexed by pointer addresses,
+the stake keys associated with these pointers. This data is needed for the
+epoch boundary reward calculations, see Section~\ref{sec:epoch}.
 
 The ledger additionally keeps track of the stake pools in a separate state variable
 $\PState$.

--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -24,7 +24,8 @@ which it will retire.
 
 Delegation requires the following to be tracked by the ledger state:
 the registered stake keys, the delegation map from registered stake keys to stake
-pools, the registered stake pools, and upcoming stake pool retirements.
+pools, pointer addresses associated with stakey keys,
+the registered stake pools, and upcoming stake pool retirements.
 Additionally, the blockchain protocol rewards eligible stake, and so we must
 also include a mapping from active stake keys to rewards.
 
@@ -40,22 +41,26 @@ also include a mapping from active stake keys to rewards.
   mappings in $\var{delegations}$ when stake pools retire.
 \end{note}
 
-\clearpage
 
 \subsection{Delegation Definitions}
 \label{sec:deleg-defs}
 
 In \cref{fig:delegation-definitons} we give the delegation primitives.
-Here we introduce the following primitive datatypes used in delegation :
-reward addresses
-(different from base addresses introduced later),
-epochs, slot numbers, and duration (the difference between two slot numbers).
-We also make use of the primitive datatype $\StakePool$, which represents
-constants found in a stake pool registration certificate. We make use of
-these constants after registration is processed and thus they must be kept
-track of.
-The constant $\emax$ gives the number of epochs a stake pool will take to retire.
+Here we introduce the following primitive datatypes used in delegation:
 
+\begin{itemize}
+\item reward addresses: different from base addresses introduced later
+\item indexes: this type is used to index certificates in a transaction,
+index of a transaction inside a slot, outputs inside a transaction,
+and inputs in a UTxO or a transaction
+\item epochs
+\item slot numbers
+\item duration: the difference between two slot numbers
+\item $\StakePool$: constants found in a stake pool registration certificate
+(we must continue to keep track of these after registration is complete)
+\end{itemize}
+
+The constant $\emax$ gives the number of epochs a stake pool will take to retire.
 The type $\DCert$ is a generic certificate type, which can be a registration,
 deregistration or delegation certificate for a key, or a registration/retirement
  certificate for a stake pool. It is denoted as disjoint union in the figure,
@@ -74,16 +79,22 @@ way, a type for transitions describing stake pool-related ledger updates
 The type $\Allocs$ is a general datatype used to represent both individual and stake
 pool resource allocations. It stores, as a finite map, the hash key to which the resource is
 allocated, and the corresponding slot number in which this allocation
-(registration) was made.
+(registration) was made. Here we also introduce pointer address structure
+$\PtrAddr$, which
+we will store associated to every key on the ledger. It is these pointer
+addresses that will will use to retrieve a key associated to an address
+(for example, to check a signature). A variable of this type consists of
+the slot number when transaction (which carried the key registration certificate)
+was processed, the index of the transaction inside that slot, and the index
+of the certificate inside the transaction (i.e. its position in the list of
+the transaction's certificates).
 
-The maps $\fun{hash}$, $\AddrRWD$, $\fun{author}$, $\fun{dpool}$,
+The maps $\fun{hash}$, $\fun{addr_{rwd}}$, $\fun{author}$, $\fun{dpool}$,
 $\fun{stakepool}$,
 $\fun{retire}$, $\fun{epoch}$, and $\fun{slot}$ are all used to
 retrieve specific information about the origin type. The subtraction $\slotminus{}{}$
 of slots gives the number of slots in between (referred to here as
 $\Duration$ here by $\var{dur}$).
-
-
 
 %%
 %% Figure - Delegation Definitions
@@ -93,6 +104,7 @@ $\Duration$ here by $\var{dur}$).
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
+      ix & \Ix & \text{index}\\
       a & \AddrRWD & \text{reward address} \\
       slot & \Slot & \text{absolute slot}\\
       dur & \Duration & \text{duration}\\
@@ -125,7 +137,12 @@ $\Duration$ here by $\var{dur}$).
       & \Allocs
       & hkeys \mapsto slot
       & \HashKey \mapsto \Slot
-      & \text{resource allocations}
+      & \text{resource allocations} \\
+      \var{ptr}
+      & \PtrAddr
+      & (s,t,c)
+      & \powerset{(\Slot*\Ix*\Ix)}
+      & \text{pointer addresses}
     \end{array}
   \end{equation*}
   %
@@ -138,6 +155,12 @@ $\Duration$ here by $\var{dur}$).
   \\
   \fun{author} & \DCert \to \HashKey
   & \text{certificate author}
+  \\
+  \fun{txSlotIx} & \Slot \to \Tx \to \Ix
+  & \text{tx index in slot}
+  \\
+  \fun{cIx} & \DCert \to \Ix
+  & \text{certificate index in tx}
   \\
   \fun{dpool} & \DCertDeleg \to \HashKey
   & \text{pool being delegated to}
@@ -165,7 +188,6 @@ $\Duration$ here by $\var{dur}$).
 \end{figure}
 
 
-\clearpage
 
 \subsection{Delegation Transitions}
 \label{sec:deleg-trans}
@@ -190,6 +212,9 @@ key to which this address is associated. The third
 variable in $\DState$ stores currently registered delegations.
 Delegations ($\var{delegations}$) are also expressed by a finite map, which
 associates a stake key with the hash key of the pool to which it delegates.
+Finally, there a record of which pointer address is associated with which
+registered key is stored in the $\var{pointeraddr}$ variable, also as finite
+map (indexed by the pointer addresses).
 
 The ledger additionally keeps track of the stake pools in a separate state variable
 $\PState$.
@@ -227,6 +252,7 @@ certificate (contained in a signal transaction).
       \var{stkeys} & \Allocs & \text{registered stake keys to creation time}\\
       \var{rewards} & \AddrRWD \mapsto \Coin & \text{rewards}\\
       \var{delegations} & \HashKey \mapsto \HashKey & \text{delegations}\\
+      \var{pointeraddr} & \PtrAddr \mapsto \HashKey & \text{pointer address lookup}\\
     \end{array}\right)
     \\
     \\
@@ -255,7 +281,6 @@ certificate (contained in a signal transaction).
   \label{fig:delegation-transitions}
 \end{figure}
 
-\clearpage
 
 \subsection{Delegation Rules}
 \label{sec:deleg-rules}
@@ -270,9 +295,19 @@ already found in the current list of stake keys.
 
 In order to delegate to a stake pool, a stake key must first be registered.
 When registering a new stake key (the \cref{eq:deleg-reg} inference rule),
-the key must be
-added to the set of stake keys ($\var{stkeys}$), the rewards for the address
-corresponding to that key set to 0, and no new delegations added. Note that
+
+\begin{itemize}
+\item the key must be
+added to the set of stake keys ($\var{stkeys}$),
+\item the rewards for the address
+corresponding to that key set to 0,
+\item the pointer address consisting of the current slot number, the
+index of the transaction in this slot, and the index of the certificate, is
+added to the $\var{pointeraddr}$ finite map, mapping to the new key
+\item no new delegations are added
+\end{itemize}
+
+Note that
 since the hash key corresponding to the address must not have been previously
 registered,
 it should not have any rewards in its associated address. Thus, it is safe
@@ -285,8 +320,8 @@ that the key of the author is indeed a registered stake key
 in order to be able to retrieve its address for the rewards update.
 
 As a result of this rule, the author's key must be removed from the $\var{stkeys}$ list,
-and all the rewards and delegations associated with this key must be removed
-from the $\var{rewards}$ and $\var{delegations}$ parameters also.
+and all the rewards, pointer address, and delegations associated with this key must be removed
+from the $\var{rewards}$, $\var{pointeraddr}$, and $\var{delegations}$ parameters also.
 
 Finally, for creating a delegation (the \cref{eq:deleg-deleg} rule),
 given that the certificate $c$ is of the correct type, we add to the
@@ -294,7 +329,7 @@ $\var{delegations}$ finite map the pair of
 the author's hash key and hash key of the pool being delegated to.
 Again, we require the author's key be a registered key, as it does not make
 sense to allow delegation otherwise.
-The $\var{stkeys}$ and $\var{rewards}$ parameters are kept constant by
+The $\var{stkeys}$, $\var{rewards}$, and $\var{pointeraddr}$ parameters are kept constant by
 this rule. The use of union override here allows us to use the same rule
 to perform an update on an existing delegation while keeping the rewards
 associated with the key accounted for.
@@ -332,7 +367,8 @@ being delegated to.
       \begin{array}{r}
         \var{stkeys} \\
         \var{rewards} \\
-        \var{delegations}
+        \var{delegations} \\
+        \var{pointeraddr}
       \end{array}
       \right)
       \trans{deleg}{\var{c}}
@@ -340,7 +376,9 @@ being delegated to.
       \begin{array}{rcl}
         \var{stkeys} & \union & \{\var{hk} \mapsto slot\}\\
         \var{rewards} & \unionoverrideRight & \{\addrRw \var{hk} \mapsto 0\}\\
-        \var{delegations}
+        \var{delegations} \\
+        \var{pointeraddr} & \union & \{(slot,\fun{txSlotIx}~\var{tx},
+          \fun{cIx}~\var{c}) \mapsto \var{hk}\}
       \end{array}
       \right)
     }
@@ -357,7 +395,8 @@ being delegated to.
       \begin{array}{r}
         \var{stkeys} \\
         \var{rewards} \\
-        \var{delegations}
+        \var{delegations} \\
+        \var{pointeraddr}
       \end{array}
       \right)
       \trans{deleg}{\var{c}}
@@ -365,7 +404,9 @@ being delegated to.
       \begin{array}{rcl}
         \{\var{hk}\} & \subtractdom & \var{stkeys}\\
         \{\addrRw \var{hk}\} & \subtractdom & \var{rewards} \\
-        \{\var{hk}\} & \subtractdom & \var{delegations}
+        \{\var{hk}\} & \subtractdom & \var{delegations} \\
+        \{(slot,\fun{txSlotIx}~\var{tx},
+         \fun{cIx}~\var{c})\} & \subtractdom & \var{pointeraddr} \\
       \end{array}
       \right)
     }
@@ -382,7 +423,8 @@ being delegated to.
       \begin{array}{r}
         \var{stkeys} \\
         \var{rewards} \\
-        \var{delegations}
+        \var{delegations} \\
+        \var{pointeraddr}
       \end{array}
       \right)
       \trans{deleg}{c}
@@ -390,7 +432,8 @@ being delegated to.
       \begin{array}{rcl}
         \var{stkeys} \\
         \var{rewards} \\
-        \var{delegations} & \unionoverrideRight & \{\var{hk} \mapsto \dpool c\}
+        \var{delegations} & \unionoverrideRight & \{\var{hk} \mapsto \dpool c\} \\
+        \var{pointeraddr}
       \end{array}
       \right)
     }
@@ -400,7 +443,6 @@ being delegated to.
 \end{figure}
 
 
-\clearpage
 
 \subsection{Stake Pool Rules}
 \label{sec:pool-rules}

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -56,9 +56,15 @@ pool deposits in a given slot number, $\fun{obligation}$.
 
 Next, we give the type of the function used to calculate additional rewards that will become
 available to be claimed after the boundary. This function is denoted $\fun{reward}$,
-and depends on this epoch's blocks, protocol constants and rewards made available
-for claiming this epoch. Based on these values, the $\fun{reward}$ function
-updates the existing records of the unclaimed coin values in each reward address.
+and depends on this epoch's blocks, protocol constants, the delegation
+and pool states, and existing rewards unclaimed in the previous epoch.
+The $\fun{reward}$ function
+updates the existing records of the unclaimed coin values by adding newly
+accumulated rewards this epoch to the value in each reward address.
+
+\begin{todo}
+  This calculation has been decided on already?
+\end{todo}
 
 The function $\fun{poolRefunds}$ is used to calculate the total refunds
 that must be distributed

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -354,6 +354,14 @@ $\var{pparams}$, and $\var{retiring}$ which correspond to any of the hash keys
 of the stake pools scheduled to retire this epoch are removed from
 these variables.
 
+It is important to note here that we \textit{do not} clean up delegations to
+retired stake pools. While we do not allow registration to non-existent
+stake pools (because that is a meaningless operation likely to be the result
+of an error), delegating to a pool that was once active means that there may
+be stake associated with this delegation. While this stake becomes inactive when
+the pool is retired, the delegations to that pool must remain on the ledger
+for potential future use.
+
 %%
 %% Figure - Pool Clean Rule
 %%

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -304,7 +304,8 @@ smaller refunds for deposits than were paid upon depositing.
           \var{rewardPool} \\
           \var{stkeys} \\
           \var{rewards} \\
-          \var{delegations}
+          \var{delegations} \\
+          \var{pointeraddr} \\
         \end{array}
       \right)
       \trans{accnt}{}
@@ -315,7 +316,8 @@ smaller refunds for deposits than were paid upon depositing.
           \var{availablePool} & - & \var{paidRewards} \\
           \var{stkeys} \\
           \var{rewards} & \unionoverridePlus & \var{rewards'} \\
-          \var{delegations}
+          \var{delegations} \\
+          \var{pointeraddr} \\
         \end{array}
       \right)
     }

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -925,12 +925,7 @@ The $\PrtclConsts$ is needed as part of the environment here in order to
 keep track of parameters such as the $\fun{minfee}$ value, deposits, etc.
 The environment also has variables $\var{stkeys}$ and $\var{stpools}$
 to keep track of the current individual and pool resource allocations,
-the $\var{pointeraddr}$ variable to look up staking keys corresponding to
-pointer addresses, and the current slot number.
-
-\begin{todo}
-  Remove pointeraddr from the UTxOEnv if needed
-\end{todo}
+and the current slot number.
 
 The relevant state variables for a UTxO transition include the UTxO itself,
 as well as the value in the deposits pool and the fees pool.
@@ -948,7 +943,6 @@ a transaction $\var{tx}$ in the environment $\UTxOEnv$.
         \var{pc} & \PrtclConsts & \text{protocol constants}\\
         \var{stkeys} & \Allocs & \text{stake key allocations}\\
         \var{stpools} & \Allocs & \text{stake pool allocations}\\
-        \var{pointeraddr} & \PtrAddr \mapsto \HashKey & \text{pointer addresses}\\
       \end{array}
     \right)
   \end{equation*}
@@ -1119,7 +1113,6 @@ variable
         \var{pc}\\
         \var{stkeys}\\
         \var{stpools}\\
-        \var{pointeraddr} \\
       \end{array}
       \vdash
       \left(

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -53,6 +53,7 @@
 \newcommand{\ledgerState}{\ensuremath{\type{ledgerState}}}
 
 \newcommand{\AddrRWD}{\type{Addr_{rwd}}}
+\newcommand{\PtrAddr}{\type{PtrAddr}}
 \newcommand{\DState}{\type{DState}}
 \newcommand{\DWState}{\type{DWState}}
 \newcommand{\DWEnv}{\type{DWEnv}}
@@ -331,13 +332,10 @@ In this document, the properties and rules we state involving serialization are
 assumed to hold true independently of the storage medium and style of data
 organization chosen for an implementation.
 
-\clearpage
-
 \section{Delegation}
 \label{sec:delegation}
 \input{delegation.tex}
 
-\clearpage
 
 \section{UTxO}
 \label{sec:utxo}
@@ -658,7 +656,7 @@ Section~\cref{sec:epoch}.
   \label{fig:functions:deposits-decay}
 \end{figure}
 
-\clearpage
+
 
 \subsection{UTxO Transitions}
 \label{sec:state-trans-utxo-1}
@@ -667,9 +665,10 @@ The types involved in defining a UTxO and its transitions are presented in
 Figure~\ref{fig:defs:utxo}. Note that here, among other primitive types,
 we introduce $\Addr_{base}$. This is the usual type of address used for
 coin transfers by the transactions. We also introduce the derived type $\Addr$,
-which is a disjoint union of reward and base-type addresses. Using this type,
+which is a disjoint union of base-type, pointer, and reward addresses. Using this type,
 it is possible to do rewards accounting (which we discuss later in this chapter)
-in the same $\UTxO$ style as the base address coin transfers.
+in the same $\UTxO$ style as the base address coin transfers, as well as
+using the staking keys pointer address records in place of base addresses.
 Similar to the certificate structure, each address is either a reward or a base
 address.
 
@@ -758,7 +757,7 @@ account for this address and added to the UTxO.
       \var{addr}
       & \Addr
       & \var{addr}
-      & \Addr_{base} \uniondistinct \AddrRWD
+      & \Addr_{base} \uniondistinct \PtrAddr \uniondistinct \AddrRWD
       & \text{address}\\
       \var{txin}
       & \TxIn
@@ -925,8 +924,9 @@ This environment is made up of several variables.
 The $\PrtclConsts$ is needed as part of the environment here in order to
 keep track of parameters such as the $\fun{minfee}$ value, deposits, etc.
 The environment also has variables $\var{stkeys}$ and $\var{stpools}$
-to keep track of the current individual and pool resource allocations, and
-the current slot number.
+to keep track of the current individual and pool resource allocations,
+the $\var{pointeraddr}$ variable to look up staking keys corresponding to
+pointer addresses, and the current slot number.
 
 The relevant state variables for a UTxO transition include the UTxO itself,
 as well as the value in the deposits pool and the fees pool.
@@ -944,6 +944,7 @@ a transaction $\var{tx}$ in the environment $\UTxOEnv$.
         \var{pc} & \PrtclConsts & \text{protocol constants}\\
         \var{stkeys} & \Allocs & \text{stake key allocations}\\
         \var{stpools} & \Allocs & \text{stake pool allocations}\\
+        \var{pointeraddr} & \PtrAddr \mapsto \HashKey & \text{pointer addresses}\\
       \end{array}
     \right)
   \end{equation*}
@@ -971,7 +972,6 @@ a transaction $\var{tx}$ in the environment $\UTxOEnv$.
   \label{fig:ts-types:utxo}
 \end{figure}
 
-\clearpage
 
 \subsection{UTxO, Fees, and Deposits Ledger Update}
 \label{sec:utxo-ufd}
@@ -1115,6 +1115,7 @@ variable
         \var{pc}\\
         \var{stkeys}\\
         \var{stpools}\\
+        \var{pointeraddr} \\
       \end{array}
       \vdash
       \left(
@@ -1148,7 +1149,6 @@ variable
   This extra condition would be added to \cref{eq:utxo-inductive}.
 \end{note}
 
-\clearpage
 
 \subsection{Rewards Ledger Update}
 \label{sec:utxo-rewards}
@@ -1330,7 +1330,6 @@ rest of the delegation state update is triggered by the cetificate list.
 \label{fig:delegation-total}
 \end{figure}
 
-\clearpage
 
 \subsection{Witnesses}
 \label{sec:witnesses}
@@ -1346,9 +1345,7 @@ A transaction is witnessed by
 a signature and a verification key corresponding to this signature, which can
 be obtained from the the transaction by applying the $\fun{txwits}$ function.
 The witnesses for each certificate in a transaction are obtained by applying $\fun{dwits}$
-to the certificate. The
-$\fun{hashKey_{spend}}$ map associates to an address the hash of the spending key
-at this address.
+to the certificate.
 
 \begin{figure}
   \emph{Abstract types}
@@ -1373,8 +1370,8 @@ at this address.
       & \text{delegation certificates in a transaction}\\
       \fun{txwits} & \Tx \to \powerset{\left(\VKey \times \Sig\right)}
       & \text{witnesses of a transaction}\\
-      \fun{hashKey_{spend}} & \Addr \mapsto \HashKey
-      & \text{hashKey of a spending key in an address}\\
+%      \fun{hashKey_{spend}} & \Addr \mapsto \HashKey
+%      & \text{hashKey of a spending key in an address}\\
     \end{array}
   \end{equation*}
   \caption{Definitions used in the UTxO transition system with witnesses}
@@ -1395,9 +1392,10 @@ the address in the corresponding $\var{txout}$ in the UTxO.
     & \addr{}{} \in \UTxO \to \TxIn \mapsto \Addr & \text{address of an input}\\
     & \addr{utxo} = \{ i \mapsto a \mid i \mapsto (a, \wcard) \in \var{utxo} \} \\
     \nextdef
-    & \fun{addr_h} \in \UTxO \to \TxIn \mapsto \HashKey & \text{hashKey of an input address}\\
-    & \fun{addr_h}~utxo = \{ i \mapsto h \mid i \mapsto (a, \wcard) \in \var{utxo}
-      \wedge a \mapsto h \in \fun{hashKey_{spend}} \}
+    & \fun{addr_h} \in \UTxO \to \TxIn \mapsto \HashKey & \text{hashKey of a pointer address}\\
+    & \fun{addr_h}~utxo~\var{pointeraddr} = \\
+    & \{ i \mapsto h \mid i \mapsto (a, \wcard) \in \var{utxo}
+      \wedge a \mapsto h \in \var{pointeraddr} \}
   \end{align*}
   \caption{Functions used in rules witnesses}
   \label{fig:derived-defs:utxow}
@@ -1417,7 +1415,7 @@ Figure~\ref{fig:rules:utxow}):
  \item For each input $\var{i}$ of the signal transaction $\var{tx}$,
  there exists a (unique) verifiable witness (there could be more than one valid
  key-signature pair serving as a witness) such that the hash of the spending key
- of the address corresponding to the output of $\var{i}$ in the current UTxO
+ of the pointer address corresponding to the output of $\var{i}$ in the current UTxO
  is the same as the hash of the verification key of the witness.
 
  \item For each certificate in $\var{tx}$, the signature of the transaction
@@ -1483,7 +1481,7 @@ being unnecessarily large and full of redundant witnessing.
       \forall i \in \txins{tx} \cdot \exists! (\var{vk}, \sigma) \in \txwits{\var{tx}}
       \cdot \\
      \mathcal{V}_{\var{vk}}{\serialised{\txdata{tx}}}_{\sigma}
-     \wedge  \fun{addr_h}~{utxoSt}~i = \hashKey{vk}\\
+     \wedge  \fun{addr_h}~{utxo}~{pointeraddr}~i = \hashKey{vk}\\
      ~ \\
       & \forall c \in \fun{dcerts}~{tx}, \dwit{c} = (\var{vk}, \sigma)
       \cdot \\
@@ -1505,7 +1503,6 @@ being unnecessarily large and full of redundant witnessing.
   \label{fig:rules:utxow}
 \end{figure}
 
-\clearpage
 
 \subsection{Ledger State Transition}
 \label{sec:ledger}
@@ -1582,10 +1579,7 @@ by the given transaction.
     {
       {
         \begin{array}{r}
-        slot\\
-        pc\\
-        stkeys\\
-        stpools\\
+        \var{utxoEnv}
         \end{array}
       }
       \vdash \var{utxoSt} \trans{utxow}{tx} \var{utxoSt'}\\~\\~\\
@@ -1623,14 +1617,12 @@ by the given transaction.
   \label{fig:rules:ledger}
 \end{figure}
 
-\clearpage
 
 \section{Epoch Boundary}
 \label{sec:epoch}
 \input{epoch.tex}
 
 
-\clearpage
 
 \section{Properties}
 \label{sec:properties}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -1249,8 +1249,9 @@ numbers datatype concern.
 In Figure~\ref{fig:delegation-total}, we present the inference rule for
 the total delegation state transition. This rule is a composition of the
 DELRWDS rule above and the DELEGS $\DWState$ transition defined in
-Section~\ref{sec:delegation}. Several conditions must be satisfied for this
-rule to be applied:
+Section~\ref{sec:delegation}. Having all the the delegation state data as well
+as all the data in a transaction in one place allows us to perform the following
+necassary remaining checks:
 
 \begin{itemize}
 \item A transaction cannot register a key and simultaneously request
@@ -1259,11 +1260,15 @@ rewards to the associated address
 associated with any key that is being deregistered
 \item A transaction cannot request to deregister an individual key
 associated with an existing stake pool
+\item A transaction cannot request to have a key delegate to a non-existent
+stake pool
 \end{itemize}
 
 With these checks in place, there are never any unclaimed rewards left over
 in the accounts, so we do not need to clean these up. There are also
-no orphaned pools left over without associated stake keys.
+no orphaned pools left over without associated stake keys. Furthermore, we
+prevent any problems associated with delegation to a nonexistent pool
+(by mistake or otherwise) by not allowing it.
 
 In the consequent transition of this total rule, the DELRWDS transition is
 applied first in the composition
@@ -1286,6 +1291,8 @@ rest of the delegation state update is triggered by the cetificate list.
         \addrRw~(\fun{author}~{c}) \notin \dom \var{wdrls} \\
       \forall \var{c}\in \Gamma, \var{c}\in\DCertDeRegKey \Rightarrow
         \addrRw~(\fun{author}~{c}) \in \dom \var{wdrls} \\
+      \forall \var{c}\in \Gamma, \var{c}\in\DCertDeleg \Rightarrow
+        \fun{author}~{c} \in \dom \var{stpools} \\
       \forall \var{c}\in \Gamma, \var{c}\in\DCertDeRegKey \Rightarrow
         \fun{author}~{c} \notin \dom \var{retiring} \union \dom \var{stpools} \\ ~ \\
       {
@@ -1370,8 +1377,8 @@ to the certificate.
       & \text{delegation certificates in a transaction}\\
       \fun{txwits} & \Tx \to \powerset{\left(\VKey \times \Sig\right)}
       & \text{witnesses of a transaction}\\
-%      \fun{hashKey_{spend}} & \Addr \mapsto \HashKey
-%      & \text{hashKey of a spending key in an address}\\
+      \fun{hashKey_{spend}} & \Addr \mapsto \HashKey
+      & \text{hashKey of a spending key in an address}\\
     \end{array}
   \end{equation*}
   \caption{Definitions used in the UTxO transition system with witnesses}
@@ -1383,19 +1390,46 @@ In Figure~\ref{fig:derived-defs:utxow}, we give the definitions of two maps
 associated with input and reward addresses and their keys.
 The first, $\fun{addr}$, gives the finite map
 which associates to a given $\var{txin}$ in the UTxO the address of the
-corresponding $\var{txout}$. The map $\fun{addr_h}$, given a UTxO, returns the
+corresponding $\var{txout}$.
+
+The map $\fun{addr_h}$, given a UTxO, returns the
 finite map which associates $\var{txin}$ with the hash of a spending key in
-the address in the corresponding $\var{txout}$ in the UTxO.
+the address in the corresponding $\var{txout}$ in the UTxO. The way this is
+done is different for pointer and base addresses. For base addresses,
+we must look up the address owner using the $\fun{hashKey_{spend}}$ finite map,
+which literally checks the data at a given address for the hash of the key of
+the owner, which is stored there. This base address direct lookup is only done
+for spending keys which are not also registered staking keys (i.e. not in the
+domain of $\var{stkeys}$).
+
+For registered staking keys listed in $\var{stkeys}$, we need to perform this
+hash key lookup in the $\var{pointeraddr}$ variable in the delegation state
+on the ledger, which is a finite map that stores a pointer address
+paired with the hash of the key which controls it. Note that there is a third
+possibility of address type - the reward address. The application of the
+$\fun{addr_h}$ hash key lookup map will not fail in this case either,
+since this fits into the $\notin \dom stkeys$ case. A hash key corresponding
+to a reward address will not be found in the $\fun{hashKey_{spend}}$ finite map,
+so that we will get empty finite map as the result of this lookup.
+We will, however, never be applying the $\fun{addr_h}$ calculation to a
+reward-type address since once the rewards get withdrawn, their value is added
+to the UTxO as standard entries, referencing base or pointer addresses in the
+$\TxOut$ value.
 
 \begin{figure}
   \begin{align*}
     & \addr{}{} \in \UTxO \to \TxIn \mapsto \Addr & \text{address of an input}\\
     & \addr{utxo} = \{ i \mapsto a \mid i \mapsto (a, \wcard) \in \var{utxo} \} \\
     \nextdef
-    & \fun{addr_h} \in \UTxO \to \TxIn \mapsto \HashKey & \text{hashKey of a pointer address}\\
-    & \fun{addr_h}~utxo~\var{pointeraddr} = \\
-    & \{ i \mapsto h \mid i \mapsto (a, \wcard) \in \var{utxo}
-      \wedge a \mapsto h \in \var{pointeraddr} \}
+    & \fun{addr_h} \in \UTxO \to \Allocs \to \TxIn \mapsto \HashKey &
+        \text{hashKey of a pointer address}\\
+    & \fun{addr_h}~utxo~stkeys~\var{pointeraddr} = \\
+      & \begin{cases}
+      \{ i \mapsto h \mid i \mapsto (a, \wcard) \in \var{utxo} \\
+        \wedge a \mapsto h \in \fun{hashKey_{spend}} \} & \text{if $\var{hk} \notin \dom~stkeys$} \\
+      \{ i \mapsto h \mid i \mapsto (a, \wcard) \in \var{utxo} \\
+        \wedge a \mapsto h \in \var{pointeraddr} \} & \text{if $\var{hk} \in \dom~stkeys$} \\
+        \end{cases} \\
   \end{align*}
   \caption{Functions used in rules witnesses}
   \label{fig:derived-defs:utxow}
@@ -1481,7 +1515,7 @@ being unnecessarily large and full of redundant witnessing.
       \forall i \in \txins{tx} \cdot \exists! (\var{vk}, \sigma) \in \txwits{\var{tx}}
       \cdot \\
      \mathcal{V}_{\var{vk}}{\serialised{\txdata{tx}}}_{\sigma}
-     \wedge  \fun{addr_h}~{utxo}~{pointeraddr}~i = \hashKey{vk}\\
+     \wedge  \fun{addr_h}~{utxo}~{stkeys}~{pointeraddr}~i = \hashKey{vk}\\
      ~ \\
       & \forall c \in \fun{dcerts}~{tx}, \dwit{c} = (\var{vk}, \sigma)
       \cdot \\

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -603,7 +603,7 @@ the given slot number.
 The amount
 decayed for individual keys is then computed by adding the values of $\fun{decayed}~\var{allocs}~\var{pc}~(\fun{ttl}~\var{tx})~\var{c}$
 for each deregistration certificate in a given transaction, and is given by
-$\fun{decatedTx}~\var{pc}~\var{stkeys}~\var{cslot}~\var{c}$. Here, again,
+$\fun{decayedTx}~\var{pc}~\var{stkeys}~\var{cslot}~\var{c}$. Here, again,
 we use the $\fun{ttl}~\var{tx}$ value in the calculation instead of the current
 slot number in order to match with the one in the $\fun{keyRefunds}$
 calculation.
@@ -665,10 +665,10 @@ The types involved in defining a UTxO and its transitions are presented in
 Figure~\ref{fig:defs:utxo}. Note that here, among other primitive types,
 we introduce $\Addr_{base}$. This is the usual type of address used for
 coin transfers by the transactions. We also introduce the derived type $\Addr$,
-which is a disjoint union of base-type, pointer, and reward addresses. Using this type,
+which is a disjoint union of base-type and reward addresses. Using this type,
 it is possible to do rewards accounting (which we discuss later in this chapter)
 in the same $\UTxO$ style as the base address coin transfers, as well as
-using the staking keys pointer address records in place of base addresses.
+the usual base address lookups and calculations.
 Similar to the certificate structure, each address is either a reward or a base
 address.
 
@@ -757,7 +757,7 @@ account for this address and added to the UTxO.
       \var{addr}
       & \Addr
       & \var{addr}
-      & \Addr_{base} \uniondistinct \PtrAddr \uniondistinct \AddrRWD
+      & \Addr_{base} \uniondistinct \AddrRWD
       & \text{address}\\
       \var{txin}
       & \TxIn
@@ -927,6 +927,10 @@ The environment also has variables $\var{stkeys}$ and $\var{stpools}$
 to keep track of the current individual and pool resource allocations,
 the $\var{pointeraddr}$ variable to look up staking keys corresponding to
 pointer addresses, and the current slot number.
+
+\begin{todo}
+  Remove pointeraddr from the UTxOEnv if needed
+\end{todo}
 
 The relevant state variables for a UTxO transition include the UTxO itself,
 as well as the value in the deposits pool and the fees pool.
@@ -1367,17 +1371,17 @@ to the certificate.
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \fun{dbody} & \DCert \mapsto \DCertBody
+      \fun{dbody} & \DCert \to \DCertBody
       & \text{body of the delegation certificate}\\
-      \fun{txdata} & \Tx \mapsto \TData
+      \fun{txdata} & \Tx \to \TData
       & \text{transaction data}\\
-      \fun{dwit} & \DCert \mapsto (\VKey \times \Sig)
+      \fun{dwit} & \DCert \to (\VKey \times \Sig)
       & \text{witness for the delegation certificate}\\
       \fun{dcerts} & \Tx \to \text{list}~\DCert
       & \text{delegation certificates in a transaction}\\
       \fun{txwits} & \Tx \to \powerset{\left(\VKey \times \Sig\right)}
       & \text{witnesses of a transaction}\\
-      \fun{hashKey_{spend}} & \Addr \mapsto \HashKey
+      \fun{hashKey_{spend}} & \Addr \to \HashKey
       & \text{hashKey of a spending key in an address}\\
     \end{array}
   \end{equation*}
@@ -1395,41 +1399,22 @@ corresponding $\var{txout}$.
 The map $\fun{addr_h}$, given a UTxO, returns the
 finite map which associates $\var{txin}$ with the hash of a spending key in
 the address in the corresponding $\var{txout}$ in the UTxO. The way this is
-done is different for pointer and base addresses. For base addresses,
-we must look up the address owner using the $\fun{hashKey_{spend}}$ finite map,
-which literally checks the data at a given address for the hash of the key of
-the owner, which is stored there. This base address direct lookup is only done
-for spending keys which are not also registered staking keys (i.e. not in the
-domain of $\var{stkeys}$).
-
-For registered staking keys listed in $\var{stkeys}$, we need to perform this
-hash key lookup in the $\var{pointeraddr}$ variable in the delegation state
-on the ledger, which is a finite map that stores a pointer address
-paired with the hash of the key which controls it. Note that there is a third
-possibility of address type - the reward address. The application of the
-$\fun{addr_h}$ hash key lookup map will not fail in this case either,
-since this fits into the $\notin \dom stkeys$ case. A hash key corresponding
-to a reward address will not be found in the $\fun{hashKey_{spend}}$ finite map,
-so that we will get empty finite map as the result of this lookup.
-We will, however, never be applying the $\fun{addr_h}$ calculation to a
-reward-type address since once the rewards get withdrawn, their value is added
-to the UTxO as standard entries, referencing base or pointer addresses in the
-$\TxOut$ value.
+done is by performing a lookup of the address owner using the
+$\fun{hashKey_{spend}}$ map,
+which retrieves the hash of the key of
+the owner from the data stored at the given address.
 
 \begin{figure}
   \begin{align*}
     & \addr{}{} \in \UTxO \to \TxIn \mapsto \Addr & \text{address of an input}\\
     & \addr{utxo} = \{ i \mapsto a \mid i \mapsto (a, \wcard) \in \var{utxo} \} \\
     \nextdef
-    & \fun{addr_h} \in \UTxO \to \Allocs \to \TxIn \mapsto \HashKey &
-        \text{hashKey of a pointer address}\\
-    & \fun{addr_h}~utxo~stkeys~\var{pointeraddr} = \\
-      & \begin{cases}
-      \{ i \mapsto h \mid i \mapsto (a, \wcard) \in \var{utxo} \\
-        \wedge a \mapsto h \in \fun{hashKey_{spend}} \} & \text{if $\var{hk} \notin \dom~stkeys$} \\
-      \{ i \mapsto h \mid i \mapsto (a, \wcard) \in \var{utxo} \\
-        \wedge a \mapsto h \in \var{pointeraddr} \} & \text{if $\var{hk} \in \dom~stkeys$} \\
-        \end{cases} \\
+    & \fun{addr_h} \in \UTxO \to \TxIn \mapsto \HashKey &
+        \text{hashKey of an address}\\
+    & \fun{addr_h}~utxo = \\
+      &
+      \{ i \mapsto h \mid i \mapsto (a, \wcard) \in \var{utxo}
+        \wedge \fun{hashKey_{spend}}~{a} = h \} \\
   \end{align*}
   \caption{Functions used in rules witnesses}
   \label{fig:derived-defs:utxow}
@@ -1449,7 +1434,7 @@ Figure~\ref{fig:rules:utxow}):
  \item For each input $\var{i}$ of the signal transaction $\var{tx}$,
  there exists a (unique) verifiable witness (there could be more than one valid
  key-signature pair serving as a witness) such that the hash of the spending key
- of the pointer address corresponding to the output of $\var{i}$ in the current UTxO
+ of the address corresponding to the output of $\var{i}$ in the current UTxO
  is the same as the hash of the verification key of the witness.
 
  \item For each certificate in $\var{tx}$, the signature of the transaction
@@ -1515,11 +1500,12 @@ being unnecessarily large and full of redundant witnessing.
       \forall i \in \txins{tx} \cdot \exists! (\var{vk}, \sigma) \in \txwits{\var{tx}}
       \cdot \\
      \mathcal{V}_{\var{vk}}{\serialised{\txdata{tx}}}_{\sigma}
-     \wedge  \fun{addr_h}~{utxo}~{stkeys}~{pointeraddr}~i = \hashKey{vk}\\
+     \wedge  \fun{addr_h}~{utxo}~i = \hashKey{vk}\\
      ~ \\
       & \forall c \in \fun{dcerts}~{tx}, \dwit{c} = (\var{vk}, \sigma)
       \cdot \\
-      \verify{vk}{\serialised{\txdata~\var{tx}}}{\sigma}\\
+      \mathcal{V}_{\var{vk}}{\serialised{\txdata~\var{tx}}}_{\sigma}
+      \wedge \fun{hashKey}~{vk} = \fun{author}~{c}\\
       ~ \\
       & \forall (a \mapsto c) \in \txwdrls{tx} \cdot \exists! (\var{vk}, \sigma) \in \txwits{\var{tx}}
       \cdot \\


### PR DESCRIPTION
The Addr type is now (base U pointer U reward).
In the (addr_h utxo pointeraddr) calculation, we have
{ a \mapsto h | i \mapsto (a,_) \in utxo /\ a \mapsto h \in pointeraddr}
Which means any address in the transaction has to be a pointer address, and pointer addresses are only for registered staking keys, 
not arbitrary paying keys. How should this work?