### PR TITLE
Allocs type split into StakeKeys and StakePools

### DIFF
--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -42,7 +42,7 @@ and inputs in a UTxO or a transaction
 \item epochs
 \item slot numbers
 \item duration: the difference between two slot numbers
-\item $\StakePool$: constants found in a stake pool registration certificate
+\item $\PoolParam$: constants found in a stake pool registration certificate
 (we must continue to keep track of these after registration is complete)
 \end{itemize}
 
@@ -62,8 +62,9 @@ and, in a very similarly
 way, a type for transitions describing stake pool-related ledger updates
 (i.e. $\PState$ transitions).
 
-The type $\Allocs$ is a general datatype used to represent both individual and stake
-pool resource allocations. It stores, as a finite map, the hash key to which the resource is
+The type $\StakeKeys$ represents individual key registrations and $\StakePools$
+represents stake pool registrations.
+They both store, as a finite maps, the hash key to which the resource is
 allocated, and the corresponding slot number in which this allocation
 (registration) was made. Here we also introduce the pointer structure
 $\Ptr$, which we will use to index stake keys based on
@@ -76,7 +77,7 @@ of the certificate inside the transaction (i.e.\ its position in the list of
 the transaction's certificates).
 
 The maps $\fun{hash}$, $\fun{addr_{rwd}}$, $\fun{author}$, $\fun{dpool}$,
-$\fun{stakepool}$,
+$\fun{poolParam}$,
 $\fun{retire}$, $\fun{epoch}$, and $\fun{slot}$ are all used to
 retrieve specific information about the origin type. The subtraction $\slotminus{}{}$
 of slots gives the number of slots in between (referred to here as
@@ -92,7 +93,7 @@ $\Duration$ here by $\var{dur}$).
     \begin{array}{r@{~\in~}lr}
       dur & \Duration & \text{duration}\\
       epoch & \Epoch & \text{epoch} \\
-      stakepool & \StakePool & \text{stake pool parameters} \\
+      poolParam & \PoolParam & \text{stake pool parameters} \\
     \end{array}
   \end{equation*}
   %
@@ -115,10 +116,15 @@ $\Duration$ here by $\var{dur}$).
   \emph{Derived types}
   \begin{equation*}
     \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
-      \var{allocs}
-      & \Allocs
+      \var{stkeys}
+      & \StakeKeys
       & \HashKey \mapsto \Slot
-      & \text{resource allocations} \\
+      & \text{registered stake keys} \\
+      %
+      \var{stpools}
+      & \StakePools
+      & \HashKey \mapsto \Slot
+      & \text{registered stake pools} \\
     \end{array}
   \end{equation*}
   %
@@ -132,10 +138,10 @@ $\Duration$ here by $\var{dur}$).
   \fun{dpool} & \DCertDeleg \to \HashKey
   & \text{pool being delegated to}
   \\
-  \fun{stakepool} & \DCertRegPool \to \StakePool
+  \fun{poolParam} & \DCertRegPool \to \PoolParam
   & \text{stake pool}
   \\
-  \fun{poolowners} & \StakePool \to \powerset{\HashKey}
+  \fun{poolowners} & \PoolParam \to \powerset{\HashKey}
   & \text{stake pool owners}
   \\
   \fun{retire} & \DCertRetirePool \to \Epoch
@@ -167,7 +173,7 @@ In \cref{fig:delegation-transitions} we give the delegation and stake pool
 state transition types. We define two separate parts of the ledger state.
 The part of the ledger state keeping track of current delegations, $\DState$,
 consists of four variables. The first, $\var{stkeys}$, keeps track of individual
-stake key resource allocations using the $\Allocs$ type.
+stake key resource allocations.
 
 Note that for security, privacy, and usability reasons, the staking (delegating)
 key pair associated with an address must be different from its paying key pair.
@@ -202,12 +208,12 @@ epoch boundary reward calculations, see Section~\ref{sec:epoch}.
 The ledger additionally keeps track of the stake pools in a separate state variable
 $\PState$.
 This state contains a list of registered stake pools, $\var{stpools}$.
-These are again stored as pairs of type $\Allocs$. The stake pool certificates
-do contain useful data that must be stored. However, they are stored in a
+The stake pool certificates contain useful data that must be stored.
+However, they are stored in a
 separate variable in order to allow us to use a signle datatype for
 all deposit and refund calculations for both individual and pool key registrations
 and deregistrations or retirement. The variable that stores other necessary pool
-registration data is $\var{poolParam}$, and is a finite map that stores $\StakePool$
+registration data is $\var{poolParams}$, and is a finite map that stores $\PoolParam$
 constants indexed by the hash keys to which they correspond.
 Finally, $\var{avgs}$ stores the latest value of the pool's moving average
 used in the reward calculation, see Section~\ref{sec:epoch}. This value
@@ -235,7 +241,7 @@ certificate (contained in a signal transaction).
     \begin{array}{l}
     \DState =
     \left(\begin{array}{r@{~\in~}lr}
-      \var{stkeys} & \Allocs & \text{registered stake keys}\\
+      \var{stkeys} & \StakeKeys & \text{registered stake keys}\\
       \var{rewards} & \AddrRWD \mapsto \Coin & \text{rewards}\\
       \var{delegations} & \HashKey_{stkey} \mapsto \HashKey_{pool} & \text{delegations}\\
       \var{ptrs} & \Ptr \mapsto \HashKey & \text{pointer to hashkey}\\
@@ -244,8 +250,8 @@ certificate (contained in a signal transaction).
     \\
     \PState =
     \left(\begin{array}{r@{~\in~}lr}
-      \var{stpools} & \Allocs & \text{registered pools to creation time}\\
-      \var{poolParam} & \HashKey \mapsto \StakePool
+      \var{stpools} & \StakePools & \text{registered pools to creation time}\\
+      \var{poolParams} & \HashKey \mapsto \PoolParam
         & \text{registered pools to pool parameters}\\
       \var{retiring} & \HashKey \mapsto \Epoch & \text{retiring stake pools}\\
       \var{avgs} & \HashKey \mapsto \mathbb{R}_{>0} & \text{performance moving average}\\
@@ -482,14 +488,14 @@ The first rule, \cref{eq:pool-reg}, can only be used to register a stake pool
 with a new key (to which no stake pool was previously registered).
 When this rule is invoked,
  the author's key and current slot number are added to $\var{stpools}$, and the
-key and $\var{stakepool}$ constants in the certificate are added to the $\var{poolParam}$
+key and $\var{poolParam}$ constants in the certificate are added to the $\var{poolParams}$
 finite map.
 
 The second rule, \cref{eq:pool-rereg}, is used to re-register a
 stake pool with a new certificate ($\var{c}$), or stop the retirement
 process for that key. It does not update the slot number recorded previously
 for the registration of this key, but it does update the associated pool constants
-in $\var{poolParam}$. The author's hash key and associated data
+in $\var{poolParams}$. The author's hash key and associated data
 are also removed from the $\var{retiring}$ parameter to cancel any pending
 retirement for that key.
 
@@ -542,7 +548,7 @@ that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
       \left(
       \begin{array}{r}
         \var{stpools} \\
-        \var{poolParam} \\
+        \var{poolParams} \\
         \var{retiring} \\
         \var{avgs}
       \end{array}
@@ -552,8 +558,8 @@ that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
       \begin{array}{rcl}
         \varUpdate{\var{stpools}} & \varUpdate{\union}
                                   & \varUpdate{\{\var{hk} \mapsto \var{slot}\}} \\
-        \varUpdate{\var{poolParam}} & \varUpdate{\union}
-                                    & \varUpdate{\{\var{hk} \mapsto \stakepool{c}\}} \\
+        \varUpdate{\var{poolParams}} & \varUpdate{\union}
+                                    & \varUpdate{\{\var{hk} \mapsto \poolParam{c}\}} \\
        \var{retiring} \\
        \var{avgs}
       \end{array}
@@ -577,7 +583,7 @@ that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
       \left(
       \begin{array}{r}
         \var{stpools} \\
-        \var{poolParam} \\
+        \var{poolParams} \\
         \var{retiring} \\
         \var{avgs}
       \end{array}
@@ -586,8 +592,8 @@ that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
       \left(
       \begin{array}{rcl}
         \var{stpools} \\
-        \varUpdate{\var{poolParam}} & \varUpdate{\unionoverrideRight}
-                                  & \varUpdate{\{\var{hk} \mapsto \stakepool{c}\}}\\
+        \varUpdate{\var{poolParams}} & \varUpdate{\unionoverrideRight}
+                                  & \varUpdate{\{\var{hk} \mapsto \poolParam{c}\}}\\
         \varUpdate{\{\var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{retiring}} \\
         \var{avgs}
       \end{array}
@@ -614,7 +620,7 @@ that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
     \left(
       \begin{array}{r}
         \var{stpools} \\
-        \var{poolParam} \\
+        \var{poolParams} \\
         \var{retiring} \\
         \var{avgs}
       \end{array}
@@ -623,7 +629,7 @@ that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
     \left(
       \begin{array}{rcl}
         \var{stpools} \\
-        \var{poolParam} \\
+        \var{poolParams} \\
         \varUpdate{\var{retiring}} & \varUpdate{\unionoverrideRight}
                                    & \varUpdate{\{\var{hk} \mapsto \var{e}\}} \\
         \var{avgs}
@@ -831,7 +837,7 @@ whole transaction will be invalid.
         \var{delegations} \\
         \var{ptrs} \\
         \var{stpools} \\
-        \var{poolParam} \\
+        \var{poolParams} \\
         \var{retiring} \\
         \var{avgs}
       \end{array}
@@ -844,7 +850,7 @@ whole transaction will be invalid.
         \var{delegations} \\
         \var{ptrs} \\
         \var{stpools} \\
-        \var{poolParam} \\
+        \var{poolParams} \\
         \var{retiring} \\
         \var{avgs}
       \end{array}

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -76,7 +76,7 @@ needed for performing rewards calculations.
       & \text{base address hashkey}\\
       \fun{stakePtr} & \Addr_{ptr} \to \Ptr
       & \text{pointer address pointer}\\
-      \fun{poolCosts} & \StakePool \to \Coin\times [0,1] \times \Coin
+      \fun{poolCosts} & \PoolParam \to \Coin\times [0,1] \times \Coin
       & \text{pool cost parameters}\\
     \end{array}
   \end{equation*}
@@ -143,15 +143,16 @@ These stake-related calculations are used in the calculation of rewards.
       & \text{potential stake} \\
       & \fun{stake}~{outs}~{ptrs} = (\fun{baseStake}~{outs}) \cup (\fun{ptrStake}~{outs}~{ptrs})
       \nextdef
-      & \fun{isActive} \in \HashKey \to \Allocs \to (\HashKey \mapsto \HashKey) \to \Allocs \to \mathbb{B}
+      & \fun{isActive} \in \HashKey \to \StakeKeys \to (\HashKey \mapsto \HashKey) \\
+      & ~~ \to \StakePools \to \mathbb{B}
       & \text{active stake} \\
       & \isActive{v_{sk}}{stkeys}{delegs}{stpools} = \exists \var{v_{p}}\\
       & ~~ \var{v_{sk}} \in \dom stkeys
               \land \var{v_{sk}}\mapsto\var{v_{p}} \in delegs
               \land \var{v_{p}} \in \dom \var{stpools}
       \nextdef
-      & \fun{activeStake} \in \powerset{\TxOut} \to (\Ptr \mapsto \HashKey) \to \Allocs\\
-      & ~~\to (\HashKey \mapsto \HashKey) \to \Allocs \to (\HashKey \mapsto \Coin)
+      & \fun{activeStake} \in \powerset{\TxOut} \to (\Ptr \mapsto \HashKey) \to \StakeKeys\\
+      & ~~\to (\HashKey \mapsto \HashKey) \to \StakePools \to (\HashKey \mapsto \Coin)
       & \text{active stake holdings} \\
       & \activeStake{outs}{ptrs}{stkeys}{delegs}{stpools} = \\
       & ~~ \left\{
@@ -199,7 +200,7 @@ at the epoch boundary.
 %%
 \begin{figure}[htb]
   \begin{align*}
-      & \fun{obligation} \in \PParams \to \Allocs \to \Allocs \to \Slot \to \Coin
+      & \fun{obligation} \in \PParams \to \StakeKeys \to \StakePools \to \Slot \to \Coin
       & \text{total possible refunds} \\
       & \obligation{pp}{stkeys}{stpools}{cslot} =\\
       & \sum\limits_{(\_ \mapsto s) \in \var{stkeys}}
@@ -213,7 +214,8 @@ at the epoch boundary.
           & (p_{\mathsf{val}},~p_{\min},~\lambda_p) & \fun{decayPool}~\var{pp}\\
       \end{array}\\
       \nextdef
-      & \fun{poolRefunds} \in \PParams \to \Allocs \to \Slot \to (\HashKey \mapsto \Coin)
+      & \fun{poolRefunds} \in \PParams \to (\HashKey \mapsto \Epoch) \\
+      & ~~ \to \Slot \to (\HashKey \mapsto \Coin)
       & \text{pool refunds} \\
       & \poolRefunds{pp}{retiring}{cslot} = \\
       & \bigcup_{\var{hk}\mapsto s\in\var{retiring}}
@@ -239,7 +241,7 @@ following variables, sourced as indicated (listed here for reference):
 \item[] From the delegation state:
 \item $\var{avgs}$ stores the (moving) average for each
 stake pool
-\item $\var{poolParam}$ stores stake pool-specific parameters
+\item $\var{poolParams}$ stores stake pool-specific parameters
 \item $\var{delegs}$ stores delegations as stake and pool key pairs \medskip
 
 From the boundary accounting transition context:
@@ -259,7 +261,7 @@ influence on pool rewards
 \item $\gamma$ is the moving average exponent constant \medskip
 
 From pool-specific parameters denoted $\var{pool}$, associated to a specific
-hash key in $\var{poolParam}$:
+hash key in $\var{poolParams}$:
 \item $c \in \Coin$ is the pool costs
 \item $m \in [0,1]$ is the stake pool margin
 \item $p \in \Coin$ is the pledge a stake key registering a pool defines (via
@@ -377,7 +379,7 @@ which the given leader is the leader of.
 %%
 \begin{figure}[htb]
   \begin{align*}
-      & \fun{leaderRew} \in \Coin \to \StakePool \to [0, 1] \to [0, 1] \to \Coin
+      & \fun{leaderRew} \in \Coin \to \PoolParam \to [0, 1] \to [0, 1] \to \Coin
       & \text{pool leader reward} \\
       & \fun{leaderRew}~\hat{f}~\var{pool}~\sigma~\var{s} = \\
       & \begin{cases}
@@ -388,7 +390,7 @@ which the given leader is the leader of.
       & ~~~\where \\
       & ~~~~~~~(c, m, \_) = \fun{poolCosts}~pool \\
       \nextdef
-      & \fun{memberRew} \in \Coin \to \StakePool \to [0, 1] \to [0, 1] \to \Coin
+      & \fun{memberRew} \in \Coin \to \PoolParam \to [0, 1] \to [0, 1] \to \Coin
       & \text{pool member reward} \\
       & \fun{memberRew}~\hat{f}~\var{pool}~\sigma~\var{s} = \\
       & \begin{cases}
@@ -399,7 +401,7 @@ which the given leader is the leader of.
       & ~~~\where \\
       & ~~~~~~~(c, m, \_) = \fun{poolCosts}~pool \\
       \nextdef
-      & \fun{indivRew} \in \Coin \to \StakePool \to [0, 1] \to [0, 1] \to \mathbb{B} \to \Coin
+      & \fun{indivRew} \in \Coin \to \PoolParam \to [0, 1] \to [0, 1] \to \mathbb{B} \to \Coin
       & \text{pool individual reward} \\
       & \fun{indivRew}~\hat{f}~\var{pool}~\sigma~\var{s}~\var{isLeader} = \\
       & \begin{cases}
@@ -483,7 +485,7 @@ component of the range of the $\var{results}$ finite map).
 %%
 \begin{figure}[htb]
   \begin{align*}
-      & \fun{rewardOnePool} \in \PParams \to \Coin \to \mathbb{N} \to \HashKey \to \StakePool\\
+      & \fun{rewardOnePool} \in \PParams \to \Coin \to \mathbb{N} \to \HashKey \to \PoolParam\\
       & ~~~\to (\HashKey \mapsto \Coin)\to \Distr \to \Coin \to (\AddrRWD \mapsto \Coin)\times[0, 1]
       & \text{reward one pool} \\
       & \fun{rewardOnePool}~\var{pp}~\var{R}~\var{n}~\var{poolHK}~\var{pool}
@@ -517,7 +519,7 @@ component of the range of the $\var{results}$ finite map).
       & ~~~~~~~\var{outs} = \{out\mid\_\mapsto\var{out}\in\var{utxo}\} \\
       & ~~~~~~~\var{dstate},\var{pstate} = \var{dpstate} \\
       & ~~~~~~~\var{stkeys},\_,\var{delegs},\var{ptrs} = \var{dstate} \\
-      & ~~~~~~~\var{stpools},\var{poolParam},\var{retiring},\var{avgs} = \var{pstate} \\
+      & ~~~~~~~\var{stpools},\var{poolParams},\var{retiring},\var{avgs} = \var{pstate} \\
       & ~~~~~~~active = \activeStake{outs}{ptrs}{stkeys}{delegs}{stpools} \\
       & ~~~~~~~tot = \sum_{\_\mapsto c\in \var{active}}c \\
 %      & ~~~~~~~stDistr = \left\{ hk\mapsto c \div tot \mid hk \mapsto c \in \var{active} \right\}\\
@@ -525,7 +527,7 @@ component of the range of the $\var{results}$ finite map).
       & ~~~~~~~pdata = \left\{
                          hk\mapsto (pool, n, actgr)  \mathrel{\Bigg|}
                           \begin{array}{r@{\mapsto}c@{~\in~}l}
-                          hk & \var{pool} & \var{poolParam} \\
+                          hk & \var{pool} & \var{poolParams} \\
                           hk & \var{n} & \var{prod} \\
                           hk & \var{actgr} & \var{pactive} \\
                           \end{array}
@@ -743,7 +745,7 @@ the ``total pot'' used during the epoch transition in Figure \ref{fig:rules:accn
           \var{delegations} \\
           \var{ptrs} \\
           \var{stpools} \\
-          \var{poolParam} \\
+          \var{poolParams} \\
           \var{retiring} \\
           \var{avgs} \\
           \var{utxo} \\
@@ -762,7 +764,7 @@ the ``total pot'' used during the epoch transition in Figure \ref{fig:rules:accn
           \var{delegations} \\
           \var{ptrs} \\
           \var{stpools} \\
-          \var{poolParam} \\
+          \var{poolParams} \\
           \var{retiring} \\
           \varUpdate{\var{avgs'}} \\
           \var{utxo} \\
@@ -802,7 +804,7 @@ however, this one has an empty signal (as it happens at the boundary).
 We now present the pool-cleanup transition rule in Figure~\ref{fig:rules:pool-clean}.
 This rule will be applied whenever there is one or more stake pools scheduled
 to retire this epoch. If so, all of the entries in $\var{stpools}$,
-$\var{poolParam}$, and $\var{retiring}$ which correspond to any of the hash keys
+$\var{poolParams}$, and $\var{retiring}$ which correspond to any of the hash keys
 of the stake pools scheduled to retire this epoch are removed from
 these variables.
 
@@ -831,7 +833,7 @@ for potential future use.
       \left(
         \begin{array}{r}
           \var{stpools} \\
-          \var{poolParam} \\
+          \var{poolParams} \\
           \var{retiring} \\
           \var{avgs} \\
         \end{array}
@@ -840,7 +842,7 @@ for potential future use.
       \left(
         \begin{array}{rcl}
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{stpools}} \\
-          \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{poolParam}} \\
+          \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{poolParams}} \\
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{retiring}} \\
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{avgs}} \\
         \end{array}

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -43,7 +43,8 @@
 \newcommand{\PParams}{\type{PParams}}
 \newcommand{\Slot}{\type{Slot}}
 \newcommand{\Duration}{\type{Duration}}
-\newcommand{\Allocs}{\type{Allocs}}
+\newcommand{\StakePools}{\type{StakePools}}
+\newcommand{\StakeKeys}{\type{StakeKeys}}
 
 \newcommand{\DCert}{\type{DCert}}
 \newcommand{\DCertRegKey}{\type{DCert_{regkey}}}
@@ -51,7 +52,7 @@
 \newcommand{\DCertDeleg}{\type{DCert_{delegate}}}
 \newcommand{\DCertRegPool}{\type{DCert_{regpool}}}
 \newcommand{\DCertRetirePool}{\type{DCert_{retirepool}}}
-\newcommand{\StakePool}{\type{StakePool}}
+\newcommand{\PoolParam}{\type{PoolParam}}
 \newcommand{\UTxOState}{\ensuremath{\type{UTxOState}}}
 \newcommand{\ledgerState}{\ensuremath{\type{ledgerState}}}
 
@@ -124,7 +125,7 @@
 \newcommand{\RetirePool}[1]{\textsc{RetirePool}(#1)}
 \newcommand{\cauthor}[1]{\fun{author}~ \var{#1}}
 \newcommand{\dpool}[1]{\fun{dpool}~ \var{#1}}
-\newcommand{\stakepool}[1]{\fun{stakepool}~ \var{#1}}
+\newcommand{\poolParam}[1]{\fun{poolParam}~ \var{#1}}
 \newcommand{\retire}[1]{\fun{retire}~ \var{#1}}
 \newcommand{\addrRw}[1]{\fun{addr_{rwd}}~ \var{#1}}
 \newcommand{\epoch}[1]{\fun{epoch}~ \var{#1}}
@@ -580,9 +581,6 @@ The constant returned by $\fun{decay}$ consists of two values. The first is
 a natural number which determines the minimal proportion of a deposit that will
 be refunded on resource release. The second is a positive rational number
 used to determine the rate of (exponential) decrease of the value.
-Recall that the $\Allocs$ type pairs a hash key with a slot number and is a generic datatype
-which we use below to represent both individual and pool allocation
-parameters passed to refund calculations.
 
 For a given transaction and protocol parameters, the map $\fun{dresource}$
 returns all the certificates of that transaction which allocate resources
@@ -598,12 +596,10 @@ The functions used in refund calculations are presented in
 Figure~\ref{fig:functions:deposits-refunds}.
 The function
 $\fun{deposits}$ returns the total deposits that have to be made by a transaction.
-This calculation is
-based on the resource-allocating certificates it carries and the protocol parameters.
+This calculation is based on the protocol parameters.
 Specifically, for a given transaction,
-it sums up the values of all the deposits made by the resource-allocating
-certificates that are \textit{resource allocations to new keys}.  Those
-certificates which are
+it sums up the values of the stake key deposits and the stake pool deposits.
+Those certificates which are
 updates of stake pool parameters of already registered pool keys should not
 (and are, in fact, not allowed to) make a deposit.
 
@@ -683,7 +679,7 @@ body must also contain inputs onto which this refund can be added.
 
 \begin{figure}
   \begin{align*}
-    & \fun{deposits} \in \PParams \to \Allocs \to \seqof{\DCert} \to \Coin
+    & \fun{deposits} \in \PParams \to \StakePools \to \seqof{\DCert} \to \Coin
     & \text{total deposits for transaction} \\
     & \fun{deposits}~{pp}~{stpools}~{certs} = \\
     &  \sum\limits_{\substack{c\in\var{certs} \\ c\in\DCertRegKey}}(\fun{keyDeposit}~pp)
@@ -698,7 +694,7 @@ body must also contain inputs onto which this refund can be added.
             \left(d_{\min}+(1-d_{\min})\cdot e^{-\lambda\cdot\delta}\right)}
       \nextdef
       & \fun{keyRefund} \in \Coin \to \unitInterval \to \posReals \to \\
-      & ~~~~~\Allocs \to \Slot \to \DCertDeRegKey \to \Coin
+      & ~~~~~\StakeKeys \to \Slot \to \DCertDeRegKey \to \Coin
       & \text{key refund for a certificate} \\
       & \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{slot}{c} =\\
       & ~~~~~\begin{cases}
@@ -712,7 +708,7 @@ body must also contain inputs onto which this refund can be added.
         &\delta & \slotminus{slot}{(stkeys~(\cauthor c))}\\
       \end{array}\\
       \nextdef
-      & \fun{keyRefunds} \in \PParams \to \Allocs \to \Tx \to \Coin
+      & \fun{keyRefunds} \in \PParams \to \StakeKeys \to \Tx \to \Coin
       & \text{key refunds for a transaction} \\
       & \keyRefunds{pp}{stkeys}{tx} =\\
       & ~~~~~ \sum\limits_{\substack{c \in \fun{dcerts}~tx \\ c\in\DCertDeRegKey}}
@@ -748,7 +744,7 @@ full-duration decayed refund value ($\fun{currentRefund}$) calculated based on
 the given slot number.
 
 The amount decayed for individual keys is then computed by adding the values of
-$$\fun{decayed}~\var{allocs}~\var{pc}~(\fun{txttl}~\var{tx})~\var{c}$$
+$$\fun{decayed}~\var{stkeys}~\var{pc}~(\fun{txttl}~\var{tx})~\var{c}$$
 for each deregistration certificate in a given transaction, and is given by
 $$\fun{decatedTx}~\var{pc}~\var{stkeys}~\var{cslot}~\var{c}$$
 Here, again, we use the $\fun{txttl}~\var{tx}$ value in the calculation instead of the current
@@ -771,7 +767,7 @@ Section~\cref{sec:epoch}.
 \begin{figure}
   \begin{align*}
       & \fun{decayedKey} \in
-      \PParams \to \Allocs \to \Slot \to \DCertDeRegKey \to \Coin
+      \PParams \to \StakeKeys \to \Slot \to \DCertDeRegKey \to \Coin
       & \text{decayed since epoch} \\
       & \decayedKey{pp}{stkeys}{cslot}{c} =\\
       & \begin{cases}
@@ -791,7 +787,7 @@ Section~\cref{sec:epoch}.
           & \lambda & \fun{keyDecayRate}~\var{pp}\\
       \end{array}\\
       \nextdef
-      & \fun{decayedTx} \in \PParams \to \Allocs \to \Tx \to \Coin
+      & \fun{decayedTx} \in \PParams \to \StakeKeys \to \Tx \to \Coin
       & \text{decayed deposit portions} \\
       & \decayedTx{pp}{stkeys}{tx} =\\
       &   \sum\limits_{\substack{c \in \fun{dcerts}~tx \\ c \in\DCertDeRegKey}}
@@ -1041,16 +1037,16 @@ deposits is found in the protocol parameters, not in $\var{stkeys}$ or $\var{stp
         & \fun{reapRewards}~\var{rewards}~\var{wdrls} =
          \var{rewards} \unionoverrideRight \{(w, 0) \mid w \in \dom \var{wdrls}\} \\
     \nextdef
-    & \fun{consumed} \in \PParams \to \UTxO \to \Allocs \to \Wdrl \to \Tx \to \Coin
+    & \fun{consumed} \in \PParams \to \UTxO \to \StakeKeys \to \Wdrl \to \Tx \to \Coin
     & \text{value consumed} \\
     & \consumed{pp}{utxo}{stkeys}{rewards}~{tx} = \\
     & ~~\balance{(\txins{tx} \restrictdom \var{utxo})} +
         \sum_{(a \mapsto c) \in \fun{txwdrls}~{tx}} c  \\
         & + \keyRefunds{pp}{stkeys}{tx} \\
     \nextdef
-    & \fun{produced} \in \PParams \to \Allocs \to \Tx \to \Coin
+    & \fun{produced} \in \PParams \to \StakePools \to \Tx \to \Coin
     & \text{value produced} \\
-    & \fun{produced} ~ pp ~ stpools ~ tx = \\
+    & \fun{produced}~\var{pp}~\var{stpools}~\var{tx} = \\
     &~~\balance{(\outs{tx})}
     + \txfee{tx} + \deposits{pp}{stpools}~{(\dcerts{tx})}\\
   \end{align*}
@@ -1084,8 +1080,8 @@ a transaction $\var{tx}$ in the environment $\UTxOEnv$.
       \begin{array}{r@{~\in~}lr}
         \var{slot} & \Slot & \text{current slot}\\
         \var{pp} & \PParams & \text{protocol parameters}\\
-        \var{stkeys} & \Allocs & \text{stake key}\\
-        \var{stpools} & \Allocs & \text{stake pool}\\
+        \var{stkeys} & \StakeKeys & \text{stake key}\\
+        \var{stpools} & \StakePools & \text{stake pool}\\
       \end{array}
     \right)
   \end{equation*}


### PR DESCRIPTION
The `Allocs` type has, up until now, been representing both the registered stake keys and the registered stake pools. It is an alias for `HashKey |-> Slot`, since we keep track of the slot when registrations happened in order to calculate the deposit refunds.

We realized, however, that this generality (ie have one type for both) was both never really needed and confusing. Therefore this PR removes `Allocs` and replaces it with `StakeKeys` and `StakePools`. The aliases are the same as they were before: `HashKey |-> Slot`.

This forced a bit of other renaming.  The previous type which held the stake pool parameters has been changed from `StakePool` to `PoolParam`.  We now use the variable name `poolParam` to represent the parameters associated with a single stake pool, and `poolParams` (plural) to represent mappings from hashkeys to such parameters.

#176 