### PR TITLE
Implement STS rules for epoch boundary

### DIFF
--- a/hs/src/EpochBoundary.hs
+++ b/hs/src/EpochBoundary.hs
@@ -6,8 +6,7 @@ This modules implements the necessary functions for the changes that can happen 
 -}
 module EpochBoundary
   ( Stake
-  , Distr
-  , Production
+  , Production(..)
   , baseStake
   , ptrStake
   , stake
@@ -16,21 +15,13 @@ module EpochBoundary
   , obligation
   , poolRefunds
   , maxPool
-  , movingAvg
-  , poolRew
-  , leaderRew
-  , memberRew
-  , indivRew
   , groupByPool
-  , rewardOnePool
-  , reward
   ) where
 
 import           Coin
 import           Delegation.Certificates (Allocs, decayKey, decayPool, refund)
 import           Delegation.StakePool
 import           Keys
-import           LedgerState
 import           PParams
 import           Slot
 import           UTxO
@@ -145,55 +136,6 @@ maxPool pc (Coin r) sigma pR = floor $ factor1 * factor2
     factor3 = (sigma' - p' * factor4) / z0
     factor4 = (z0 - sigma') / z0
 
--- | Calulcate moving average
-movingAvg :: PParams -> HashKey -> Natural -> Rational -> Distr -> Rational
-movingAvg pc hk n expectedSlots (Distr averages) =
-  let fraction = fromIntegral n / max expectedSlots 1
-   in case Map.lookup hk averages of
-        Nothing -> fraction
-        Just (StakeShare prev) -> alpha * fraction + (1 - alpha) * prev
-          where alpha = intervalValue $ pc ^. movingAvgWeight
-
--- | Calculate pool reward
-poolRew ::
-     PParams
-  -> HashKey
-  -> Natural
-  -> Rational
-  -> Distr
-  -> Coin
-  -> (Coin, Rational)
-poolRew pc hk n expectedSlots averages (Coin maxP) =
-  (floor $ e * fromIntegral maxP, avg)
-  where
-    avg = intervalValue $ pc ^. movingAvgExp
-    gamma = movingAvg pc hk n expectedSlots averages
-    e = fromRational avg ** fromRational gamma :: Double
-
--- | Calculate pool leader reward
-leaderRew :: Coin -> StakePool -> StakeShare -> StakeShare -> Coin
-leaderRew f@(Coin f') pool (StakeShare sigma) (StakeShare s)
-  | f' <= c = f
-  | otherwise =
-    floor $ fromIntegral (c + (f' - c)) * (m' + (1 - m') * sigma / s)
-  where
-    (Coin c, m, _) = poolSpec pool
-    m' = intervalValue m
-
--- | Calculate pool member reward
-memberRew :: Coin -> StakePool -> StakeShare -> StakeShare -> Coin
-memberRew (Coin f') pool (StakeShare sigma) (StakeShare s)
-  | f' <= c = 0
-  | otherwise = floor $ fromIntegral (f' - c) * (1 - m') * sigma / s
-  where
-    (Coin c, m, _) = poolSpec pool
-    m' = intervalValue m
-
--- | Calculate individual reward
-indivRew :: Coin -> StakePool -> StakeShare -> StakeShare -> Bool -> Coin
-indivRew f pool sigma s True  = leaderRew f pool sigma s
-indivRew f pool sigma s False = memberRew f pool sigma s
-
 -- | Pool individual reward
 groupByPool ::
      Map.Map HashKey Coin
@@ -205,75 +147,3 @@ groupByPool active delegs =
     [ (delegs Map.! hk, Map.restrictKeys active (Set.singleton hk))
     | hk <- Map.keys delegs
     ]
-
--- | Reward one pool
-rewardOnePool ::
-     PParams
-  -> Coin
-  -> Natural
-  -> HashKey
-  -> StakePool
-  -> Map.Map HashKey Coin
-  -> Distr
-  -> Coin
-  -> (Map.Map RewardAcnt Coin, StakeShare)
-rewardOnePool pc r n poolHK pool actgr averages (Coin total) =
-  (Map.fromList keysVals, StakeShare avg)
-  where
-    (Coin pstake) = Map.foldl (+) (Coin 0) actgr
-    sigma = fromIntegral pstake % fromIntegral total
-    expectedSlots = sigma * fromIntegral slotsPerEpoch
-    (_, _, Coin p) = poolSpec pool
-    pr = fromIntegral p % fromIntegral total
-    maxP =
-      if p <= pstake
-        then maxPool pc r sigma pr
-        else 0
-    (poolR, avg) = poolRew pc poolHK n expectedSlots averages maxP
-    sFrac = StakeShare (sigma / fromIntegral total)
-    keysVals =
-      [ ( RewardAcnt hk
-        , indivRew
-            poolR
-            pool
-            sFrac
-            (StakeShare (fromIntegral c % fromIntegral total))
-            (hk == poolHK))
-      | (hk, Coin c) <- Map.toList actgr
-      ]
-
-reward ::
-     Production
-  -> PParams
-  -> Coin
-  -> DWState
-  -> Set.Set TxOut
-  -> (Map.Map RewardAcnt Coin, Distr)
-reward (Production prod) pc r dwstate outs =
-  ( foldl Map.union Map.empty [rew | (_, (rew, _)) <- results]
-  , Distr $ Map.fromList [(hk, avg) | (hk, (_, avg)) <- results])
-  where
-    active =
-      activeStake
-        outs
-        (dwstate ^. dstate . ptrs)
-        (dwstate ^. dstate . stKeys)
-        (dwstate ^. dstate . delegations)
-        (dwstate ^. pstate . stPools)
-    total = Map.foldl (+) (Coin 0) active
-    pactive = groupByPool active (dwstate ^. dstate . delegations)
-    pdata =
-      [ ( key
-        , ( (dwstate ^. pstate . pParams) Map.! key
-          , prod Map.! key
-          , pactive Map.! key))
-      | key <-
-          Set.toList $ Map.keysSet (dwstate ^. pstate . pParams) `Set.intersection`
-          Map.keysSet prod `Set.intersection`
-          Map.keysSet pactive
-      ]
-    results =
-      [ ( hk
-        , rewardOnePool pc r n hk pool actgr (dwstate ^. pstate . avgs) total)
-      | (hk, (pool, n, actgr)) <- pdata
-      ]

--- a/hs/src/EpochBoundary.hs
+++ b/hs/src/EpochBoundary.hs
@@ -20,7 +20,6 @@ module EpochBoundary
 
 import           Coin
 import           Delegation.Certificates (Allocs, decayKey, decayPool, refund)
-import           Delegation.StakePool
 import           Keys
 import           PParams
 import           Slot

--- a/hs/src/LedgerState.hs
+++ b/hs/src/LedgerState.hs
@@ -19,6 +19,7 @@ module LedgerState
   , Ix
   , DWState(..)
   , DState(..)
+  , AccountState(..)
   , dstate
   , pstate
   , ptrs
@@ -200,6 +201,15 @@ data DWState =
     , _pstate :: PState
     } deriving (Show, Eq)
 
+data AccountState = AccountState
+  { _treasury   :: Coin
+  , _reserves   :: Coin
+  , _rewardPool :: Coin
+  } deriving (Show, Eq)
+
+emptyAccount :: AccountState
+emptyAccount = AccountState (Coin 0) (Coin 0) (Coin 0)
+
 emptyDelegation :: DWState
 emptyDelegation =
     DWState emptyDState emptyPState
@@ -236,6 +246,7 @@ makeLenses ''DWState
 makeLenses ''DState
 makeLenses ''PState
 makeLenses ''UTxOState
+makeLenses ''AccountState
 makeLenses ''LedgerState
 
 -- |The transaction Id for 'UTxO' included at the beginning of a new ledger.

--- a/hs/src/LedgerState.hs
+++ b/hs/src/LedgerState.hs
@@ -59,6 +59,14 @@ module LedgerState
   , retiring
   -- refunds
   , keyRefunds
+  -- epoch boundary
+  , movingAvg
+  , poolRew
+  , leaderRew
+  , memberRew
+  , indivRew
+  , rewardOnePool
+  , reward
   ) where
 
 import           Control.Monad           (foldM)
@@ -74,13 +82,18 @@ import           Lens.Micro              ((^.), (&), (.~), (%~))
 import           Lens.Micro.TH           (makeLenses)
 
 import           Coin                    (Coin (..))
-import           Slot                    (Slot (..), Epoch (..), (-*))
+import           Slot                    (Slot (..), Epoch (..), (-*),
+                                               slotsPerEpoch)
 import           Keys
 import           UTxO
-import           PParams                 (PParams(..), minfeeA, minfeeB)
+import           PParams                 (PParams(..), minfeeA, minfeeB,
+                                                 intervalValue, movingAvgWeight,
+                                                 movingAvgExp)
+import           EpochBoundary
 
 import           Delegation.Certificates (DCert (..), refund, getRequiredSigningKey, Allocs, decayKey)
-import           Delegation.StakePool    (Delegation (..), StakePool (..), poolPubKey)
+import           Delegation.StakePool    (Delegation (..), StakePool (..),
+                                                     poolPubKey, poolSpec)
 
 import Control.State.Transition
 
@@ -568,6 +581,131 @@ delegatedStake ls@(LedgerState _ ds _ _ _) = Map.fromListWith mappend delegatedO
       return (pool, c)
     outs = getOutputs $ ls ^. utxoState . utxo
     delegatedOutputs = mapMaybe (addStake $ ds ^. dstate . delegations) outs
+
+---------------------------------
+-- epoch boundary calculations --
+---------------------------------
+
+-- | Calulcate moving average
+movingAvg :: PParams -> HashKey -> Natural -> Rational -> Distr -> Rational
+movingAvg pc hk n expectedSlots (Distr averages) =
+  let fraction = fromIntegral n / max expectedSlots 1
+   in case Map.lookup hk averages of
+        Nothing -> fraction
+        Just (StakeShare prev) -> alpha * fraction + (1 - alpha) * prev
+          where alpha = intervalValue $ pc ^. movingAvgWeight
+
+-- | Calculate pool reward
+poolRew ::
+     PParams
+  -> HashKey
+  -> Natural
+  -> Rational
+  -> Distr
+  -> Coin
+  -> (Coin, Rational)
+poolRew pc hk n expectedSlots averages (Coin maxP) =
+  (floor $ e * fromIntegral maxP, avg)
+  where
+    avg = intervalValue $ pc ^. movingAvgExp
+    gamma = movingAvg pc hk n expectedSlots averages
+    e = fromRational avg ** fromRational gamma :: Double
+
+-- | Calculate pool leader reward
+leaderRew :: Coin -> StakePool -> StakeShare -> StakeShare -> Coin
+leaderRew f@(Coin f') pool (StakeShare sigma) (StakeShare s)
+  | f' <= c = f
+  | otherwise =
+    floor $ fromIntegral (c + (f' - c)) * (m' + (1 - m') * sigma / s)
+  where
+    (Coin c, m, _) = poolSpec pool
+    m' = intervalValue m
+
+-- | Calculate pool member reward
+memberRew :: Coin -> StakePool -> StakeShare -> StakeShare -> Coin
+memberRew (Coin f') pool (StakeShare sigma) (StakeShare s)
+  | f' <= c = 0
+  | otherwise = floor $ fromIntegral (f' - c) * (1 - m') * sigma / s
+  where
+    (Coin c, m, _) = poolSpec pool
+    m' = intervalValue m
+
+-- | Calculate individual reward
+indivRew :: Coin -> StakePool -> StakeShare -> StakeShare -> Bool -> Coin
+indivRew f pool sigma s True  = leaderRew f pool sigma s
+indivRew f pool sigma s False = memberRew f pool sigma s
+
+-- | Reward one pool
+rewardOnePool ::
+     PParams
+  -> Coin
+  -> Natural
+  -> HashKey
+  -> StakePool
+  -> Map.Map HashKey Coin
+  -> Distr
+  -> Coin
+  -> (Map.Map RewardAcnt Coin, StakeShare)
+rewardOnePool pc r n poolHK pool actgr averages (Coin total) =
+  (Map.fromList keysVals, StakeShare avg)
+  where
+    (Coin pstake) = Map.foldl (+) (Coin 0) actgr
+    sigma = fromIntegral pstake % fromIntegral total
+    expectedSlots = sigma * fromIntegral slotsPerEpoch
+    (_, _, Coin p) = poolSpec pool
+    pr = fromIntegral p % fromIntegral total
+    maxP =
+      if p <= pstake
+        then maxPool pc r sigma pr
+        else 0
+    (poolR, avg) = poolRew pc poolHK n expectedSlots averages maxP
+    sFrac = StakeShare (sigma / fromIntegral total)
+    keysVals =
+      [ ( RewardAcnt hk
+        , indivRew
+            poolR
+            pool
+            sFrac
+            (StakeShare (fromIntegral c % fromIntegral total))
+            (hk == poolHK))
+      | (hk, Coin c) <- Map.toList actgr
+      ]
+
+reward ::
+     Production
+  -> PParams
+  -> Coin
+  -> DWState
+  -> Set.Set TxOut
+  -> (Map.Map RewardAcnt Coin, Distr)
+reward (Production prod) pc r dwstate outs =
+  ( foldl Map.union Map.empty [rew | (_, (rew, _)) <- results]
+  , Distr $ Map.fromList [(hk, avg) | (hk, (_, avg)) <- results])
+  where
+    active =
+      activeStake
+        outs
+        (dwstate ^. dstate . ptrs)
+        (dwstate ^. dstate . stKeys)
+        (dwstate ^. dstate . delegations)
+        (dwstate ^. pstate . stPools)
+    total = Map.foldl (+) (Coin 0) active
+    pactive = groupByPool active (dwstate ^. dstate . delegations)
+    pdata =
+      [ ( key
+        , ( (dwstate ^. pstate . pParams) Map.! key
+          , prod Map.! key
+          , pactive Map.! key))
+      | key <-
+          Set.toList $ Map.keysSet (dwstate ^. pstate . pParams) `Set.intersection`
+          Map.keysSet prod `Set.intersection`
+          Map.keysSet pactive
+      ]
+    results =
+      [ ( hk
+        , rewardOnePool pc r n hk pool actgr (dwstate ^. pstate . avgs) total)
+      | (hk, (pool, n, actgr)) <- pdata
+      ]
 
 ---------------------------------------------------------------------------------
 -- State transition system

--- a/hs/src/LedgerState.hs
+++ b/hs/src/LedgerState.hs
@@ -687,7 +687,7 @@ reward ::
   -> PParams
   -> Coin
   -> DWState
-  -> Set.Set TxOut
+  -> [TxOut]
   -> (Map.Map RewardAcnt Coin, Distr)
 reward (Production prod) pc r dwstate outs =
   ( foldl Map.union Map.empty [rew | (_, (rew, _)) <- results]
@@ -1107,7 +1107,7 @@ accntTransition = do
     let availablePool = totalPool - newTreasury -- underflow?
     let getOutputs (UTxO utxo') = Map.elems utxo'
     let outs = getOutputs (us ^. utxo)
-    let (rewards', avgs') = reward production pp (Coin availablePool) dw (Set.fromList outs)
+    let (rewards', avgs') = reward production pp (Coin availablePool) dw outs
     let paidRewards = Map.foldl (+) (Coin 0) rewards'
     let as' = as & treasury %~ (+) (Coin newTreasury)
                  & reserves %~ (-) expansion      -- underflow?

--- a/hs/src/PParams.hs
+++ b/hs/src/PParams.hs
@@ -14,6 +14,8 @@ module PParams
   , poolConsts
   , poolMinRefund
   , poolDecayRate
+  , rho
+  , tau
   , UnitInterval
   , mkUnitInterval
   , intervalValue
@@ -68,6 +70,9 @@ data PParams = PParams
   , _poolMinRefund   :: UnitInterval
     -- | Decay rate for pool deposits
   , _poolDecayRate   :: Rational
+    -- | Account transition parameter
+  , _rho             :: UnitInterval
+  , _tau             :: UnitInterval
   } deriving (Show, Eq)
 
 makeLenses ''PParams

--- a/hs/test/Generator.hs
+++ b/hs/test/Generator.hs
@@ -107,7 +107,7 @@ genTxOut addrs = do
 -- TODO generate sensible protocol constants
 defPCs :: PParams
 defPCs =
-    PParams 0 0 100 100 interval0 0 interval0 interval0 (0%1, 0) interval0 0
+    PParams 0 0 100 100 interval0 0 interval0 interval0 (0%1, 0) interval0 0 interval0 interval0
 
 -- | Generator of a non-empty genesis ledger state, i.e., at least one valid
 -- address and non-zero UTxO.
@@ -227,6 +227,7 @@ repeatCollectTx' n keyPairs fees ls txs validationErrors
 findPayKeyPair :: Addr -> KeyPairs -> KeyPair
 findPayKeyPair (AddrTxin addr _) keyList =
     fst $ head $ filter (\(pay, _) -> addr == (hashKey $ vKey pay)) keyList
+findPayKeyPair _ _ = error "currently no such keys should be generated"
 
 -- | Find first matching key pair for stake key in 'AddrTxin'.
 findStakeKeyPair :: HashKey -> KeyPairs -> KeyPair

--- a/hs/test/UnitTests.hs
+++ b/hs/test/UnitTests.hs
@@ -7,6 +7,7 @@ import           Data.Map                (Map)
 import qualified Data.Map                as Map
 import           Data.Ratio
 import qualified Data.Set                as Set
+import           Data.Maybe              (fromMaybe)
 
 import           Lens.Micro              ((^.), (&), (.~))
 
@@ -41,13 +42,12 @@ bobAddr :: Addr
 bobAddr = AddrTxin (hashKey (vKey bobPay)) (hashKey (vKey bobStake))
 
 oneFourth :: UnitInterval
-oneFourth = iVal
-    where Just iVal = mkUnitInterval 0.25
-
+oneFourth =
+    fromMaybe (error "could not construct unit interval") $ mkUnitInterval 0.25
 
 testPCs :: PParams
 testPCs =
-    PParams 1 1 100 250 oneFourth 0.001 interval0 interval0 (0%1, 0) oneFourth 0.001
+    PParams 1 1 100 250 oneFourth 0.001 interval0 interval0 (0%1, 0) oneFourth 0.001 interval0 interval0
 
 aliceInitCoin :: Coin
 aliceInitCoin = Coin 10000
@@ -329,8 +329,8 @@ stakePool = StakePool
             }
 
 halfInterval :: UnitInterval
-halfInterval = i
-    where Just i = mkUnitInterval 0.5
+halfInterval =
+    fromMaybe (error "could not construct unit interval") $ mkUnitInterval 0.5
 
 stakePoolUpdate :: StakePool
 stakePoolUpdate = StakePool

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -903,7 +903,8 @@ for potential future use.
         \begin{array}{r}
           \var{stpools} \\
           \var{pparams} \\
-          \var{retiring}
+          \var{retiring} \\
+          \var{avgs}
         \end{array}
       \right)
       \trans{poolclean}{}

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -1133,8 +1133,8 @@ be the \textit{last slot of the epoch before the boundary}.
         \begin{array}{l}
           \var{slot}\\
           \var{pcOld}\\
-          \var{dstate}\\
-          \var{pstate}\\
+          \var{stKeys}\\
+          \var{stPools}
         \end{array}
       }
       \vdash \var{utxoSt} \trans{utxoep}{} \var{utxoSt'}
@@ -1169,8 +1169,7 @@ be the \textit{last slot of the epoch before the boundary}.
       \\~\\~\\
       {
         \begin{array}{l}
-          \var{slot}\\
-          \var{pcOld}\\
+          \var{slot}
         \end{array}
       }
       \vdash

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -1037,7 +1037,9 @@ for ease of reading.
     {
       \begin{array}{l}
         \var{slot}\\
-        \var{pc}\\
+        \var{pcOld}\\
+        \var{pcNew}\\
+        \var{dwstate}
       \end{array}
       \vdash
       \left(

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -795,7 +795,7 @@ the ``total pot'' used during the epoch transition in Figure \ref{fig:rules:accn
       \begin{array}{r@{=}l}
         \var{obl} & \obligation{pc}{stkeys}{stpools}{slot} \\
         \var{decayed} & \var{deposits} - \var{obl} \\
-        %\rho, \tau \in pc \\
+        \rho, \tau \in pc \\
         \var{expansion} & \floor*{\rho \cdot \var{reserves}} \\
         \var{totalPool} & \var{fees} + \var{decayed} + \var{rewardPool} + \var{expansion} \\
         \var{newTreasury} & \floor*{\tau \cdot \var{totalPool}} \\
@@ -1151,8 +1151,7 @@ be the \textit{last slot of the epoch before the boundary}.
         {
           \begin{array}{r}
             \var{accnt} \\
-            \var{dstate} \\
-            \var{pstate} \\
+            \var{dwstate}
           \end{array}
         }
       \right)
@@ -1161,8 +1160,7 @@ be the \textit{last slot of the epoch before the boundary}.
       {
         \begin{array}{rcl}
           \var{accnt'} \\
-          \var{dstate'} \\
-          \var{pstate'} \\
+          \var{dwstate'}
         \end{array}
       }
       \right)


### PR DESCRIPTION
some small changes / adaption in the latex doc for typing
more involved change: transform set of `TxOut` to `[TxOut]` to make sure no elements can get lost in `stake` calculation.