### PR TITLE
consolidate all address definitions into one table

### DIFF
--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -90,9 +90,6 @@ $\Duration$ here by $\var{dur}$).
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      ix & \Ix & \text{index}\\
-      a & \AddrRWD & \text{reward address} \\
-      slot & \Slot & \text{absolute slot}\\
       dur & \Duration & \text{duration}\\
       epoch & \Epoch & \text{epoch} \\
       stakepool & \StakePool & \text{stake pool parameters} \\
@@ -124,10 +121,6 @@ $\Duration$ here by $\var{dur}$).
       & \Allocs
       & \HashKey \mapsto \Slot
       & \text{resource allocations} \\
-      \var{(s,t,c)}
-      & \Ptr
-      & \Slot\times\Ix\times\Ix
-      & \text{certificate pointer}
     \end{array}
   \end{equation*}
   %
@@ -135,9 +128,6 @@ $\Duration$ here by $\var{dur}$).
   %
   \begin{equation*}
   \begin{array}{r@{~\in~}lr}
-  \fun{addr_{rwd}} & \HashKey \to \AddrRWD
-  & \text{address of a stake key}
-  \\
   \fun{author} & \DCert \to \HashKey
   & \text{certificate author}
   \\

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -55,6 +55,9 @@
 \newcommand{\ledgerState}{\ensuremath{\type{ledgerState}}}
 
 \newcommand{\AddrRWD}{\type{Addr_{rwd}}}
+\newcommand{\AddrB}{\type{Addr_{base}}}
+\newcommand{\AddrP}{\type{Addr_{ptr}}}
+\newcommand{\AddrE}{\type{Addr_{enterprise}}}
 \newcommand{\Ptr}{\type{Ptr}}
 \newcommand{\DState}{\type{DState}}
 \newcommand{\DWState}{\type{DWState}}
@@ -249,6 +252,7 @@ the rest of the document.
   \label{fig:notation:nonstandard}
 \end{figure}
 
+\clearpage
 
 \section{Cryptographic primitives}
 \label{sec:crypto-primitives}
@@ -339,6 +343,91 @@ Serialization is a physical manipulation of data on a given storage device.
 In this document, the properties and rules we state involving serialization are
 assumed to hold true independently of the storage medium and style of data
 organization chosen for an implementation.
+
+\clearpage
+
+\section{Addresses}
+\label{sec:addresses}
+
+TODO - Move address explanations here.
+
+\begin{figure*}
+  \emph{Abstract types}
+  %
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      slot & \Slot & \text{absolute slot}\\
+      ix & \Ix & \text{index}\\
+    \end{array}
+  \end{equation*}
+  %
+  \emph{Derived types}
+  %
+  \begin{equation*}
+    \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
+      \var{(s,t,c)}
+      & \Ptr
+      & \Slot\times\Ix\times\Ix
+      & \text{certificate pointer}
+      \\
+      \var{acct}
+      & \AddrRWD
+      & \HashKey_{stake}
+      & \text{reward account}
+      \\
+      \var{addr}
+      & \AddrB
+      & \HashKey_{pay}\times\HashKey_{stake}
+      & \text{base address}
+      \\
+      \var{addr}
+      & \AddrP
+      & \HashKey_{pay}\times\Ptr
+      & \text{pointer address}
+      \\
+      \var{addr}
+      & \AddrE
+      & \HashKey_{pay}
+      & \text{enterprise address}
+      \\
+
+      \var{addr}
+      & \Addr
+      & \AddrB \uniondistinct \AddrP \uniondistinct \AddrE
+      & \text{output address}
+      \\
+    \end{array}
+  \end{equation*}
+  %
+  \emph{Accessor Functions}
+  %
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      \fun{paymentHK} & \Addr \to \HashKey
+        & \text{hash of payment key from addr}\\
+      \fun{stakeHK_b} & \AddrB \to \HashKey
+        & \text{hash of stake key from base addr}\\
+      \fun{stakeHK_r} & \AddrRWD \to \HashKey
+        & \text{hash of stake key from reward account}\\
+      \fun{addrPtr} & \AddrP \to \Ptr
+        & \text{pointer from pointer addr}\\
+    \end{array}
+  \end{equation*}
+  %
+  \emph{Constructor Functions}
+  %
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      \fun{addr_{rwd}}
+        & \HashKey \to \AddrRWD
+        & \text{construct a reward account}
+    \end{array}
+  \end{equation*}
+  \caption{Definitions used in Addresses}
+  \label{fig:defs:addresses}
+\end{figure*}
+
+\clearpage
 
 \section{Delegation}
 \label{sec:delegation}
@@ -749,24 +838,13 @@ account for this address and added to the UTxO.
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \var{txid} & \TxId & \text{transaction id}\\
-      %
-      %
-      \var{addr} & \Addr_{base} & \text{base address}\\
-      \var{addr} & \Addr_{ptr} & \text{pointer address}\\
-      %
       c & \Coin & \text{currency value}\\
-      %
-      slot & \Slot & \text{slot}
     \end{array}
   \end{equation*}
   \emph{Derived types}
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
-      \var{addr}
-      & \Addr
-      & \Addr_{base} \uniondistinct \Addr_{ptr} \uniondistinct \AddrRWD
-      & \text{address}\\
       (\var{txid}, \var{ix})
       & \TxIn
       & \TxId \times \Ix
@@ -1383,8 +1461,6 @@ to the certificate.
       & \text{delegation certificates in a transaction}\\
       \fun{txwits} & \Tx \to \powerset{\left(\VKey \times \Sig\right)}
       & \text{witnesses of a transaction}\\
-      \fun{hashKey_{spend}} & \Addr \to \HashKey
-      & \text{hashKey of a spending key in an address}\\
     \end{array}
   \end{equation*}
   \caption{Definitions used in the UTxO transition system with witnesses}
@@ -1402,7 +1478,7 @@ The map $\fun{addr_h}$, given a UTxO, returns the
 finite map which associates $\var{txin}$ with the hash of a spending key in
 the address in the corresponding $\var{txout}$ in the UTxO. The way this is
 done is by performing a lookup of the address owner using the
-$\fun{hashKey_{spend}}$ map,
+$\fun{paymentHK}$ function,
 which retrieves the hash of the key of
 the owner from the data stored at the given address.
 
@@ -1416,7 +1492,7 @@ the owner from the data stored at the given address.
     & \fun{addr_h}~utxo = \\
       &
       \{ i \mapsto h \mid i \mapsto (a, \wcard) \in \var{utxo}
-        \wedge \fun{hashKey_{spend}}~{a} = h \} \\
+        \wedge \fun{paymentHK}~{a} = h \} \\
   \end{align*}
   \caption{Functions used in rules witnesses}
   \label{fig:derived-defs:utxow}
@@ -1511,7 +1587,7 @@ being unnecessarily large and full of redundant witnessing.
       & \forall (a \mapsto c) \in \txwdrls{tx} \cdot \exists! (\var{vk}, \sigma) \in \txwits{\var{tx}}
       \cdot \\
       \mathcal{V}_{\var{vk}}{\serialised{\txdata{tx}}}_{\sigma}
-      \wedge \fun{hashKey_{spend}} \var{a} = \hashKey{vk}\\
+      \wedge \fun{paymentHK} \var{a} = \hashKey{vk}\\
     }
     {
       \begin{array}{l}


### PR DESCRIPTION
This PR creates a singe table to consolidate all the definitions relating to addresses.  This includes reward accounts and the three output addresses: base, ptr, and enterprise.  Enterprise addresses are new.  They do nothing but exist for payments and are excluded for staking.

This will be a general pattern that we will follow for a couple up-coming topics. We will be consolidating protocol constants and transaction definitions as well.  This means that some definitions will be introduced before they are strictly needed.  It should, however, add to the readability and coherence.

I have not attempted to move the prose to the correct section. I will do this after all the regrouping is finished.

#174 