### PR TITLE
Latex/consolidated proto params

### DIFF
--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -101,7 +101,6 @@ $\Duration$ here by $\var{dur}$).
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \slotsPer & \mathbb{N} & \text{slots per epoch} \\
-      \emax & \Epoch & \text{epoch bound on pool retirement} \\
     \end{array}
   \end{equation*}
   %
@@ -258,15 +257,37 @@ certificate (contained in a signal transaction).
     \end{array}
   \end{equation*}
   %
+  \emph{Delegation Environment}
+  \begin{equation*}
+    \DEnv =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{slot} & \Slot & \text{slot}\\
+        \var{ptr} & \Ptr & \text{certificate pointer}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
+  \emph{Pool Environment}
+  \begin{equation*}
+    \PEnv =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{slot} & \Slot & \text{slot}\\
+        \var{pp} & \PParams & \text{protocol parameters}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
   \emph{Delegation Transitions}
   \begin{equation*}
     \_ \vdash \_ \trans{deleg}{\_} \_ \in
-      \powerset (\Slot \times \DState \times \DCert \times \DState)
+      \powerset (\DEnv \times \DState \times \DCert \times \DState)
   \end{equation*}
   %
   \begin{equation*}
     \_ \vdash \_ \trans{pool}{\_} \_ \in
-      \powerset (\Slot \times \PState \times \DCert \times \PState)
+    \powerset (\PEnv \times \PState \times \DCert \times \PState)
   \end{equation*}
   %
   \caption{Delegation Transitions}
@@ -352,13 +373,16 @@ being delegated to.
   \begin{equation}\label{eq:deleg-reg}
     \inference[Deleg-Reg]
     {
-      \var{c}\in\DCertRegKey & hk = \cauthor{c} \\
-      hk \notin \dom \var{stkeys} & ptr = (slot,~\fun{txSlotIx}~\var{tx},~\fun{cIx}~\var{c})
+    \var{c}\in\DCertRegKey & hk = \cauthor{c} & hk \notin \dom \var{stkeys}
     }
     {
-      \var{slot} \vdash
-      \left(
       \begin{array}{r}
+        \var{slot} \\
+        \var{ptr} \\
+      \end{array}
+      \vdash
+      \left(
+        \begin{array}{r}
         \var{stkeys} \\
         \var{rewards} \\
         \var{delegations} \\
@@ -385,7 +409,11 @@ being delegated to.
     hk \mapsto 0 \in \var{rewards}
     }
     {
-      \var{slot} \vdash
+      \begin{array}{r}
+        \var{slot} \\
+        \var{ptr} \\
+      \end{array}
+      \vdash
       \left(
       \begin{array}{r}
         \var{stkeys} \\
@@ -412,7 +440,11 @@ being delegated to.
       \var{c}\in \DCertDeleg & hk = \cauthor{c} & hk \in \dom \var{stkeys}
     }
     {
-      \var{slot} \vdash
+      \begin{array}{r}
+        \var{slot} \\
+        \var{ptr} \\
+      \end{array}
+      \vdash
       \left(
       \begin{array}{r}
         \var{stkeys} \\
@@ -507,7 +539,11 @@ that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
       & hk \notin \dom \var{stpools}
     }
     {
-      \var{slot} \vdash
+      \begin{array}{r}
+        \var{slot} \\
+        \var{pp} \\
+      \end{array}
+      \vdash
       \left(
       \begin{array}{r}
         \var{stpools} \\
@@ -538,7 +574,11 @@ that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
       & hk \in \dom \var{stpools}
     }
     {
-      \var{slot} \vdash
+      \begin{array}{r}
+        \var{slot} \\
+        \var{pp} \\
+      \end{array}
+      \vdash
       \left(
       \begin{array}{r}
         \var{stpools} \\
@@ -568,10 +608,14 @@ that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
     & \var{hk} \in \dom \var{stpools} \\
     \var{e} = \retire{c}
     & \var{cepoch} = \epoch{slot}
-    & \var{cepoch} < \var{e} < \var{cepoch} + \emax
+    & \var{cepoch} < \var{e} < \var{cepoch} + (\fun{emax}~{pp})
   }
   {
-    \var{slot} \vdash
+    \begin{array}{r}
+      \var{slot} \\
+      \var{pp} \\
+    \end{array}
+    \vdash
     \left(
       \begin{array}{r}
         \var{stpools} \\
@@ -610,8 +654,9 @@ Figure~\ref{fig:defs:delpl}.
     \DPEnv =
     \left(
       \begin{array}{r@{~\in~}lr}
-        \var{tx} & \Tx & \text{transaction}\\
         \var{slot} & \Slot & \text{slot}\\
+        \var{ptr} & \Tx & \text{certificate pointer}\\
+        \var{pp} & \PParams & \text{protocol parameters}\\
       \end{array}
     \right)
   \end{equation*}
@@ -640,7 +685,7 @@ Figure~\ref{fig:defs:delpl}.
 
 In the following Figure~\ref{fig:rules:delpl}, we give the rules for
 defining a valid state transition for the combined delegation and pool
-state, $\DWState$, signaled by a certificate. There are two separate rules,
+state, $\DPState$, signaled by a certificate. There are two separate rules,
 one where only the
 delegation state changes, and one where only the pool state changes.
 This is because a certificate can never trigger a transition of both kinds,
@@ -653,13 +698,21 @@ and can only be applied to \textit{either} register (deregister) a key,
     \label{eq:delpl-d}
     \inference[Delpl-Del]
     {
-      & \var{slot} \vdash \var{dstate} \trans{deleg}{c} \var{dstate'}
+      &
+      {
+        \begin{array}{r}
+          \var{slot} \\
+          \var{ptr} \\
+        \end{array}
+      }
+      \vdash \var{dstate} \trans{deleg}{c} \var{dstate'}
     }
     { \left(
-      \begin{array}{r}
-        \var{tx} \\
-        \var{slot}
-      \end{array}
+        \begin{array}{r}
+          \var{slot} \\
+          \var{ptr} \\
+          \var{pp} \\
+        \end{array}
       \right)
       \vdash
       \left(
@@ -681,13 +734,21 @@ and can only be applied to \textit{either} register (deregister) a key,
     \label{eq:delpl-p}
     \inference[Delpl-Pool]
     {
-    & \var{slot} \vdash \var{pstate} \trans{pool}{c} \var{pstate'}
+    &
+    {
+      \begin{array}{r}
+        \var{slot} \\
+        \var{pp} \\
+      \end{array}
+    }
+    \vdash \var{pstate} \trans{pool}{c} \var{pstate'}
     }
     { \left(
-      \begin{array}{r}
-        \var{tx} \\
-        \var{slot}
-      \end{array}
+        \begin{array}{r}
+          \var{slot} \\
+          \var{ptr} \\
+          \var{pp} \\
+        \end{array}
       \right)
       \vdash
       \left(
@@ -731,13 +792,25 @@ whole transaction will be invalid.
 
 
 \begin{figure}
-\begin{equation*}
-  \_ \vdash \_ \trans{delegs}{\_} \_ \in
+  \emph{Certificate List Environment}
+  \begin{equation*}
+    \DPSEnv =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{slot} & \Slot & \text{slot}\\
+        \var{txIx} & \Ix & \text{transaction index}\\
+        \var{pp} & \PParams & \text{protocol parameters}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
+  \begin{equation*}
+    \_ \vdash \_ \trans{delegs}{\_} \_ \in
     \powerset (
-    \DPEnv \times \DPState \times \seqof{\DCert} \times \DPState)
-\end{equation*}
-\caption{Delegation with a certificate list transition type}
-\label{fig:type:delegations}
+    \DPSEnv \times \DPState \times \seqof{\DCert} \times \DPState)
+  \end{equation*}
+  \caption{Delegation with a certificate list transition type}
+  \label{fig:type:delegations}
 \end{figure}
 
 
@@ -748,10 +821,13 @@ whole transaction will be invalid.
       \var{wdrls} = \txwdrls{tx} & \var{wdrls} \subseteq \var{rewards}
     }
     {
+      \left(
       \begin{array}{r}
-        \var{tx}\\
-        \var{slot}
+        \var{slot} \\
+        \var{txIx} \\
+        \var{pp} \\
       \end{array}
+    \right)
       \vdash
       \left(
       \begin{array}{r}
@@ -760,7 +836,7 @@ whole transaction will be invalid.
         \var{delegations} \\
         \var{ptrs} \\
         \var{stpools} \\
-        \var{pparams} \\
+        \var{poolParam} \\
         \var{retiring} \\
         \var{avgs}
       \end{array}
@@ -773,7 +849,7 @@ whole transaction will be invalid.
         \var{delegations} \\
         \var{ptrs} \\
         \var{stpools} \\
-        \var{pparams} \\
+        \var{poolParam} \\
         \var{retiring} \\
         \var{avgs}
       \end{array}
@@ -788,23 +864,30 @@ whole transaction will be invalid.
     \inference[Seq-delg-ind]
     {
       \forall \var{c'}\in \Gamma;c,~\var{c'}\in\DCertDeleg \Rightarrow
-        \fun{dpool}~{c'} \in \dom \var{stpools} \\~\\
-      {
-        \begin{array}{r}
-          \var{tx}\\
-          \var{slot}\\
-        \end{array}
-      }
+        \fun{dpool}~{c'} \in \dom \var{stpools} \\
+        ptr = (\var{slot},~\var{txIx},~\mathsf{len}~\Gamma - 1) \\~\\
+        {
+          \left(
+            \begin{array}{r}
+              \var{slot}\\
+              \var{txIx}\\
+              \var{pp}\\
+            \end{array}
+          \right)
+        }
       \vdash
       \var{dpstate}
       \trans{delegs}{\Gamma}
       \var{dpstate'}
-    \\ ~ \\
+    \\~\\~\\
     {
-      \begin{array}{r}
-        \var{tx}\\
-        \var{slot}\\
-      \end{array}
+      \left(
+        \begin{array}{r}
+          \var{slot}\\
+          \var{ptr}\\
+          \var{pp}\\
+        \end{array}
+      \right)
     }
     \vdash
       \var{dpstate'}
@@ -813,10 +896,13 @@ whole transaction will be invalid.
     }
     {
     {
+      \left(
       \begin{array}{r}
-        \var{tx}\\
         \var{slot}\\
+        \var{txIx}\\
+        \var{pp}\\
       \end{array}
+    \right)
     }
     \vdash
       \var{dpstate}

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -478,15 +478,6 @@ map, and pair it with the union of all the pool keys (the domain of the
 $\var{results}$) and the associated moving averages for these (the second
 component of the range of the $\var{results}$ finite map).
 
-\begin{note}
-In the~\cite{delegation_design} document, Section 6.5.1, the values of individual
-relative stake $s$ and pool relative stake $\sigma$ are calculated by
-dividing the corresponding total values by total ADA (31, 000, 000, 000). In this
-document, we normalize pool and individual stake, i.e. obtain $s$ and $\sigma$
-by dividing by the sum total of \textit{all active stake} $tot$. We also calculate
-the relative pledge in the same way, $p_r = p \div tot$.
-\end{note}
-
 %%
 %% Figure - The Reward Calculation
 %%

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -76,14 +76,6 @@ needed for performing rewards calculations.
       & \text{base address hashkey}\\
       \fun{stakePtr} & \Addr_{ptr} \to \Ptr
       & \text{pointer address pointer}\\
-      \fun{movingAvgWeight} & \PParams \to [0, 1]
-      & \text{moving average weight}\\
-      \fun{movingAvgExp} & \PParams \to [0, 1]
-      & \text{moving average exponent}\\
-      \fun{globalPool} & \PParams \to \mathbb{R}_{>0}\times\mathbb{N}
-      & \text{global pool parameters}\\
-      \fun{globalAccntng} & \PParams \to [0,1] \times [0, 1]
-      & \text{global accounting parameters}\\
       \fun{poolCosts} & \StakePool \to \Coin\times [0,1] \times \Coin
       & \text{pool cost parameters}\\
     \end{array}
@@ -323,7 +315,8 @@ possible rewards for this pool.
            \cdot
            \left(\sigma' + p'\cdot a_0\cdot\frac{\sigma' - p'\frac{z_0-\sigma'}{z_0}}{z_0}\right)} \\
       & ~~~\where \\
-      & ~~~~~~~(a_0, n_{opt}) = \fun{globalPool}~pp \\
+      & ~~~~~~~a_0 = \fun{influence}~pp \\
+      & ~~~~~~~n_{opt} = \fun{nopt}~pp \\
       & ~~~~~~~z_0 = 1/n_{opt} \\
       & ~~~~~~~\sigma'=\min(\sigma,~z_0) \\
       & ~~~~~~~p'=\min(p_r,~z_0) \\
@@ -731,12 +724,11 @@ the ``total pot'' used during the epoch transition in Figure \ref{fig:rules:accn
     {
       {
       \begin{array}{r@{=}l}
-        \rho, \tau & \fun{globalAccntng}~{pp} \\
         \var{obl} & \obligation{pp}{stkeys}{stpools}{slot} \\
         \var{decayed} & \var{deposits} - \var{obl} \\
-        \var{expansion} & \floor*{\rho \cdot \var{reserves}} \\
+        \var{expansion} & \floor*{(\fun{rho}~{pp}) \cdot \var{reserves}} \\
         \var{totalPool} & \var{fees} + \var{decayed} + \var{rewardPot} + \var{expansion} \\
-        \var{newTreasury} & \floor*{\tau \cdot \var{totalPool}} \\
+        \var{newTreasury} & \floor*{(\fun{tau}~{pp}) \cdot \var{totalPool}} \\
         \var{availablePool} & \var{totalPool} - \var{newTreasury} \\
         \var{rewards'},~\var{avgs'} & \reward{blocksMade}{pp}{availablePool}{dpstate}{utxo}\\
         \var{paidRewards} & \sum\limits_{\_\mapsto c\in\var{rewards'}}c
@@ -887,8 +879,8 @@ The type of this state transition is given in Figure~\ref{fig:ts-types:new-proto
     \left(
       \begin{array}{r@{~\in~}ll}
         \var{slot} & \Slot & \text{current slot}\\
-        \var{pcOld} & \PParams & \text{old protocol parameters}\\
-        \var{pcNew} & \PParams & \text{new protocol parameters}\\
+        \var{ppOld} & \PParams & \text{old protocol parameters}\\
+        \var{ppNew} & \PParams & \text{new protocol parameters}\\
         \var{dstate} & \DState & \text{delegation state}\\
         \var{pstate} & \PState & \text{pool state}\\
       \end{array}
@@ -955,8 +947,8 @@ for ease of reading.
   \begin{equation}\label{eq:new-pc-accepted}
     \inference[New-Proto-Consts-Accepted]
     {
-      \var{oblgOld} = \obligation{pcOld}{stkeys}{stpools}{slot} \\
-      \var{oblgNew} = \obligation{pcNew}{stkeys}{stpools}{slot} \\
+      \var{oblgOld} = \obligation{ppOld}{stkeys}{stpools}{slot} \\
+      \var{oblgNew} = \obligation{ppNew}{stkeys}{stpools}{slot} \\
       ~\\
       \var{diff} = \var{oblgOld} - \var{oblgNew} \\
       \var{reserves} + \var{diff} \geq 0\\
@@ -987,8 +979,8 @@ for ease of reading.
     {
       \begin{array}{l}
         \var{slot}\\
-        \var{pcOld}\\
-        \var{pcNew}\\
+        \var{ppOld}\\
+        \var{ppNew}\\
         \var{dstate}\\
         \var{pstate}\\
       \end{array}
@@ -1014,8 +1006,8 @@ for ease of reading.
   \begin{equation}\label{eq:new-pc-denied}
     \inference[New-Proto-Consts-Denied]
     {
-      \var{oblgOld} = \obligation{pcOld}{stkeys}{stpools}{slot} \\
-      \var{oblgNew} = \obligation{pcNew}{stkeys}{stpools}{slot} \\
+      \var{oblgOld} = \obligation{ppOld}{stkeys}{stpools}{slot} \\
+      \var{oblgNew} = \obligation{ppNew}{stkeys}{stpools}{slot} \\
       ~\\
       \var{diff} = \var{oblgOld} - \var{oblgNew} \\
       \var{reserves} + \var{diff} < 0\\
@@ -1023,8 +1015,8 @@ for ease of reading.
     {
       \begin{array}{l}
         \var{slot}\\
-        \var{pcOld}\\
-        \var{pcNew}\\
+        \var{ppOld}\\
+        \var{ppNew}\\
         \var{dstate}\\
         \var{pstate}\\
       \end{array}
@@ -1067,8 +1059,8 @@ pool state.
     \left(
       \begin{array}{r@{~\in~}ll}
         \var{slot} & \Slot & \text{current slot}\\
-        \var{pcOld} & \PParams & \text{old protocol parameters}\\
-        \var{pcNew} & \PParams & \text{new protocol parameters}\\
+        \var{ppOld} & \PParams & \text{old protocol parameters}\\
+        \var{ppNew} & \PParams & \text{new protocol parameters}\\
         \var{blocksMade} & \HashKey \mapsto \mathbb{N} & \text{blocks made in the epoch}\\
       \end{array}
     \right)
@@ -1119,7 +1111,7 @@ be the \textit{last slot of the epoch before the boundary}.
       {
         \begin{array}{l}
           \var{slot}\\
-          \var{pcOld}\\
+          \var{ppOld}\\
           \var{blocksMade}\\
         \end{array}
       }
@@ -1171,8 +1163,8 @@ be the \textit{last slot of the epoch before the boundary}.
       {
         \begin{array}{l}
           \var{slot}\\
-          \var{pcOld}\\
-          \var{pcNew}\\
+          \var{ppOld}\\
+          \var{ppNew}\\
           \var{dstate'}\\
           \var{pstate''}\\
         \end{array}
@@ -1199,8 +1191,8 @@ be the \textit{last slot of the epoch before the boundary}.
     {
       \begin{array}{l}
         \var{slot}\\
-        \var{pcOld}\\
-        \var{pcNew}\\
+        \var{ppOld}\\
+        \var{ppNew}\\
         \var{blocksMade}\\
       \end{array}
       \vdash

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -1287,15 +1287,6 @@ variable
 \end{figure}
 
 
-\begin{note}
-  $\Coin$ is defined as a primitive type, but there is a difference
-  between implementing it with $\mathbb{N}$ versus $\mathbb{Z}$.
-  Since this is a pure UTxO ledger, $\mathbb{N}$ suffices.
-  If, however, $\mathbb{Z}$ is used, then extra validation is required
-  to ensure that all $\TxOut$ are non-negative.
-  This extra condition would be added to \cref{eq:utxo-inductive}.
-\end{note}
-
 \clearpage
 
 \subsection{Witnesses}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -60,9 +60,11 @@
 \newcommand{\AddrE}{\type{Addr_{enterprise}}}
 \newcommand{\Ptr}{\type{Ptr}}
 \newcommand{\DState}{\type{DState}}
-\newcommand{\DWState}{\type{DWState}}
 \newcommand{\DWEnv}{\type{DWEnv}}
+\newcommand{\DPSEnv}{\type{DPSEnv}}
 \newcommand{\DPEnv}{\type{DPEnv}}
+\newcommand{\DEnv}{\type{DEnv}}
+\newcommand{\PEnv}{\type{PEnv}}
 \newcommand{\DPState}{\type{DPState}}
 \newcommand{\PState}{\type{PState}}
 \newcommand{\DCertBody}{\type{DCertBody}}
@@ -105,7 +107,7 @@
 \newcommand{\deposits}[2]{\fun{deposits}~ \var{#1} ~ \var{#2}}
 \newcommand{\decayedKey}[4]{\fun{decayedKey}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
 \newcommand{\decayedTx}[3]{\fun{decayedTx}~ \var{#1}~ \var{#2}~ \var{#3}}
-\newcommand{\certRefund}[6]{\fun{certRefund}~ {#1}~{#2}~{#3}~\var{#4}~\var{#5}~\var{#6}}
+\newcommand{\keyRefund}[6]{\fun{keyRefund}~ {#1}~{#2}~{#3}~\var{#4}~\var{#5}~\var{#6}}
 \newcommand{\refund}[4]{\fun{refund}~ \var{#1}~ \var{#2}~ {#3}~ {#4}}
 \newcommand{\keyRefunds}[3]{\fun{keyRefunds}~ \var{#1}~ \var{#2}~ \var{#3}}
 \newcommand{\consumed}[4]{\fun{consumed}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
@@ -165,6 +167,10 @@
 \newcommand{\emax}{\ensuremath{\mathsf{E_{max}}}}
 \newcommand{\slotsPer}{\ensuremath{\mathsf{slotsPerEpoch}}}
 
+\newcommand{\unitInterval}{\ensuremath{[0,~1]}}
+\newcommand{\nonnegReals}{\ensuremath{[0,~\infty)}}
+\newcommand{\posReals}{\ensuremath{(0,~\infty)}}
+
 \theoremstyle{definition}
 \newtheorem{definition}{Definition}[section]
 
@@ -187,25 +193,25 @@
 The transition system is explained in \cite{small_step_semantics}.
 
 \begin{description}
-\item[Powerset] Given a set $\type{X}$, $\powerset{\type{X}}$ is the set of all
-  the subsets of $X$.
-\item[Sequences] Given a set $\type{X}$, $\seqof{\type{X}}$ is the set of
-  sequences having elements taken from $\type{X}$. The empty sequence is
-  denoted by $\epsilon$, and given a sequence $\Lambda$, $\Lambda; \type{x}$ is
-  the sequence that results from appending $\type{x} \in \type{X}$ to
-  $\Lambda$.
-\item[Functions] $A \to B$ denotes a \textbf{total function} from $A$ to $B$.
-  Given a function $f$ we write $f~a$ for the application of $f$ to argument
-  $a$.
-\item[Inverse Image] Given a function $f: A \to B$ and $b\in B$, we write
-  $f^{-1}~b$ for the \textbf{inverse image} of $f$ at $b$, which is defined by
-  $\{a \mid\ f a =  b\}$.
-\item[Maps and partial functions] $A \mapsto B$ denotes a \textbf{partial
+  \item[Powerset] Given a set $\type{X}$, $\powerset{\type{X}}$ is the set of all
+    the subsets of $X$.
+  \item[Sequences] Given a set $\type{X}$, $\seqof{\type{X}}$ is the set of
+    sequences having elements taken from $\type{X}$. The empty sequence is
+    denoted by $\epsilon$, and given a sequence $\Lambda$, $\Lambda; \type{x}$ is
+    the sequence that results from appending $\type{x} \in \type{X}$ to
+    $\Lambda$.
+  \item[Functions] $A \to B$ denotes a \textbf{total function} from $A$ to $B$.
+    Given a function $f$ we write $f~a$ for the application of $f$ to argument
+    $a$.
+  \item[Inverse Image] Given a function $f: A \to B$ and $b\in B$, we write
+    $f^{-1}~b$ for the \textbf{inverse image} of $f$ at $b$, which is defined by
+    $\{a \mid\ f a =  b\}$.
+  \item[Maps and partial functions] $A \mapsto B$ denotes a \textbf{partial
     function} from $A$ to $B$, which can be seen as a map (dictionary) with
-  keys in $A$ and values in $B$. Given a map $m \in A \mapsto B$, notation
-  $a \mapsto b \in m$ is equivalent to $m~ a = b$.
-\item[Map Operations] Figure \ref{fig:notation:nonstandard}
-  describes some non-standard map operations.
+    keys in $A$ and values in $B$. Given a map $m \in A \mapsto B$, notation
+    $a \mapsto b \in m$ is equivalent to $m~ a = b$.
+  \item[Map Operations] Figure \ref{fig:notation:nonstandard}
+    describes some non-standard map operations.
 
 \end{description}
 
@@ -298,25 +304,25 @@ it using the corresponding public key.
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \hashKey{} & \VKey \to \HashKey
-      & \text{hashKey function} \\
-      %
+                 & \text{hashKey function} \\
+                 %
       \fun{verify} & \powerset{\left(\VKey \times \Data \times \Sig\right)}
-      & \text{verification relation}\\
-      %
+                   & \text{verification relation}\\
+                   %
       \fun{sign} & \SKey \to \Data \to \Sig
-      & \text{signing function}\\
+                 & \text{signing function}\\
     \end{array}
   \end{equation*}
   \emph{Constraints}
   \begin{align*}
     & \forall (sk, vk) \in \KeyPair,~ d \in \Data,~ \sigma \in \Sig \cdot
-      \sign{sk}{d} = \sigma \implies \verify{vk}{d}{\sigma}
+    \sign{sk}{d} = \sigma \implies \verify{vk}{d}{\sigma}
   \end{align*}
   \emph{Notation for serialized and verified data}
   \begin{align*}
     & \serialised{x} & \text{serialised representation of } x\\
     & \mathcal{V}_{\var{vk}}{\serialised{d}}_{\sigma} = \verify{vk}{d}{\sigma}
-      & \text{shorthand notation for } \fun{verify}
+    & \text{shorthand notation for } \fun{verify}
   \end{align*}
   \caption{Cryptographic definitions}
   \label{fig:crypto-defs}
@@ -349,7 +355,9 @@ organization chosen for an implementation.
 \section{Addresses}
 \label{sec:addresses}
 
-TODO - Move address explanations here.
+\begin{todo}
+Move address explanations here.
+\end{todo}
 
 \begin{figure*}
   \emph{Abstract types}
@@ -404,13 +412,13 @@ TODO - Move address explanations here.
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \fun{paymentHK} & \Addr \to \HashKey
-        & \text{hash of payment key from addr}\\
+                      & \text{hash of payment key from addr}\\
       \fun{stakeHK_b} & \AddrB \to \HashKey
-        & \text{hash of stake key from base addr}\\
+                      & \text{hash of stake key from base addr}\\
       \fun{stakeHK_r} & \AddrRWD \to \HashKey
-        & \text{hash of stake key from reward account}\\
+                      & \text{hash of stake key from reward account}\\
       \fun{addrPtr} & \AddrP \to \Ptr
-        & \text{pointer from pointer addr}\\
+                    & \text{pointer from pointer addr}\\
     \end{array}
   \end{equation*}
   %
@@ -425,6 +433,96 @@ TODO - Move address explanations here.
   \end{equation*}
   \caption{Definitions used in Addresses}
   \label{fig:defs:addresses}
+\end{figure*}
+
+\clearpage
+
+\section{Protocol Parameters}
+\label{sec:protocol-parameters}
+
+The $\PParams$ is
+an abstract type that will represent an environment variable that contains
+values on which the functionality of the blockchain protocol depends, such
+as the fees transactions are obligated to pay to be processed.
+
+\begin{todo}
+Move explanations of indididual parameters explanation here.
+\end{todo}
+
+\begin{figure*}
+  \emph{Abstract types}
+  %
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      \var{fparams} & \type{FeeParams} & \text{min fee parameters}\\
+    \end{array}
+  \end{equation*}
+  %
+  \emph{Derived types}
+  %
+  \begin{equation*}
+    \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
+      \var{coin}
+      & \Coin
+      & \mathbb{Z}
+      & \text{unit of value}
+      \\
+    \end{array}
+  \end{equation*}
+  %
+  \emph{Protocol Parameters}
+  %
+  \begin{equation*}
+    \PParams =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{fparams} & \type{FeeParams} & \text{min fee parameters}\\
+        \var{keyDeposit} & \Coin & \text{stake key deposit}\\
+        \var{keyMinRefund} & \unitInterval & \text{stake key min refund}\\
+        \var{keyDecayRate} & \nonnegReals & \text{stake key decay rate}\\
+        \var{poolDeposit} & \Coin & \text{stake pool deposit}\\
+        \var{poolMinRefund} & \unitInterval & \text{stake pool min refund}\\
+        \var{poolDecayRate} & \nonnegReals & \text{stake pool decay rate}\\
+        \var{movingAvgWeight} & \unitInterval & \text{moving average weight}\\
+        \var{movingAvgExp} & \unitInterval & \text{moving average exponent}\\
+        \var{E_{max}} & \Epoch & \text{epoch bound on pool retirement}\\
+        \var{n_{opt}} & \mathbb{N}^+ & \text{desired number of pools}\\
+        \var{a_0} & \posReals & \text{pool influence}\\
+        \tau & \unitInterval & \text{treasury expansion}\\
+        \rho & \unitInterval & \text{monetary expansion}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
+  \emph{Accessor Functions}
+  %
+  \begin{center}
+    \fun{fparams},
+    \fun{keyDeposit},
+    \fun{keyMinRefund},
+    \fun{keyDecayRate},
+    \fun{poolDeposit},
+    \fun{poolMinRefund},
+    \fun{poolDecayRate},
+    \fun{movingAvgWeight},
+    \fun{movingAvgExp},
+    \fun{emax},
+    \fun{nopt},
+  \fun{influence},
+  \fun{tau},
+  \fun{rho}
+  \end{center}
+  %
+  \emph{Abstract Functions}
+  %
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      \fun{minfee} & \PParams \to \Tx \to \Coin
+                   & \text{minimum fee calculation}\\
+    \end{array}
+  \end{equation*}
+  \caption{Definitions used in Protocol Parameters}
+  \label{fig:defs:protocol-parameters}
 \end{figure*}
 
 \clearpage
@@ -478,15 +576,6 @@ that a transaction failed to be processed.
 We present the types of variables and functions needed for deposit and
 refund calculations in Figure~\ref{fig:defs:deposits}.
 
-The $\PParams$ is
-an abstract type that will represent an environment variable that contains
-values on which the functionality of the blockchain protocol depends, such
-as the fees transactions are obligated to pay to be processed. In particular,
-we define two maps here that return values stored in the set of protocol
-parameters. The map $\fun{dvalue}$ returns the amount a certificate must
-deposit to claim a specific resource (i.e. for the declaration of a new staking
-key or the registration of a stake pool, depending on the type of certificate).
-
 The map $\fun{decay}$
 represents the rate of decrease of the value of a unit of $\Coin$.
 The constant returned by $\fun{decay}$ consists of two values. The first is
@@ -530,7 +619,7 @@ which a given resource was allocated $\delta$, and a decay rate constant $\lambd
 The larger the duration, the more
 the value of the deposit decays, up to a minimum refund value.
 
-The function $\fun{certRefund}$, given a set of protocol parameters, resource
+The function $\fun{keyRefund}$, given a set of protocol parameters, resource
 allocations, slot number, and certificate, uses the refund calculation to
 assign a non-zero refund to a resource releasing certificate if also the key of
 the certificate author of which is listed in the provided resource allocations.
@@ -540,14 +629,14 @@ The minimum and decay values are also found in the protocol parameters, while
 the duration is the difference between given slot number and the slot
 number associated with the author's key in the resource allocation argument.
 
-The function $\fun{keyRefunds}$, in turn, uses $\fun{certRefund}$ to calculate
+The function $\fun{keyRefunds}$, in turn, uses $\fun{keyRefund}$ to calculate
 the total value to be refunded to all individual key deregistration
 certificate authors in a transaction.
 Given protocol parameters, resource allocations, and a transaction,
 this calculation sums up all the refunds for the individual key
 deregistration certificates
 carried by the given transaction by passing the relevant parameters to the
-$\fun{certRefund}$ function.
+$\fun{keyRefund}$ function.
 
 It is important to note here that instead of the \textit{current} slot number,
 the time to live of $\var{tx}$ is passed to the $\fun{certRefunds}$ function
@@ -595,35 +684,9 @@ body must also contain inputs onto which this refund can be added.
 
 
 \begin{figure*}
-  \emph{Abstract types}
-  \begin{equation*}
-    \begin{array}{r@{~\in~}lr}
-      pc & \PParams & \text{protocol parameters}
-    \end{array}
-  \end{equation*}
-  %
   \emph{Abstract Functions}
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \fun{dvalue} & \PParams \to \DCert \to \Coin
-        & \text{deposit amount of a certificate}\\
-
-      \fun{decayKey} & \PParams \to
-      (\Coin\times\lbrack 0, 1\rbrack\times\mathbb{Q}^{+})
-        & \text{decay parameters for key certificates}\\
-      \fun{decayPool} & \PParams \to
-      (\Coin\times\lbrack 0, 1\rbrack\times\mathbb{Q}^{+})
-        & \text{decay parameters for pool certificates}\\
-
-      \fun{dresource} & \Tx \to \powerset{(\DCertRegKey \uniondistinct \DCertRegPool)}
-        & \text{resource allocating certificates}\\
-
-      \fun{dderegister} & \Tx \to \powerset{\DCertDeRegKey}
-        & \text{resource releasing certificates}\\
-
-      \fun{dretire} & \Tx \to \powerset{\DCertRetirePool}
-        & \text{resource releasing certificates}\\
-
       \fun{ttl} & \Tx \to \Slot
         & \text{time to live}\\
     \end{array}
@@ -634,46 +697,46 @@ body must also contain inputs onto which this refund can be added.
 
 \begin{figure}
   \begin{align*}
-    & \fun{deposits} \in \PParams \to \Allocs \to \Tx \to \Coin
+    & \fun{deposits} \in \PParams \to \Allocs \to \seqof{\DCert} \to \Coin
     & \text{total deposits for transaction} \\
-    & \fun{deposits}~{pc}~{stpools}~{tx} = \sum\limits_{c \in \fun{dresource}~tx
-        \wedge \fun{author}~c \notin \dom~\var{stpools}}(\fun{dvalue}~pc~c)
+    & \fun{deposits}~{pp}~{stpools}~{certs} = \\
+    &  \sum\limits_{\substack{c\in\var{certs} \\ c\in\DCertRegKey}}(\fun{keyDeposit}~pp)
+    +  \sum\limits_{\substack{c\in\var{certs} \\ c\in\DCertRegPool \\ (\cauthor{c})\notin \var{stpools}}}
+            (\fun{poolDeposit}~pp)
       \nextdef
-      & \fun{isReleasing} \in \DCert \to \mathsf{Bool}
-      & \text{releases resources} \\
-      & \fun{isReleasing}~c = c \in \DCertDeRegKey \cup \DCertRetirePool\\
-      \nextdef
-      & \fun{refund} \in \Coin \to [0, 1] \to \mathbb{Q}^{+} \to \Duration \to \Coin
+      & \fun{refund} \in \Coin \to \unitInterval \to \posReals \to \Duration \to \Coin
       & \text{refund calculation} \\
       & \refund{\dval}{d_{\min}}{\lambda}{\delta} =
             \floor*{
               \dval \cdot
             \left(d_{\min}+(1-d_{\min})\cdot e^{-\lambda\cdot\delta}\right)}
       \nextdef
-      & \fun{certRefund} \in \Coin \to [0, 1] \to \mathbb{Q}^{+} \to \\
-      & ~~~~~\Allocs \to \Slot \to \DCert \to \Coin
-      & \text{refund for a certificate} \\
-      & \certRefund{\dval}{d_{\min}}{\lambda}{allocs}{slot}{c} =\\
+      & \fun{keyRefund} \in \Coin \to \unitInterval \to \posReals \to \\
+      & ~~~~~\Allocs \to \Slot \to \DCertDeRegKey \to \Coin
+      & \text{key refund for a certificate} \\
+      & \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{slot}{c} =\\
       & ~~~~~\begin{cases}
-        0 & \text{if not}~(\fun{isReleasing}~c)\\
-            0 & \text{if}~\cauthor c \notin \dom allocs\\
+            0 & \text{if}~\cauthor c \notin \dom stkeys\\
             \refund{\dval}{d_{\min}}{\lambda}{\delta}
             & \text{otherwise}
         \end{cases}\\
       &
       \begin{array}{lr@{~=~}l}
         \where
-        &\delta & \slotminus{slot}{(allocs~(\cauthor c))}\\
+        &\delta & \slotminus{slot}{(stkeys~(\cauthor c))}\\
       \end{array}\\
       \nextdef
       & \fun{keyRefunds} \in \PParams \to \Allocs \to \Tx \to \Coin
-      & \text{key refunds for transaction} \\
-      & \keyRefunds{pc}{stkeys}{tx} =\\
-      & ~~~~~ \sum\limits_{c \in \fun{dderegister}~tx} \certRefund{\dval}{d_{\min}}{\lambda}{stkeys}{(\ttl{tx})}{c}\\
+      & \text{key refunds for a transaction} \\
+      & \keyRefunds{pp}{stkeys}{tx} =\\
+      & ~~~~~ \sum\limits_{\substack{c \in \fun{dcerts}~tx \\ c\in\DCertDeRegKey}}
+              \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{(\ttl{tx})}{c}\\
       &
       \begin{array}{lr@{~=~}l}
-        \where
-        & (\dval,~d_{\min},~\lambda) & \fun{decayKey}~\var{pc}\\
+        \where \\
+        & \dval & \fun{keyDeposit}~\var{pp}\\
+        & d_{\min} & \fun{keyMinRefund}~\var{pp}\\
+        & \lambda & \fun{keyDecayRate}~\var{pp}\\
       \end{array}\\
   \end{align*}
   \caption{Functions used in Deposits - Refunds}
@@ -726,11 +789,10 @@ Section~\cref{sec:epoch}.
       & \fun{lastEpoch}~{s} =  s~\mathsf{mod}~\slotsPer
       \nextdef
       & \fun{decayedKey} \in
-      \PParams \to \Allocs \to \Slot \to \DCert \to \Coin
+      \PParams \to \Allocs \to \Slot \to \DCertDeRegKey \to \Coin
       & \text{decayed since epoch} \\
-      & \decayedKey{pc}{stkeys}{cslot}{c} =\\
+      & \decayedKey{pp}{stkeys}{cslot}{c} =\\
       & \begin{cases}
-        0 & \text{if not}~(\fun{isReleasing}~c)\\
             0 & \text{if}~\cauthor c \notin \dom stkeys\\
             \var{epochRefund} - \var{currentRefund}
             & \text{otherwise}
@@ -740,15 +802,18 @@ Section~\cref{sec:epoch}.
         \where
           & \var{created} & \var{stkeys}~(\cauthor~\var{c}) \\
           & \var{start} & \mathsf{max}~(lastEpoch~cslot)~created \\
-          & \var{epochRefund} & \certRefund{\dval}{d_{\min}}{\lambda}{stkeys}{start}{c} \\
-          & \var{currentRefund} & \certRefund{\dval}{d_{\min}}{\lambda}{stkeys}{cslot}{c} \\
-          & (\dval,~d_{\min},~\lambda) & \fun{decayKey}~\var{pc}\\
+          & \var{epochRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{start}{c} \\
+          & \var{currentRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{cslot}{c} \\
+          & \dval & \fun{keyDeposit}~\var{pp}\\
+          & d_{\min} & \fun{keyMinRefund}~\var{pp}\\
+          & \lambda & \fun{keyDecayRate}~\var{pp}\\
       \end{array}\\
       \nextdef
       & \fun{decayedTx} \in \PParams \to \Allocs \to \Tx \to \Coin
       & \text{decayed deposit portions} \\
-      & \decayedTx{pc}{stkeys}{tx} =\\
-      &   \sum\limits_{c \in \fun{dderegister}~tx} \decayedKey{pc}{stkeys}{(\ttl{tx})}{c}\\
+      & \decayedTx{pp}{stkeys}{tx} =\\
+      &   \sum\limits_{\substack{c \in \fun{dcerts}~tx \\ c \in\DCertDeRegKey}}
+          \decayedKey{pp}{stkeys}{(\ttl{tx})}{c}\\
   \end{align*}
   \caption{Functions used in Deposits - Decay}
   \label{fig:functions:deposits-decay}
@@ -877,8 +942,6 @@ account for this address and added to the UTxO.
       %
       \fun{txfee} & \Tx \to \Coin & \text{transaction fee}\\
       %
-      \fun{minfee} & \PParams \to \Tx \to \Coin & \text{minimum fee}\\
-      %
       \fun{txwdrls} & \Tx \to \Wdrl & \text{transaction withdrawals}\\
     \end{array}
   \end{equation*}
@@ -981,16 +1044,16 @@ deposits is found in the protocol parameters, not in $\var{stkeys}$ or $\var{stp
     \nextdef
     & \fun{consumed} \in \PParams \to \UTxO \to \Allocs \to \Wdrl \to \Tx \to \Coin
     & \text{value consumed} \\
-    & \consumed{pc}{utxo}{stkeys}{rewards}~{tx} = \\
+    & \consumed{pp}{utxo}{stkeys}{rewards}~{tx} = \\
     & ~~\balance{(\txins{tx} \restrictdom \var{utxo})} +
         \sum_{(a \mapsto c) \in \fun{txwdrls}~{tx}} c  \\
-        & + \keyRefunds{pc}{stkeys}{tx} \\
+        & + \keyRefunds{pp}{stkeys}{tx} \\
     \nextdef
     & \fun{produced} \in \PParams \to \Allocs \to \Tx \to \Coin
     & \text{value produced} \\
-    & \fun{produced} ~ pc ~ stpools ~ tx = \\
+    & \fun{produced} ~ pp ~ stpools ~ tx = \\
     &~~\balance{(\txouts{tx})}
-     + \txfee{tx} + \deposits{pc}{stpools}~{tx}\\
+    + \txfee{tx} + \deposits{pp}{stpools}~{(\dcerts{tx})}\\
   \end{align*}
 
   \caption{Functions used in UTxO rules}
@@ -1021,7 +1084,7 @@ a transaction $\var{tx}$ in the environment $\UTxOEnv$.
     \left(
       \begin{array}{r@{~\in~}lr}
         \var{slot} & \Slot & \text{current slot}\\
-        \var{pc} & \PParams & \text{protocol parameters}\\
+        \var{pp} & \PParams & \text{protocol parameters}\\
         \var{stkeys} & \Allocs & \text{stake key}\\
         \var{stpools} & \Allocs & \text{stake pool}\\
       \end{array}
@@ -1176,10 +1239,10 @@ variable
     \inference[UTxO-inductive]
     { \ttl tx \geq \var{slot}
       & \txins{tx} \neq \emptyset
-      & \minfee{pc}{tx} \leq \txfee{tx}
+      & \minfee{pp}{tx} \leq \txfee{tx}
       & \txins{tx} \subseteq \dom \var{utxo}
       \\
-      \consumed{pc}{utxo}{stkeys}{rewards}~{tx} = \produced{pc}{stpools}~{tx}
+      \consumed{pp}{utxo}{stkeys}{rewards}~{tx} = \produced{pp}{stpools}~{tx}
       \\
       ~
       \\
@@ -1188,16 +1251,16 @@ variable
       \\
       ~
       \\
-      \var{refunded} = \keyRefunds{pc}{stkeys}~{tx}
+      \var{refunded} = \keyRefunds{pp}{stkeys}~{tx}
       \\
-      \var{decayed} = \decayedTx{pc}{stkeys}~{tx}
+      \var{decayed} = \decayedTx{pp}{stkeys}~{tx}
       \\
-      \var{depositChange} = (\deposits{pc}~{stpools}~{tx}) - (\var{refunded} + \var{decayed})
+      \var{depositChange} = (\deposits{pp}~{stpools}~{tx}) - (\var{refunded} + \var{decayed})
     }
     {
       \begin{array}{l}
         \var{slot}\\
-        \var{pc}\\
+        \var{pp}\\
         \var{stkeys}\\
         \var{stpools}\\
       \end{array}
@@ -1422,7 +1485,7 @@ protocol parameters.
 
 The full ledger state consists of a $\UTxOState$ state variable (keeping track of
 the UTxO, deposits, fees, etc.), as well as
-a $\DWState$ state variable (which keeps track of registered keys and pools).
+a $\DPState$ state variable (which keeps track of registered keys and pools).
 This state type and the type of the transition rule is given in
 (see Figure~\ref{fig:ts-types:ledger}). The ledger state transition is signaled
 by a transaction.
@@ -1434,7 +1497,8 @@ by a transaction.
     \left(
       \begin{array}{r@{~\in~}lr}
         \var{slot} & \Slot & \text{current slot}\\
-        \var{pc} & \PParams & \text{protocol parameters}\\
+        \var{txIx} & \Ix & \text{transaction index}\\
+        \var{pp} & \PParams & \text{protocol parameters}\\
       \end{array}
     \right)
   \end{equation*}
@@ -1445,7 +1509,7 @@ by a transaction.
     \left(
       \begin{array}{r@{~\in~}lr}
         \var{utxoSt} & \UTxOState & \text{UTxO state}\\
-        \var{dwstate} & \DWState & \text{delegation witnesess state}\\
+        \var{dpstate} & \DPState & \text{delegation and pool state}\\
       \end{array}
     \right)
   \end{equation*}
@@ -1473,7 +1537,7 @@ the antecedent. However, the $\UTxOState$ transition also contains the
 stake keys and stake pools resource allocations in the context. This is not
 an issue since all this difference is highlighting is that in a $\UTxOState$
 transition, these variables are immutable (but they do change in the full
-ledger state and the $\DWState$ transitions).
+ledger state and the $\DPState$ transitions).
 
 The full ledger state transition combines the UTxO transition and the
 delegation transition into a single transition
@@ -1487,11 +1551,11 @@ by the given transaction.
     {
       (\var{dstate}, \var{pstate}) = \var{dpstate} \\
     (\var{stkeys}, \_, \_, \_) = \var{dstate} \\
-    (\_, \_, \var{stpools}, \_) = \var{pstate} \\
+    (\_, \_, \var{stpools}, \_) = \var{pstate} \\~\\
       \left({
         \begin{array}{r}
         \var{slot} \\
-        \var{pc} \\
+        \var{pp} \\
         \var{stkeys} \\
         \var{stpools}
         \end{array}
@@ -1499,18 +1563,25 @@ by the given transaction.
       \vdash \var{utxoSt} \trans{utxow}{tx} \var{utxoSt'}\\~\\~\\
       %
       {
+        \left(
         \begin{array}{l}
-          slot \\
+          \var{slot} \\
+          \var{txIx} \\
+          \var{pp} \\
         \end{array}
+      \right)
       }
       \vdash
       dpstate \trans{delegs}{\var{tx}} dpstate'
     }
     {
-      \begin{array}{l}
-        \var{slot}\\
-        \var{pc}\\
-      \end{array}
+      \left(
+        \begin{array}{l}
+          \var{slot} \\
+          \var{txIx} \\
+          \var{pp} \\
+        \end{array}
+      \right)
       \vdash
       \left(
         \begin{array}{ll}

--- a/latex/properties.tex
+++ b/latex/properties.tex
@@ -21,7 +21,7 @@ Section~\ref{sec:delegation} for delegation.
     \ledgerState & \in & \left(
                          \begin{array}{c}
                            \UTxO \\
-                           \DWState
+                           \DPState
                          \end{array}
     \right)\\
                && \\
@@ -36,7 +36,7 @@ In Figure~\ref{fig:valid-ledger} \genesisId{} marks the transaction identifier
 of the initial coin distribution, where \genesisTxOut{} represents the initial
 UTxO. It should be noted that no corresponding inputs exists, i.e., the
 transaction inputs are the empty set for the initial transaction. An element of
-\ledgerState{} is a tuple of UTxO and delegation witness state (\DWState).
+\ledgerState{} is a tuple of UTxO and delegation witness state (\DPState).
 
 \begin{definition}[\textbf{Valid Ledger State}]
   \begin{multline*}


### PR DESCRIPTION
This PR places all the protocol parameters into a single table:

![pparams](https://user-images.githubusercontent.com/943479/51343024-616b0980-1a63-11e9-99f5-b749330b1cff.png)

All the accessor functions are just listed, I did not think it was very helpful to write them all out with type signatures, etc.

Since the `deposits` method uses the protocol parameters, I took the opportunity to rewrite it and hopefully make it clearer:

![deposits](https://user-images.githubusercontent.com/943479/51343201-d4748000-1a63-11e9-9654-ca6f75be7a6a.png)

Additionally, I made the max pool retirement bound, `E_max` a protocol parameter.  Since this change touched the environment for the `POOL` transition, and therefore also the `DELEGS` environment, I took the opportunity to redo how the certificate pointers are passed to the `DELEG` transition:

![certix](https://user-images.githubusercontent.com/943479/51343328-3208cc80-1a64-11e9-88b3-95e1645c56d1.png)

Note that `txIx` (the transaction index in a block) is now a part of the `LEDGER` transition environment.

Lastly, `Coin` is now defined as an alias for the integers.

#181 #178 #204