### PR TITLE
Implement functions for epoch boundary

### DIFF
--- a/hs/src/Delegation/Certificates.hs
+++ b/hs/src/Delegation/Certificates.hs
@@ -109,11 +109,3 @@ decayPool pc = (pval, pmin, lambdap)
     where pval    = fromIntegral $ pc ^. poolDeposit
           pmin    = fromRational $ pc ^. poolMinRefund
           lambdap = pc ^. poolDecayRate
-
--- | Calculate total possible refunds.
-obligation :: PrtclConsts -> Allocs -> Allocs -> Slot -> Coin
-obligation pc stakeKeys stakePools cslot =
-    sum (map (\s -> refund dval dmin lambdad (cslot -* s)) $ Map.elems stakeKeys)
-  + sum (map (\s -> refund pval pmin lambdap (cslot -* s)) $ Map.elems stakePools)
-        where (dval, dmin, lambdad) = decayKey pc
-              (pval, pmin, lambdap) = decayPool pc

--- a/hs/src/Delegation/Certificates.hs
+++ b/hs/src/Delegation/Certificates.hs
@@ -11,7 +11,6 @@ module Delegation.Certificates
   , allocating
   , dretire
   , dderegister
-  , obligation
   , decayKey
   , decayPool
   ) where

--- a/hs/src/EpochBoundary.hs
+++ b/hs/src/EpochBoundary.hs
@@ -11,12 +11,15 @@ module EpochBoundary
   , stake
   , isActive
   , activeStake
+  , poolRefunds
   ) where
 
 import           Coin
 import           Keys
 import           UTxO
-import           Delegation.Certificates (Allocs)
+import           PrtclConsts
+import           Slot
+import           Delegation.Certificates (Allocs, decayKey, decayPool, refund)
 
 import           Data.List   (groupBy, sort)
 import qualified Data.Map    as Map
@@ -91,3 +94,9 @@ activeStake outs pointers stakeKeys delegs stakePools =
     sumKey =
       foldl1 (\(Stake (key, coin)) (Stake (_, c')) -> Stake (key, coin <> c'))
     makePair (Stake (k, c)) = (k, c)
+
+-- | Calculate pool refunds
+poolRefunds :: PrtclConsts -> Allocs -> Slot -> Map.Map HashKey Coin
+poolRefunds pc retiring cslot =
+    Map.map (\s -> refund pval pmin lambda (cslot -* s)) retiring
+    where (pval, pmin, lambda) = decayPool pc

--- a/hs/src/EpochBoundary.hs
+++ b/hs/src/EpochBoundary.hs
@@ -15,8 +15,8 @@ module EpochBoundary
 
 import           Coin
 import           Keys
-import           LedgerState
 import           UTxO
+import           Delegation.Certificates (Allocs)
 
 import           Data.List   (groupBy, sort)
 import qualified Data.Map    as Map

--- a/hs/src/LedgerState.hs
+++ b/hs/src/LedgerState.hs
@@ -75,7 +75,7 @@ import           Keys
 import           UTxO
 import           PrtclConsts              (PrtclConsts(..), minfeeA, minfeeB)
 
-import           Delegation.Certificates (DCert (..), refund, getRequiredSigningKey, Allocs)
+import           Delegation.Certificates (DCert (..), refund, getRequiredSigningKey, Allocs, decayKey)
 import           Delegation.StakePool    (Delegation (..), StakePool (..), poolPubKey)
 
 import Control.State.Transition
@@ -278,7 +278,8 @@ keyRefunds pc stkeys tx =
   where refund' key =
           case Map.lookup (hashKey key) stkeys of
             Nothing -> Coin 0
-            Just s -> refund (RegKey key) pc $ (tx ^. ttl) -* s
+            Just s -> refund dval dmin lambda $ (tx ^. ttl) -* s
+        (dval, dmin, lambda) = decayKey pc
 
 -- |Compute the lovelace which are destroyed by the transaction
 destroyed :: Allocs -> PrtclConsts -> Tx -> UTxOState -> Coin

--- a/hs/src/LedgerState.hs
+++ b/hs/src/LedgerState.hs
@@ -26,7 +26,6 @@ module LedgerState
   , LedgerValidation(..)
   , KeyPairs
   , UTxOState(..)
-  , Allocs
   -- * state transitions
   , asStateTransition
   , asStateTransition'
@@ -76,7 +75,7 @@ import           Keys
 import           UTxO
 import           PrtclConsts              (PrtclConsts(..), minfeeA, minfeeB)
 
-import           Delegation.Certificates (DCert (..), refund, getRequiredSigningKey)
+import           Delegation.Certificates (DCert (..), refund, getRequiredSigningKey, Allocs)
 import           Delegation.StakePool    (Delegation (..), StakePool (..), poolPubKey)
 
 import Control.State.Transition
@@ -134,8 +133,6 @@ instance Semigroup Validity where
 instance Monoid Validity where
   mempty = Valid
   mappend = (<>)
-
-type Allocs = Map.Map HashKey Slot
 
 type RewardAccounts = Map.Map RewardAcnt Coin
 
@@ -553,7 +550,6 @@ delegatedStake ls@(LedgerState _ ds _ _ _) = Map.fromListWith mappend delegatedO
       return (pool, c)
     outs = getOutputs $ ls ^. utxoState . utxo
     delegatedOutputs = mapMaybe (addStake $ ds ^. dstate . delegations) outs
-
 
 ---------------------------------------------------------------------------------
 -- State transition system

--- a/hs/src/LedgerState.hs
+++ b/hs/src/LedgerState.hs
@@ -136,10 +136,6 @@ instance Monoid Validity where
 
 type RewardAccounts = Map.Map RewardAcnt Coin
 
--- | Distribution density function
-newtype Distr      = Distr (Map.Map HashKey (Ratio Natural))
-newtype Production = Production (Map.Map HashKey Natural)
-
 data DState = DState
     {  -- |The active stake keys.
       _stKeys      :: Allocs

--- a/hs/src/PrtclConsts.hs
+++ b/hs/src/PrtclConsts.hs
@@ -12,6 +12,8 @@ module PrtclConsts
   , movingAvgWeight
   , movingAvgExp
   , poolConsts
+  , poolMinRefund
+  , poolDecayRate
   ) where
 
 import           Data.Ratio      (Ratio, Rational)
@@ -40,6 +42,10 @@ data PrtclConsts = PrtclConsts
   , _movingAvgExp    :: Ratio Natural
     -- |Pool constants
   , _poolConsts      :: (Ratio Natural, Natural)
+    -- | The minimum percent pool refund
+  , _poolMinRefund   :: Rational
+    -- | Decay rate for pool deposits
+  , _poolDecayRate   :: Rational
   } deriving (Show, Eq)
 
 makeLenses ''PrtclConsts

--- a/hs/src/PrtclConsts.hs
+++ b/hs/src/PrtclConsts.hs
@@ -16,7 +16,6 @@ module PrtclConsts
   , poolDecayRate
   ) where
 
-import           Data.Ratio      (Ratio, Rational)
 import           Numeric.Natural (Natural)
 
 import           Coin            (Coin (..))
@@ -37,9 +36,9 @@ data PrtclConsts = PrtclConsts
     -- |The deposit decay rate
   , _decayRate       :: Rational
     -- |Moving average weight.
-  , _movingAvgWeight :: Ratio Natural
+  , _movingAvgWeight :: Rational
     -- |Moving average exponent.
-  , _movingAvgExp    :: Ratio Natural
+  , _movingAvgExp    :: Rational
     -- |Pool constants
   , _poolConsts      :: (Rational, Natural)
     -- | The minimum percent pool refund

--- a/hs/src/PrtclConsts.hs
+++ b/hs/src/PrtclConsts.hs
@@ -41,7 +41,7 @@ data PrtclConsts = PrtclConsts
     -- |Moving average exponent.
   , _movingAvgExp    :: Ratio Natural
     -- |Pool constants
-  , _poolConsts      :: (Ratio Natural, Natural)
+  , _poolConsts      :: (Rational, Natural)
     -- | The minimum percent pool refund
   , _poolMinRefund   :: Rational
     -- | Decay rate for pool deposits

--- a/hs/src/UTxO.hs
+++ b/hs/src/UTxO.hs
@@ -70,7 +70,7 @@ import           Keys
 import           PrtclConsts (PrtclConsts(..))
 import           Slot (Slot(..))
 
-import           Delegation.Certificates (DCert (..), dvalue)
+import           Delegation.Certificates (Allocs, DCert (..), dvalue)
 import           Delegation.StakePool (poolPubKey)
 
 -- |A hash
@@ -189,7 +189,7 @@ balance (UTxO utxo) = foldr addCoins mempty utxo
   where addCoins (TxOut _ a) b = a <> b
 
 -- |Determine the total deposit amount needed
-depositAmount :: PrtclConsts -> Map.Map HashKey Slot -> Tx -> Coin
+depositAmount :: PrtclConsts -> Allocs -> Tx -> Coin
 depositAmount pc stpools tx = foldl f (Coin 0) cs
   where
     f coin cert = coin + dvalue cert pc

--- a/hs/test/Generator.hs
+++ b/hs/test/Generator.hs
@@ -106,7 +106,7 @@ genTxOut addrs = do
 
 -- TODO generate sensible protocol constants
 defPCs :: PrtclConsts
-defPCs = PrtclConsts 0 0 100 100 0 0 (0%1) (0%1) (0%1, 0)
+defPCs = PrtclConsts 0 0 100 100 0 0 (0%1) (0%1) (0%1, 0) 0 0
 
 -- | Generator of a non-empty genesis ledger state, i.e., at least one valid
 -- address and non-zero UTxO.

--- a/hs/test/UnitTests.hs
+++ b/hs/test/UnitTests.hs
@@ -41,7 +41,7 @@ bobAddr :: Addr
 bobAddr = AddrTxin (hashKey (vKey bobPay)) (hashKey (vKey bobStake))
 
 testPCs :: PrtclConsts
-testPCs = PrtclConsts 1 1 100 250 0.25 0.001 (0%1) (0%1) (0%1, 0)
+testPCs = PrtclConsts 1 1 100 250 0.25 0.001 (0%1) (0%1) (0%1, 0) 0.25 0.001
 
 aliceInitCoin :: Coin
 aliceInitCoin = Coin 10000

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -209,9 +209,9 @@ at the epoch boundary.
       & \text{total possible refunds} \\
       & \obligation{pc}{stkeys}{stpools}{cslot} =\\
       & \sum\limits_{(\_ \mapsto s) \in \var{stkeys}}
-        \refund{d_{\mathsf{val}}}{d_{\min}}{(\slotminus{cslot}{s})}{\lambda_d} \\
+        \refund{d_{\mathsf{val}}}{d_{\min}}{\lambda_d}{(\slotminus{cslot}{s})} \\
       & + \sum\limits_{(\_ \mapsto s) \in \var{stpools}}
-        \refund{p_{\mathsf{val}}}{p_{\min}}{(\slotminus{cslot}{s})}{\lambda_p} \\
+        \refund{p_{\mathsf{val}}}{p_{\min}}{\lambda_p}{(\slotminus{cslot}{s})} \\
       &
       \begin{array}{lr@{~=~}l}
         \where
@@ -223,7 +223,7 @@ at the epoch boundary.
       & \text{pool refunds} \\
       & \poolRefunds{pc}{retiring}{cslot} = \\
       & \bigcup_{\var{hk}\mapsto s\in\var{retiring}}
-          \var{hk}\mapsto( \refund{p_{\mathsf{val}}}{p_{\min}}{(\slotminus{cslot}{s})}{\lambda} ) \\
+          \var{hk}\mapsto( \refund{p_{\mathsf{val}}}{p_{\min}}{\lambda}{(\slotminus{cslot}{s})} ) \\
       &
         \where (p_{\mathsf{val}},~p_{\min},~\lambda_p) = \fun{decayPool}~\var{pc}\\
   \end{align*}


### PR DESCRIPTION
implement functions used in reward calculation, i.e., `maxPool`, `movingAvg` and `poolRew`

depends on #163 