### PR TITLE
Get nix-shell working for gitinfo2

### DIFF
--- a/latex/shell.nix
+++ b/latex/shell.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation {
                       scheme-small
 
                       # libraries
-                      stmaryrd lm-math amsmath extarrows cleveref semantic xcolor
+                      stmaryrd lm-math amsmath extarrows cleveref semantic xcolor xstring
 
                       # bclogo and dependencies
                       bclogo mdframed xkeyval etoolbox needspace
@@ -17,10 +17,14 @@ stdenv.mkDerivation {
                       # libraries for marginal notes
                       xargs todonotes
 
+                      # git info
+                      gitinfo2
+
                       # build tools
                       latexmk
 
                       ;
                   })
+                  gitMinimal
                 ];
 }


### PR DESCRIPTION
`nix-shell --pure --run make` was failing for me on `master`. This is the change that I needed to get it working.