### PR TITLE
reordering prose and adding pool refunds

### DIFF
--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -31,76 +31,57 @@ also include a mapping from active stake keys to rewards.
 \subsection{Delegation Definitions}
 \label{sec:deleg-defs}
 
-In \cref{fig:delegation-definitons} we give the delegation primitives.
+In \cref{fig:delegation-defs} we give the delegation primitives.
 Here we introduce the following primitive datatypes used in delegation:
 
 \begin{itemize}
-\item reward addresses: different from base addresses introduced later
-\item indexes: this type is used to index certificates in a transaction,
-index of a transaction inside a slot, outputs inside a transaction,
-and inputs in a UTxO or a transaction
-\item epochs
-\item slot numbers
-\item duration: the difference between two slot numbers
-\item $\PoolParam$: constants found in a stake pool registration certificate
-(we must continue to keep track of these after registration is complete)
+\item $\DCertRegKey$: a stake key registration certificate.
+\item $\DCertDeRegKey$: a stake key de-registration certificate.
+\item $\DCertDeleg$: a stake key delegation certificate.
+\item $\DCertRegPool$: a stake pool registration certificate.
+\item $\DCertRetirePool$: a stake key retirement certificate.
+\item $\DCert$: any one of of the five certificate types above.
+\end{itemize}
+The following derived types are introduced:
+\begin{itemize}
+  \item $\type{StakeKeys}$ represents registered stake keys, and is represented by a finite
+    map from hashkeys to slot when it was registered.
+  \item$\type{StakePools}$ represents registered stake pools, and has the same type as
+    $\type{StakeKeys}$.
+\item $\PoolParam$ represents the parameters found in a stake pool registration certificate
+  that must be tracked:
+  \begin{itemize}
+    \item the pool owners.
+    \item the pool cost.
+    \item the pool margin.
+    \item the pool pledge.
+  \end{itemize}
 \end{itemize}
 
-The constant $\emax$ gives the number of epochs a stake pool will take to retire.
-The type $\DCert$ is a generic certificate type, which can be a registration,
-deregistration or delegation certificate for a key, or a registration/retirement
- certificate for a stake pool. It is denoted as disjoint union in the figure,
-one should, however, think of a term of this type as a term of a specific
-one of these five subtypes.
-
-Note that the reason for combining the different types of
-certificates into a common type is that it allows us to use that type to later
-define a single type for all
-ledger state transitions having to do with delegation (i.e. $\DState$
-transitions),
-and, in a very similarly
-way, a type for transitions describing stake pool-related ledger updates
-(i.e. $\PState$ transitions).
-
-The type $\StakeKeys$ represents individual key registrations and $\StakePools$
-represents stake pool registrations.
-They both store, as a finite maps, the hash key to which the resource is
-allocated, and the corresponding slot number in which this allocation
-(registration) was made. Here we also introduce the pointer structure
-$\Ptr$, which we will use to index stake keys based on
-when and by what transaction they were registered.
-
-A variable of this type consists of
-the slot number when transaction (which carried the key registration certificate)
-was processed, the index of the transaction inside that slot, and the index
-of the certificate inside the transaction (i.e.\ its position in the list of
-the transaction's certificates).
-
-The maps $\fun{hash}$, $\fun{addr_{rwd}}$, $\fun{author}$, $\fun{dpool}$,
-$\fun{poolParam}$,
-$\fun{retire}$, $\fun{epoch}$, and $\fun{slot}$ are all used to
-retrieve specific information about the origin type. The subtraction $\slotminus{}{}$
-of slots gives the number of slots in between (referred to here as
-$\Duration$ here by $\var{dur}$).
+Accessor functions for certificates and pool parameters are also defined, but
+only the $\cwitness{}$ accessor function needs explanation.
+It does the following:
+\begin{itemize}
+\item For a $\DCertRegKey$ certificate, $\cwitness{}$ returns the hashkey
+  of the key being registered.
+\item For a $\DCertDeRegKey$ certificate, $\cwitness{}$ returns the hashkey
+  of the key being de-registered.
+\item For a $\DCertDeleg$ certificate, $\cwitness{}$ returns the hashkey
+  of the key that is delegating (and not the key to which the stake in being delegated to).
+\item For a $\DCertRegPool$ certificate, $\cwitness{}$ returns the hashkey
+  of the key of the pool operator.
+\item For a $\DCertRetirePool$ certificate, $\cwitness{}$ returns the hashkey
+  of the key of the pool operator.
+\end{itemize}
 
 %%
 %% Figure - Delegation Definitions
 %%
-\begin{figure}
+\begin{figure}[htb]
   \emph{Abstract types}
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      dur & \Duration & \text{duration}\\
-      epoch & \Epoch & \text{epoch} \\
-      poolParam & \PoolParam & \text{stake pool parameters} \\
-    \end{array}
-  \end{equation*}
-  %
-  \emph{Constants}
-  \begin{equation*}
-    \begin{array}{r@{~\in~}lr}
-      \slotsPer & \N & \text{slots per epoch} \\
     \end{array}
   \end{equation*}
   %
@@ -125,15 +106,20 @@ $\Duration$ here by $\var{dur}$).
       & \StakePools
       & \HashKey \mapsto \Slot
       & \text{registered stake pools} \\
+      %
+      \var{poolParam}
+      & \PoolParam
+      & \powerset{\HashKey} \times \Coin \times \unitInterval \times \Coin
+      & \text{stake pool parameters} \\
     \end{array}
   \end{equation*}
   %
-  \emph{Abstract functions}
+  \emph{Certificate Accessor functions}
   %
   \begin{equation*}
   \begin{array}{r@{~\in~}lr}
-  \fun{author} & \DCert \to \HashKey
-  & \text{certificate author}
+    \cwitness{} & \DCert \to \HashKey
+  & \text{certificate witness}
   \\
   \fun{dpool} & \DCertDeleg \to \HashKey
   & \text{pool being delegated to}
@@ -141,26 +127,32 @@ $\Duration$ here by $\var{dur}$).
   \fun{poolParam} & \DCertRegPool \to \PoolParam
   & \text{stake pool}
   \\
-  \fun{poolowners} & \PoolParam \to \powerset{\HashKey}
-  & \text{stake pool owners}
-  \\
   \fun{retire} & \DCertRetirePool \to \Epoch
   & \text{epoch of pool retirement}
-  \\
-  \fun{epoch} & \Slot \to \Epoch
-  & \text{epoch of a slot}
-  \\
-  \fun{slot} & \Epoch \to \Slot
-  & \text{first slot of an epoch}
-  \\
-    (\slotminus{}{}) & \Slot \to \Slot \to \Duration
-  & \text{duration between slots}
   \end{array}
   \end{equation*}
   %
+  \emph{Pool Parameter Accessor functions}
+  %
+  \begin{equation*}
+  \begin{array}{r@{~\in~}lr}
+    \fun{poolOwners} & \PoolParam \to \powerset{\HashKey}
+                     & \text{stake pool owners}
+    \\
+    \fun{poolCost} & \PoolParam \to \Coin
+                     & \text{stake pool cost}
+    \\
+    \fun{poolMargin} & \PoolParam \to \unitInterval
+                     & \text{stake pool margin}
+    \\
+    \fun{poolPledge} & \PoolParam \to \Coin
+                     & \text{stake pool pledge}
+    \\
+  \end{array}
+  \end{equation*}
 
   \caption{Delegation Definitions}
-  \label{fig:delegation-definitons}
+  \label{fig:delegation-defs}
 \end{figure}
 
 \clearpage
@@ -171,65 +163,36 @@ $\Duration$ here by $\var{dur}$).
 
 In \cref{fig:delegation-transitions} we give the delegation and stake pool
 state transition types. We define two separate parts of the ledger state.
-The part of the ledger state keeping track of current delegations, $\DState$,
-consists of four variables. The first, $\var{stkeys}$, keeps track of individual
-stake key resource allocations.
 
-Note that for security, privacy, and usability reasons, the staking (delegating)
-key pair associated with an address must be different from its paying key pair.
-\textit{Every address} must have a paying key \textit{and} a stake key
-associated to it in order to participate in using the currency. Before the
-stake key is registered and delegates to an existing stake pool,
-the money at its address can be used for
-transactions, but does not accumulate additional stake (i.e. rewards/money).
-Once the stake key is registered and delegating, either the base address or
-the pointer address can be used to generate outputs
-in a transaction. However, it makes more sense to use the shorter pointer
-address at this point.
+\begin{itemize}
+  \item $\DState$ keeps track of the delegation state, consisting of:
+    \begin{itemize}
+      \item $\var{stkeys}$ tracks the registered stake keys. It consists of a finite
+        mapping from hashkeys to the slot of the registration.
+      \item $\var{rewards}$ stores the rewards accumulated by stake keys.
+        These are represented by a finite map from reward addresses to the accumulated rewards.
+      \item $\var{delegations}$ stores the delegation relation, mapping stake keys to the
+        pool to which is delegates.
+      \item $\var{ptrs}$ maps stake keys to the position of the registration certificate
+        in the blockchain. This is needed to lookup the stake hashkey of a pointer address.
+    \end{itemize}
+  \item $\PState$ keeps track of the stake pool information:
+    \begin{itemize}
+      \item $\var{stpools}$ tracks the registered stake pools. It consists of a finite
+        mapping from hashkeys to the slot of the registration.
+      \item $\var{poolParams}$ tracks the parameters associated with each stake pool, such as
+        their costs and margin.
+      \item $\var{retiring}$ tracks stake pool retirements, using a map from hashkeys to
+        the epoch in which it will retire.
+      \item $\var{avgs}$ stores the latest value of the pool's performance moving average.  This
+        value quantifies the desirability of delegating to a given pool, based on past performance.
+    \end{itemize}
+\end{itemize}
 
-Note also that individual key registration
-and deregistration certificates contain no important data beyond a declaration
-of registration, and thus are not stored as part of the state variables once
-they have been processed.
-
-The second, $\var{rewards}$, stores the
-rewards accumulated by stake keys. These are represented by
-a finite
-map that matches addresses with the coin value of the rewards belonging to the
-key to which this address is associated. The third
-variable in $\DState$ stores currently registered delegations.
-Delegations ($\var{delegations}$) are also expressed by a finite map, which
-associates a stake key with the hash key of the pool to which it delegates.
-Finally, the finite map $\var{ptrs}$ variable stores,
-indexed by pointers,
-the stake keys associated with these pointers. This data is needed for the
-epoch boundary reward calculations, see Section~\ref{sec:epoch}.
-
-The ledger additionally keeps track of the stake pools in a separate state variable
-$\PState$.
-This state contains a list of registered stake pools, $\var{stpools}$.
-The stake pool certificates contain useful data that must be stored.
-However, they are stored in a
-separate variable in order to allow us to use a signle datatype for
-all deposit and refund calculations for both individual and pool key registrations
-and deregistrations or retirement. The variable that stores other necessary pool
-registration data is $\var{poolParams}$, and is a finite map that stores $\PoolParam$
-constants indexed by the hash keys to which they correspond.
-Finally, $\var{avgs}$ stores the latest value of the pool's moving average
-used in the reward calculation, see Section~\ref{sec:epoch}. This value
-quantifies, as a fraction, the desirability of delegating to the given pool, calculated
-based on past performance.
-
-The state $\PState$ also keeps track of
-stake pools scheduled to retire via the variable $\var{retiring}$,
-which associates
-a stake pool hash key with the epoch in which it is supposed to retire.
-
-The environment for state transitions for both $\DState$ and $\PState$ contains
-only the current slot number. The $\DState$ transition DELEG as well as
-the $\PState$ transition POOL are both triggered by a
-certificate (contained in a signal transaction).
-
+The environment for the state transition for $\DState$ contains the current slot number
+and the index for the current certificate pointer.
+The environment for the state transition for $\PState$ contains the current slot number
+and the protocol parameters.
 
 %%
 %% Figure - Delegation Transitions
@@ -302,80 +265,57 @@ certificate (contained in a signal transaction).
 \label{sec:deleg-rules}
 
 
-The rules for registering and delegating stake keys are given in
-\cref{fig:delegation-rules}. The preconditions for the registration of a stake
-key ensure that a given certificate $c$ is of the correct type
-(i.e. $\DCertRegKey$),
-and that the hash key associated with the author of the certificate is not
-already found in the current list of stake keys.
-
-In order to delegate to a stake pool, a stake key must first be registered.
-When registering a new stake key (the \cref{eq:deleg-reg} inference rule),
+The rules for registering and delegating stake keys are given in \cref{fig:delegation-rules}.
+Note that section 5.2 of \cite{delegation_design} describes how a wallet would help a user choose
+a stake pool, though these concerns are independent of the ledger rules.
 
 \begin{itemize}
-\item the key must be
-added to the set of stake keys ($\var{stkeys}$),
-\item the rewards for the address
-corresponding to that key set to 0,
-\item the pointers consisting of the current slot number, the
-index of the transaction in this slot, and the index of the certificate, is
-added to the $\var{pointers}$ finite map, mapping to the new key
-\item no new delegations are added
+  \item Stake key registration is handled by \cref{eq:deleg-reg}, since it contains the
+    precondition that the certificate has type $\DCertRegKey$.
+    All the equations in $\mathsf{DELEG}$ and $\mathsf{POOL}$ follow this same pattern of matching
+    on certificate type.
+
+    There is also a precondition on registration that the hashkey associated with the certificate
+    witness of the certificate is not already found in the current list of stake keys.
+
+    Registration causes the following state transformation:
+    \begin{itemize}
+      \item The key is added to the set of registered stake keys.
+      \item A reward account is created for this key, with a starting balance of zero.
+      \item The certificate pointer is mapped to the new stake key.
+    \end{itemize}
+
+  \item Stake key deregistration is handled by \cref{eq:deleg-dereg}.
+    There is a precondition that the key has been registered, and that the reward balance is zero.
+    Deregistration causes the following state transformation:
+    \begin{itemize}
+      \item The key is removed from the collection of registered keys.
+      \item The reward account is removed.
+      \item The key is removed from the delegation relation.
+      \item The certificate pointer is removed.
+    \end{itemize}
+
+  \item Stake key delegation is handled by \cref{eq:deleg-deleg}.
+    There is a precondition that the key has been registered.
+    Delegation causes the following state transformation:
+    \begin{itemize}
+      \item The delegation relation is updated so that stake stake key is delegated to the given
+        stake pool. The use of union override here allows us to use the same rule
+        to perform both an initial delegation and an update to an existing delegation.
+    \end{itemize}
 \end{itemize}
 
-Note that
-since the hash key corresponding to the address must not have been previously
-registered,
-it should not have any rewards in its associated address. Thus, it is safe
-to set the rewards to 0 using union override (i.e. replace any value previously
-associated with this address with 0).
-
-When deregistering a key (the \cref{eq:deleg-dereg} rule), we again
-require that the certificate is of the correct type. We also require
-that the key of the author is indeed a registered stake key
-in order to be able to retrieve its address for the rewards update.
-
-As a result of this rule, the author's key must be removed from the $\var{stkeys}$ list,
-and all the rewards, pointers, and delegations associated with this key must be removed
-from the $\var{rewards}$, $\var{pointers}$, and $\var{delegations}$ parameters as well.
-
-Finally, for creating a delegation (the \cref{eq:deleg-deleg} rule),
-given that the certificate $c$ is of the correct type, we add to the
-$\var{delegations}$ finite map the pair of
-the author's hash key and hash key of the pool being delegated to.
-Again, we require the author's key be a registered key, as it does not make
-sense to allow delegation otherwise.
-
-The $\var{stkeys}$, $\var{rewards}$, and $\var{pointers}$ parameters are kept constant by
-this rule. The use of union override here allows us to use the same rule
-to perform an update on an existing delegation while keeping the rewards
-associated with the key accounted for.
-
-The rules of the distribution of rewards to eligible stake holders are described
-in Section~\ref{sec:epoch}, since the amount of rewards they can claim in the next
-epoch is calculated at the epoch boundary. However, the claiming of the rewards
-(i.e.\ conversion of reward value to unspent outputs available to the key
-holder), can be requested by the key holder at any time as part of a transaction.
-
-We would like to point out, here, that this document does not describe
-how the wallet makes a decision about which stake pool a stake key will
-delegate to. This decision, however, is influenced by some parameters in the
-protocol. These parameters determine which stake pools are more profitable
-to delegate to, as well as the optimal number of stake pools in the system,
-by means of regulating reward distribution.
-This avoids forming a monopoly of a single large stake pool constantly
-being delegated to.
 
 
 %%
 %% Figure - Delegation Rules
 %%
-\begin{figure}
+\begin{figure}[hbt]
   \centering
   \begin{equation}\label{eq:deleg-reg}
     \inference[Deleg-Reg]
     {
-    \var{c}\in\DCertRegKey & hk = \cauthor{c} & hk \notin \dom \var{stkeys}
+    \var{c}\in\DCertRegKey & hk = \cwitness{c} & hk \notin \dom \var{stkeys}
     }
     {
       \begin{array}{r}
@@ -406,7 +346,7 @@ being delegated to.
   \begin{equation}\label{eq:deleg-dereg}
     \inference[Deleg-Dereg]
     {
-      \var{c}\in \DCertDeRegKey  & hk = \cauthor{c} \\
+      \var{c}\in \DCertDeRegKey  & hk = \cwitness{c} \\
     hk \in \dom \var{stkeys} & hk \mapsto 0 \in \var{rewards}
     }
     {
@@ -438,7 +378,7 @@ being delegated to.
   \begin{equation}\label{eq:deleg-deleg}
     \inference[Deleg-Deleg]
     {
-      \var{c}\in \DCertDeleg & hk = \cauthor{c} & hk \in \dom \var{stkeys}
+      \var{c}\in \DCertDeleg & hk = \cwitness{c} & hk \in \dom \var{stkeys}
     }
     {
       \begin{array}{r}
@@ -480,63 +420,60 @@ The rules for updating the part of the ledger state defining the current stake
 pools are given in \cref{fig:pool-rules}. The calculation of stake distribution
 is described in Section~\ref{sec:stake-dist}.
 
-In the pool rules, the stake key is used directly to register a stake pool.
-For each rule, again, we first check that a given certificate $c$ is of
-the correct type.
+In the pool rules, the stake pool is identified with the hashkey of the pool operator.
+For each rule, again, we first check that a given certificate $c$ is of the correct type.
 
-The first rule, \cref{eq:pool-reg}, can only be used to register a stake pool
-with a new key (to which no stake pool was previously registered).
-When this rule is invoked,
- the author's key and current slot number are added to $\var{stpools}$, and the
-key and $\var{poolParam}$ constants in the certificate are added to the $\var{poolParams}$
-finite map.
+\begin{itemize}
+  \item Stake pool registration is handled by \cref{eq:pool-reg}.
+    It is required that the pool not be currently registered.
+    Registration causes the following state transformation:
+    \begin{itemize}
+      \item The key is added to the set of registered stake pools.
+      \item The pool's parameters are stored.
+    \end{itemize}
+  \item Stake pool parameter updates are handled by \cref{eq:pool-reg}.
+    This rule, which also matches on the certificate type $\type{DCertRegPool}$,
+    is distinguished from \cref{eq:pool-reg} by the requirement that
+    the pool be registered. This rule also ends stake pool retirements.
+    Reregistration causes the following state transformation:
+    \begin{itemize}
+      \item The pool's parameters are updated.
+      \item The pool is removed from the collection of retiring pools.
+      \item Note that $\var{stpools}$ is \textbf{not} updated.
+        The registration creation slot does does not change.
+    \end{itemize}
+  \item Stake pool retirements are handled by \cref{eq:pool-ret}.
+    Given a slot number $\var{slot}$, the application of this rule requires that the
+    planned retirement epoch $\var{e}$ stated in the certificate is in the future,
+    i.e. after $\var{cepoch}$, the epoch of the current slot number in this context, as well as
+    that it is less than $\emax$ epochs after the current one.
+    It is also required that the pool be registered.
+    Note that imposing the $\emax$ constraint on the system is not strictly necessary.
+    However, forcing stake pools to announce their retirement a shorter time in
+    advance will curb the growth of the $\var{retiring}$ list in the ledger state.
 
-The second rule, \cref{eq:pool-rereg}, is used to re-register a
-stake pool with a new certificate ($\var{c}$), or stop the retirement
-process for that key. It does not update the slot number recorded previously
-for the registration of this key, but it does update the associated pool constants
-in $\var{poolParams}$. The author's hash key and associated data
-are also removed from the $\var{retiring}$ parameter to cancel any pending
-retirement for that key.
+    The pools scheduled for retirement must be removed from
+    the $\var{retiring}$ state variable at the end of the epoch they are scheduled
+    to retire in. This non-signaled transition (triggered, instead, directly by a
+    change of current slot number in the environment), along with all other transitions
+    that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
 
-The third rule, \cref{eq:pool-ret}, starts the pool retirement process. Given a
-slot number $\var{slot}$, the application of this rule requires that the
-planned retirement epoch $\var{e}$ stated in the certificate is in the future,
-i.e. after
-$\var{cepoch}$, the epoch of the current slot number in this context, as well as
-that it is
-less than $\emax$ epochs after the current one. Another precondition for this
-rule is that
-the certificate author's key is in the set of the registered pools' keys.
-This rule simply adds the pair of the
-certificate author's key and the planned retirement epoch $e$ to the $\var{retiring}$
-parameter, overrwiting any existing retirement schedule for the key.
-
-Note that imposing the $\emax$ constraint on the system is not strictly necessary.
-However, forcing stake pools to announce their retirement a shorter time in
-advance will curb the growth of the $\var{retiring}$ list in the ledger state
-(this is a finite map used to keep track of what stake pool is retiring when,
-discussed in more detail later).
-Allowing pools to make retirement announcements arbitrarily far in advance
-could result in a linear (in the number of pools) growth of storage space needed
-for this datatype.
-
-The pools scheduled for retirement must be removed from
-the $\var{retiring}$ state variable at the end of the epoch they are scheduled
-to retire in. This non-signaled transition (triggered, instead, directly by a
-change of current slot number in the environment), along with all other transitions
-that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
-
+    Reregistration causes the following state transformation:
+    \begin{itemize}
+      \item The pool is marked to retire on the given epoch.
+        If it was previously retiring, the retirement epoch is now updated.
+    \end{itemize}
+\end{itemize}
 
 %%
 %% Figure - Pool Rules
 %%
-\begin{figure}
+\begin{figure}[hbt]
   \begin{equation}\label{eq:pool-reg}
     \inference[Pool-Reg]
     {
       \var{c}\in\DCertRegPool
-      & \cauthor{c} = \var{hk}
+      & \cwitness{c} = \var{hk}
       & hk \notin \dom \var{stpools}
     }
     {
@@ -571,7 +508,7 @@ that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
     \inference[Pool-reReg]
     {
       \var{c}\in\DCertRegPool
-      & \cauthor{c} = \var{hk}
+      & \cwitness{c} = \var{hk}
       & hk \in \dom \var{stpools}
     }
     {
@@ -605,7 +542,7 @@ that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
     \inference[Pool-Retire]
     {
     \var{c} \in \DCertRetirePool
-    & hk = \cauthor{c}
+    & hk = \cwitness{c}
     & \var{hk} \in \dom \var{stpools} \\
     \var{e} = \retire{c}
     & \var{cepoch} = \epoch{slot}
@@ -643,13 +580,16 @@ that take place at the epoch boundary, are described in Section~\ref{sec:epoch}.
 
 \end{figure}
 
+\clearpage
 
-Next, we give the state, environment, and transition type for the full delegation
-state transition, which includes the delegations ($\DState$) and the stake pools
-($\PState$), see
-Figure~\ref{fig:defs:delpl}.
+\subsection{Delegation and Pool Combined Rules}
+\label{sec:del-pool-rules}
 
-\begin{figure}
+We now combine the delegation and pool transition systems.
+Figure~\ref{fig:defs:delpl} gives the state, environment, and transition type for the
+combined transition.
+
+\begin{figure}[hbt]
   \emph{Delegation and Pool Combined Environment}
   \begin{equation*}
     \DPEnv =
@@ -683,17 +623,14 @@ Figure~\ref{fig:defs:delpl}.
   \label{fig:defs:delpl}
 \end{figure}
 
+\clearpage
 
-In the following Figure~\ref{fig:rules:delpl}, we give the rules for
-defining a valid state transition for the combined delegation and pool
-state, $\DPState$, signaled by a certificate. There are two separate rules,
-one where only the
-delegation state changes, and one where only the pool state changes.
-This is because a certificate can never trigger a transition of both kinds,
-and can only be applied to \textit{either} register (deregister) a key,
-\textit{or} to register (retire) a pool.
+Figure~\ref{fig:rules:delpl}, gives the rules for the combined transition.
+Note that for any given certificate, at most one of the two rules
+(\cref{eq:delpl-d} and \cref{eq:delpl-p})
+will be successful, since the pool certificates are disjoint from the delegation certificates.
 
-\begin{figure}
+\begin{figure}[hbt]
   \emph{Delegation and Pool Combined Rules}
   \begin{equation}
     \label{eq:delpl-d}
@@ -731,7 +668,7 @@ and can only be applied to \textit{either} register (deregister) a key,
       \right)
     }
   \end{equation}
-    \begin{equation}
+  \begin{equation}
     \label{eq:delpl-p}
     \inference[Delpl-Pool]
     {
@@ -771,29 +708,14 @@ and can only be applied to \textit{either} register (deregister) a key,
   \label{fig:rules:delpl}
 \end{figure}
 
+We now describe a transition system that processes the list of certificates inside a transaction.
+It is defined recursively from the transition system in Figure~\ref{fig:rules:delpl} above.
 
-Now, since a transaction can carry more than one certificate at a time, we need
-to give the specifics of processing the entire list of certificates (contained
-in a transaction).
+Figure~\ref{fig:type:delegations} defines the types for the delegation certificate sequence
+transition.
 
-We may do so by defining a new type of transition, where the signal type is a
-list of certificates, as illustrated in Figure~\ref{fig:rules:delegation-sequence}.
-The transition itself is defined recursively, so that
-an empty list results in a state transition to itself, and given
-a list $\Gamma$ of certificates signaling a valid DELEGS transition, as well
-as a DELPL transition signaled by certificate $c$, the transition
-composed of these two transitions in sequence, signaled by the list $c; \Gamma$
-is also valid.
-
-This definition guarantees a certificate list (and therefore, the transaction
-carrying it) cannot be processed unless every
-certificate in it is valid. For example, if a transaction is carrying a
-certificate that schedules a pool retirement in a past epoch, the
-whole transaction will be invalid.
-
-
-\begin{figure}
-  \emph{Certificate List Environment}
+\begin{figure}[hbt]
+  \emph{Certificate Sequence Environment}
   \begin{equation*}
     \DPSEnv =
     \left(
@@ -810,16 +732,48 @@ whole transaction will be invalid.
     \powerset (
     \DPSEnv \times \DPState \times \seqof{\DCert} \times \DPState)
   \end{equation*}
-  \caption{Delegation with a certificate list transition type}
+  \caption{Delegation sequence transition type}
   \label{fig:type:delegations}
 \end{figure}
 
+Figure~\ref{fig:rules:delegation-sequence} defines the transition system recursively.
+This definition guarantees that a certificate list (and therefore, the transaction carrying it)
+cannot be processed unless every certificate in it is valid. For example, if a transaction is
+carrying a certificate that schedules a pool retirement in a past epoch, the whole transaction
+will be invalid.
 
-\begin{figure}
+\begin{itemize}
+  \item The base case, when the list is empty, is captured by \cref{eq:delegs-base}.
+    In the base case, we address one final accounting detail not yet covered by the UTxO
+    transition, namely setting the reward account balance to zero for any account that made a
+    withdrawal.  There is therefore a precondition that all withdrawals are correct, where
+    correct means that there is a reward account for each stake key, and that the balance
+    matches that of the reward being withdrawn.
+    The base case triggers the following state transformation:
+    \begin{itemize}
+      \item Reward accounts are set to zero for each corresponding withdrawal.
+    \end{itemize}
+  \item The inductive case, when the list is non-empty, is captured by \cref{eq:delegs-induct}.
+    It constructs a certificate pointer given the current slot and transaction index,
+    calls $\mathsf{DELPL}$ on the next certificate in the list, and inductively
+    calls $\mathsf{DELEGS}$ on the rest of the list.
+    The inductive case triggers the following state transformation:
+    \begin{itemize}
+      \item The delegation and pool states are (inductively) updated by the results of
+        $\mathsf{DELEGS}$, which is then updated according to $\mathsf{DELPL}$.
+    \end{itemize}
+\end{itemize}
+
+\begin{figure}[hbt]
   \begin{equation}
+    \label{eq:delegs-base}
     \inference[Seq-delg-base]
     {
-      \var{wdrls} = \txwdrls{tx} & \var{wdrls} \subseteq \var{rewards}
+      \var{wdrls} = \txwdrls{tx}
+      &
+      \var{wdrls} \subseteq \var{rewards}
+      \\
+      \var{rewards'} = \var{rewards} \unionoverrideRight \{(w, 0) \mid w \in \dom \var{wdrls}\}
     }
     {
       \left(
@@ -846,7 +800,7 @@ whole transaction will be invalid.
       \left(
       \begin{array}{r}
         \var{stkeys} \\
-        \varUpdate{\fun{reapRewards}~\var{rewards}~\var{wdrls}} \\
+        \varUpdate{rewards'} \\
         \var{delegations} \\
         \var{ptrs} \\
         \var{stpools} \\
@@ -856,16 +810,15 @@ whole transaction will be invalid.
       \end{array}
       \right)
     }
-    \label{eq:rule:sequence-delegation-base}
   \end{equation}
 
   \nextdef
 
   \begin{equation}
+    \label{eq:delegs-induct}
     \inference[Seq-delg-ind]
     {
-      \forall \var{c'}\in \Gamma;c,~\var{c'}\in\DCertDeleg \Rightarrow
-        \fun{dpool}~{c'} \in \dom \var{stpools} \\
+      \var{c}\in\DCertDeleg \Rightarrow \fun{dpool}~{c} \in \dom \var{stpools} \\
         ptr = (\var{slot},~\var{txIx},~\mathsf{len}~\Gamma - 1) \\~\\
         {
           \left(
@@ -910,7 +863,6 @@ whole transaction will be invalid.
       \trans{delegs}{\Gamma; c}
       \varUpdate{\var{dpstate''}}
     }
-    \label{eq:rule:sequence-delegation-inductive}
   \end{equation}
   \caption{Delegation sequence rules}
   \label{fig:rules:delegation-sequence}

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -1,11 +1,10 @@
 \newcommand{\UTxOEpState}{\type{UTxOEpState}}
-\newcommand{\Accnt}{\type{Accnt}}
-\newcommand{\AccntEnv}{\type{AccntEnv}}
-\newcommand{\AccntState}{\type{AccntState}}
-\newcommand{\StPlCleanEnv}{\type{StPlCleanEnv}}
-\newcommand{\StPlCleanState}{\type{StPlCleanState}}
-\newcommand{\NewProtoConstsEnv}{\type{NewProtoConstsEnv}}
-\newcommand{\NewProtoConstsState}{\type{NewProtoConstsState}}
+\newcommand{\Acnt}{\type{Acnt}}
+\newcommand{\AcntEnv}{\type{AcntEnv}}
+\newcommand{\AcntState}{\type{AcntState}}
+\newcommand{\PlReapState}{\type{PlReapState}}
+\newcommand{\NewPParamEnv}{\type{NewPParamEnv}}
+\newcommand{\NewPParamState}{\type{NewPParamState}}
 \newcommand{\EpochEnv}{\type{EpochEnv}}
 \newcommand{\EpochState}{\type{EpochState}}
 \newcommand{\BlocksMade}{\type{BlocksMade}}
@@ -26,36 +25,20 @@
 \newcommand{\movingAvg}[5]{\fun{movingAvg}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}~ \var{#5}}
 \newcommand{\updateAvgs}[4]{\fun{updateAvgs}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
 
-In this chapter we discuss the ledger state updates that take place at the epoch
-boundary. These are necessary updates that are not triggered by a transaction.
-It is impractical and unnecessary to perform the calculations and updates we
-describe below every slot. The main state updates that take place at the boundary
-are of an accounting nature, calculating new values for the various accounts
-on the ledger (treasury, reserves, rewards, fees).
+In this chapter we discuss updates to the ledger state that take place at the epoch boundary.
+These are necessary updates that are not triggered by a transaction.
+Rewards for the proof of stake leader election are calculated, and various accounting values
+are updated, such as the treasury and the reserves.  Additionally, pools scheduled for retirement
+are actually retired, and protocol updates can occur.
 
-However, it is also when
-pools scheduled for retirement at this boundary are removed from the ledger.
-In addition, if there is an update planned for any of the protocol parameters,
-it may only take place at the epoch boundary, and results in a ledger state
-update, which we also give the details of in this chapter.
-Note that witnessing here is not necessary because there is no data to sign
-in the signal.
-
-We introduce a two new derived types in this chapter. $\BlocksMade$ (see
-Figure~\ref{fig:epoch-defs}), which represents the number of blocks made by
-the blockchain this epoch associated to a particular stake key. The type
-$\Avgs$ is a finite map that pairs a hash key with a fraction. This fraction
-is meant to represent the portion of the total stake corresponding to a key,
-thus this type is used to give the stake distribution.
-
-We also introduce two lookup functions. The map $\fun{stakeHK_b}$ looks up the
-hash key at a base address, and the map $\fun{stakePtr}$ looks up the pointer
-at a given pointer address.
-
-The next three functions ($\fun{movingAvgWeight}$, $\fun{movingAvgExp}$, and
-$\fun{globalPool}$) in the figure return a specific subset of parameters
-in the set of protocol parameters (stake pool-specific parameters, respectively)
-needed for performing rewards calculations.
+Figure~\ref{fig:epoch-defs} introduces three new derived types:
+\begin{itemize}
+  \item $\type{BlocksMade}$ represents the number of blocks each stake pool produced
+    during an epoch.
+  \item $\type{Stake}$ represents the amount of stake (in $\type{Coin}$) controlled by each
+    stake pool.
+  \item $\type{Stake}$ represents the performance moving averages of the stake pools.
+\end{itemize}
 
 %%
 %% Figure - Epoch Abstract Types
@@ -86,40 +69,22 @@ needed for performing rewards calculations.
 \subsection{Stake Distribution Calculation}
 \label{sec:stake-dist}
 
-One of the main characteristics of a proof-of-stake cryptocurrency is stake
-distribution calculation. This calculation is performed at the epoch boundary.
-We give the stake distribution calculations and related functions in
-Figure~\ref{fig:functions:stake-distribution}.
-
-The $\fun{baseStake}$ generates a finite map that pairs a staking key
-associated to a base address with the coin value at that address as recorded
-in the UTxO on the ledger. Note that this is a map indexed by any staking keys,
-which every base address has (but not all of these are registered and delegating).
-After registering a stake key, the base address is added alongside the
-coin value associated to it in $outs$ (the outputs record currently in the
-ledger UTxO).
-
-The map
-$\fun{ptrStake}$ generates a similar finite map for coin values at a given
-pointer address in the UTxO outputs set, indexed the stake keys the given
-pointer address is associated with.
-This is a key and coin value pair finite map for only registered stake keys.
-
-The $\fun{stake}$ map is a union of all the stake (both active and inactive) in
-both of these finite
-maps, $\fun{baseStake}$ and the $\fun{ptrStake}$.
-The next step of calculating stake distribution is to filter the hash keys in
-the $\fun{stake}$ finite map.
-We want only those (stake) keys for which stake
-from the $\fun{baseStake}$ and the $\fun{ptrStake}$ calculations is active, i.e.
-for which the $\fun{isActive}$ filter is true.
-For a hash key, its stake is active (i.e. $\fun{isActive}$) whenever it is a
-registered stake key
-and it is delegating to some registered stake pool.
-
-The finite map output of the function $\fun{activeStake}$ gives the subset of
-all the \textit{active} stake computed by $\fun{stake}$.
-These stake-related calculations are used in the calculation of rewards.
+This section defines the stake distribution calculations performed at the epoch boundary.
+Figure~\ref{fig:functions:helper-stake-distribution} defines some helper functions.
+\begin{itemize}
+  \item $\fun{consolidate}$ transforms UTxO into a mapping from addresses to the total amount
+    of $\type{Coin}$ controlled by each address in the UTxO.
+  \item $\fun{baseStake}$ transforms the consolidated stake, as computed above by
+    $\fun{consolidated}$, into a mapping from the base address stake hashkeys to the coin value.
+  \item $\fun{ptrStake}$ transforms the consolidated stake, as computed above by
+    $\fun{consolidated}$, into a mapping from the pointer address stake hashkeys to the coin value.
+    It uses the certificate pointers to create this mapping.
+  \item $\fun{rewardStake}$ transforms the reward accounts into a mapping from hashkeys to coin
+    values.
+  \item $\fun{poolStake}$ filters all stake in the system into just the stake controlled by a given
+    stake pool.  Additionally, it combines all of the stake controlled by the pool owners into
+    a single key-value pair mapping the pool operator's hashkey to the owner-operator total.
+\end{itemize}
 
 %%
 %% Figure - Helper Functions for Stake Distribution
@@ -166,8 +131,17 @@ These stake-related calculations are used in the calculation of rewards.
   \label{fig:functions:helper-stake-distribution}
 \end{figure}
 
+The stake distribution calculations are given in Figure~\ref{fig:functions:stake-distribution}.
+\begin{itemize}
+  \item $\fun{stakeDistr}$ combines the stake from base addresses, pointer addresses, and reward
+    accounts into a single mapping of hashkeys to coin, filtering out keys that are not both
+    registered and delegated.
+  \item $\fun{poolDistr}$ groups the stake distribution calculated by $\fun{stakeDistr}$ above
+    by stake pool operator.
+\end{itemize}
+
 %%
-%% Figure Helper Functions for Stake Distribution
+%% Figure Functions for Stake Distribution
 %%
 \begin{figure}[htb]
   \emph{Stake Distribution}
@@ -201,109 +175,35 @@ These stake-related calculations are used in the calculation of rewards.
   \label{fig:functions:stake-distribution}
 \end{figure}
 
-\subsection{Accounting Functions}
-\label{sec:acc-fun}
-
-In Figure~\ref{fig:functions:epoch}, we give the functions used in the deposit
-calculations at the boundary. Here we introduce the function $\fun{obligation}$
-that gives the value of the total possible (decayed) refunds for both individual
-and pool deposits in a given slot number.
-
-Next, we give the type of the function used to calculate additional rewards that
-will become available to be claimed after the boundary. This function is denoted
-$\fun{reward}$, and depends on this epoch's blocks, protocol parameters, the
-delegation and pool states, and existing rewards unclaimed in the previous
-epoch.  The $\fun{reward}$ function updates the existing records of the
-unclaimed coin values by adding newly accumulated rewards in this epoch to the
-value in each reward address.
-
-The function $\fun{poolRefunds}$ is used to calculate the total refunds
-that must be distributed
-for stake pools scheduled to retire at an epoch boundary. Note that this
-calculation takes a slot number as a parameter because that is the type of value
-needed for the decay calculation, but will only ever be invoked
-when the slot number is the last before the boundary.
-
-The map $\fun{poolRefunds}$ uses the pool decay parameters in $\PParams$
-to assign a refund to each pool key in the set of pools scheduled for retirement
-at the epoch boundary.
+\clearpage
 
 \subsection{Rewards Distribution}
 \label{sec:reward-dist}
 
-We now discuss reward distribution calculation that happens at the epoch boundary.
-Functions used in reward calculations are presented in
-Figure~\ref{fig:functions:rewards}. The reward calculation below is done as part of the
-epoch boundary accounting to update the various accounting fields on the ledger,
-see Section~\ref{sec:acc-trans}. In the subsequent calculations, we use the
-following variables, sourced as indicated (listed here for reference):
+This section defines the reward calculation for the proof of stake leader election.
+Figure~\ref{fig:functions:rewards} defines the pool reward as described in section
+6.5.1 of \cite{delegation_design}.
 
 \begin{itemize}
-\item[] From the delegation state:
-\item $\var{avgs}$ stores the (moving) average for each
-stake pool
-\item $\var{poolParams}$ stores stake pool-specific parameters
-\item $\var{delegs}$ stores delegations as stake and pool key pairs \medskip
-
-From the boundary accounting transition context:
-\item $\var{prod}$ gives the number of blocks made by each stake pool
-this epoch, with $n$ representing the number of blocks corresponding to the
-given pool \medskip
-
-Calculated as part of epoch boundary accounting, see
-Section~\ref{sec:acc-trans}:
-\item $\var{R} \in \Coin$ is the total available rewards for the epoch (in ADA) \medskip
-
-From protocol (pool-related) constants:
-\item $n_{opt} \in \N$ is the optimal number of saturated stake pools (which the system
-tends to by protocol design)
-\item $\var{a_0} \in [0, \infty)$ is a parameter determining leader-stake
-influence on pool rewards
-\item $\gamma$ is the moving average exponent constant \medskip
-
-From pool-specific parameters denoted $\var{pool}$, associated to a specific
-hash key in $\var{poolParams}$:
-\item $c \in \Coin$ is the pool costs
-\item $m \in [0,1]$ is the stake pool margin
-\item $p \in \Coin$ is the pledge a stake key registering a pool defines (via
-the registration certificate)\medskip
-
-Calculated by the functions defined in this section using the variables above:
-\item $\var{z_0} := 1/n_{opt}$ is the size of a saturated pool
-\item $\var{active}$ is the finite map associating a stake key to all the
-active stake belonging to it
-\item $s \in [0,1]$, or $t$, is the relative stake associated to a specific stake key
-(i.e. the value associated to it in $\var{active}$ stake, normalized)
-\item $\var{tot} \in \Coin$ is the sum total of all the $\var{active}$ stake
-\item $\var{actgr}$ is the subset of the total $\var{active}$ stake
-for which its stake key delegates to a given pool
-\item $\var{pactive}$ is the finite map of all the subsets of $\var{actgr}$,
-each associated to its pool key
-\item $\sigma \in [0,1]$ is the total relative stake of a pool (expressed as a fraction of
-the total stake, which is a sum of the relative member's stake)
-\item $p_r \in [0,1]$ is the relative pledge of a given pool, calculated by normalizing $p$
-\item $\overline{N} \in \Rnn$, for a given pool, is the expected value of the number
-of slots that the pool will be elected as leader on average
-\item $\var{maxP} \in \Coin$ is the maximum stake that could be received by a particular
-pool
-\item $\var{\hat{f}}$ is the pool rewards
-\item $\var{avg}$ is the relative moving average for a given pool calculated for
-the current epoch
+  \item The function $\fun{maxPool}$ gives the maximum reward a stake pool can receive in an epoch.
+    This is a fraction of the total available rewards for the epoch.
+    The result depends on the pool's relative stake, the pool's pledge, and the following
+    protocol parameters:
+    \begin{itemize}
+      \item $\var{a_0}$, the leader-stake influence
+      \item $n_{opt}$, the optimal number of saturated stake pools
+    \end{itemize}
+  \item The function $\fun{movingAvg}$ calculates the new moving average for a given stake pool
+    based on its performance and the protocol parameter:
+    \begin{itemize}
+      \item $\alpha$, the moving average weight
+    \end{itemize}
+  \item The function $\fun{poolReward}$ gives the total rewards available to be distributed
+    to the members of the given pool. It depends on one additional protocol parameter:
+    \begin{itemize}
+      \item $\gamma$, the moving average exponent
+    \end{itemize}
 \end{itemize}
-
-The function $\fun{maxPool}$ gives the maximum possible amount of rewards a pool
-can receive in an epoch. For a given pool, it is a coin value which is some fraction of
-the total available rewards. This result depends additionally on the protocol
-parameters, the pool's relative stake, and the pool's relative pledge.
-
-The function $\fun{movingAvg}$ calculates the new moving average for a
-given stake pool based on protocol parameters, pool's block production, and
-the moving average of this pool in the previous epoch.
-
-Next, the function $\fun{poolReward}$ gives the total rewards available to be distributed
-to the members of the given pool. This value is based on protocol parameters,
-the pool's block production, moving average, election expectation, and the maximum
-possible rewards for this pool.
 
 %%
 %% Figure - Functions for the Reward Calculation
@@ -358,29 +258,20 @@ possible rewards for this pool.
   \label{fig:functions:rewards}
 \end{figure}
 
-In Figure~\ref{fig:functions:reward-splitting}, we give the strategy for the
-splitting of the rewards within a given pool. Note that the calculation of
-the total value to be split within the pool is presented above, denoted $\fun{poolReward}$.
+\clearpage
 
-The portion of rewards allocated to the pool leader and those allocated to
-the rest of the pool members is different. This portion is calculated based
-on pool-specific parameters stored on the ledger, as well as
-the pool's total stake and the individual stake of the key for which the rewards
-are being calculated. The calculation for the pool
-leader reward amount is given by the $\fun{lReward}$ function, and the
-calculation for the reward amount for each other member is given by $\fun{mReward}$.
-Finally, $\fun{indivReward}$ puts these two calculations together to give the
-reward amount for any pool member, using a boolean $\var{isLeader}$
-as an input variable which indicates
-whether a given member is the pool leader or not.
+Figure~\ref{fig:functions:reward-splitting} gives the calculation for
+splitting the pool rewards with its members, as described 6.5.2 of \cite{delegation_design}.
+The portion of rewards allocated to the pool operator and owners is different
+than that of the members.
 
-Here we also present the $\fun{groupByPool}$ map, which, given the active stake
-belonging to each registered stake key,
-as well as the current delegations, produces a
-finite map indexed by the hash keys of pool leaders. Each $\var{leader}$ key is associated
-with a subset of the active stake finite map. This associated subset
-contains only the entries where the hash keys delegate to that pool
-which the given leader is the leader of.
+\begin{itemize}
+  \item The $\fun{r_{leader}}$ function calculates the leader reward, based on the pool cost,
+    margin, and proportion of the pool's total stake.  Note that this reward will go to the
+    reward account specified in the pool registration certificate.
+  \item The $\fun{r_{member}}$ function calculates the member reward, proportionally to their
+    stake after the cost and margin are removed.
+\end{itemize}
 
 %%
 %% Figure - Functions for the Reward Splitting
@@ -396,7 +287,9 @@ which the given leader is the leader of.
         c + \floor*{(\hat{f} - c)\cdot\left(m + (1-m)\cdot\frac{s}{\sigma}\right) }&
         \text{otherwise.}
       \end{cases} \\
-      & ~~~\where (c, m, \_) = \fun{poolCosts}~pool \\
+      & ~~~\where \\
+      & ~~~~~~~c = \fun{poolCost}~pool \\
+      & ~~~~~~~m = \fun{poolMargin}~pool \\
   \end{align*}
 
   \emph{Pool member reward, from section 6.5.2 of \cite{delegation_design}}
@@ -409,7 +302,9 @@ which the given leader is the leader of.
         \floor*{(\hat{f} - c)\cdot(1-m)\cdot\frac{t}{\sigma}} &
         \text{otherwise.}
       \end{cases} \\
-    & ~~~\where (c, m, \_) = \fun{poolCosts}~pool \\
+    & ~~~\where \\
+    & ~~~~~~~c = \fun{poolCost}~pool \\
+    & ~~~~~~~m = \fun{poolMargin}~pool \\
   \end{align*}
 
   \caption{Functions used in the Reward Splitting}
@@ -417,57 +312,18 @@ which the given leader is the leader of.
 \end{figure}
 
 
-Finally, the reward calculation is presented in
-Figure~\ref{fig:functions:reward-calc}. The calculation is done pool-by-pool.
-The map $\fun{rewardOnePool}$ calculates the rewards given out to each member
-of a given pool (with leader identified by
-the stake key $\var{poolHK}$). The active stake associated to each
-pool member is passed to $\fun{rewardOnePool}$
-via the $\var{actgr}$ variable, which is a subset of hash keys in this pool
-paired with the stake associated with the keys.
-
-This $\fun{rewardOnePool}$ map outputs a finite map and an $\var{avg}$
-value. The finite map is indexed
-by reward addresses. In particular, the subset of reward addresses corresponding
-to registered keys delegating to the pool with leader $\var{poolHK}$.
-A reward address of key $hk$ is paired with the individual reward value
-produced by the $\fun{indivReward}$ map applied to relevant data passed to
-$\fun{rewardOnePool}$ as well as the results of the $\fun{maxPool}$
-and $\fun{poolReward}$ calculations. The $\var{avg}$ value for the stake pool
-(i.e. the pool's ranking) is also calculated by the $\fun{poolReward}$ function.
-
-The $\fun{reward}$ calculation itself uses the $\fun{rewardOnePool}$ function to
-reward each pool's members and calculate the pool's moving averages. In order to
-do this, it is given the following parameters:
-
+Finally, the full reward calculation is presented in Figure~\ref{fig:functions:reward-calc}.
+The calculation is done pool-by-pool.
 \begin{itemize}
-\item The number of blocks made by each key this epoch
-\item The protocol parameters
-\item The total coin value of rewards to be distributed this epoch
-\item The full delegation state
-\item The set of outputs in the UTxO on the ledger
+  \item The $\fun{rewardOnePool}$ function calculates the rewards given out to each member of a
+    given pool. The pool leader identified by the stake key of the pool operator.  The function
+    returns both the rewards and the total amount of unrealized potential rewards.  The unrealized
+    amount will go to the treasury. The rewards include that of the the pool operator, provided
+    the reward account from the pool registration certificate is still registered.  If the pool
+    reward account is not registered, the operator reward is added to the unrealized total.
+  \item The $\fun{reward}$ function applies $\fun{rewardOnePool}$ to each registered stake
+    pool, calculating both the full reward mapping and the total unrealized rewards value.
 \end{itemize}
-
-The output of the $\fun{reward}$ calculation is a pair. The first component is
-a finite map indicating the new rewards assigned to each reward address.
-The second component is the record of every pool's updated moving average.
-
-Within the $\fun{reward}$ calculation, the active stake corresponding to each
-(active and delegating to an active pool) stake key, $\var{active}$, is
-calculated by adding up the total active stake for that key currently on the
-ledger. The entries of this finite map are then grouped into subsets by the pool
-each stake key belongs to using the $\fun{groupByPool}$ mapping (to give the
-$\var{pactive}$ value).
-
-Next, a dataset of $\var{results}$ is generated by pairing each pool key with
-the set of rewards calculated for each of the delegators to the pool with this
-key, as well as the moving average for the pool. Both of these are calculated
-using the $\fun{rewardOnePool}$ function.  To generate the final output of the
-$\fun{reward}$ calculation, we take the union of the all the subsets of the
-rewards records of individual keys from the range values of the $\var{results}$
-map, and pair it with the union of all the pool keys (the domain of the
-$\var{results}$) and the associated moving averages for these (the second
-component of the range of the $\var{results}$ finite map).
 
 %%
 %% Figure - The Reward Calculation
@@ -483,8 +339,8 @@ component of the range of the $\var{results}$ finite map).
       & ~~~\where \\
       & ~~~~~~~\var{pstake} = \sum_{\_\mapsto t\in\var{stake}} t \\
       & ~~~~~~~\sigma = \var{pstake} / tot \\
-      & ~~~~~~~\var{\overline{N}} = \sigma * \slotsPer\\
-      & ~~~~~~~(\_, \_, \var{pledge}) = \fun{poolCosts}~pool \\
+      & ~~~~~~~\var{\overline{N}} = \sigma * (\fun{slotsPerEpoch}~{pp})\\
+      & ~~~~~~~\var{pledge} = \fun{poolPledge}~pool \\
       & ~~~~~~~p_{r} = \var{pledge} / \var{tot} \\
       & ~~~~~~~maxP =
       \begin{cases}
@@ -548,20 +404,100 @@ component of the range of the $\var{results}$ finite map).
 
 \clearpage
 
-\subsection{Accounting Epoch Transition}
+\subsection{Accounting Transition}
 \label{sec:acc-trans}
 
-The Figure~\ref{fig:ts-types:accnt} gives the definitions related to epoch
-boundary ledger accounting. The figure lists the accounting fields, denoted by
-$\Accnt$, which include $\var{treasury}$ (the amount of coin currently in
-circulation, but not on the UTxO and not designated for rewards),
-$\var{reserves}$ (the amount of coin
-not yet in circulation),
-and $\var{rewardPot}$ (the total amount available for distribution of rewards).
-The figure also gives the set of necessary accounting environment
-variables, $\AccntEnv$, and the accounting state, $\AccntState$, which includes
-the delegation state and the accounting fields. The accounting state transition
-type, as all transition types in this chapter, has no signal.
+Figure~\ref{fig:funcs:acnt} defines the helper functions needed for the accounting transition.
+
+\begin{itemize}
+  \item The function $\fun{obligation}$ calculates the the minimal amount of coin needed to
+    pay out all depot refunds, as of the current slot.
+  \item The function $\fun{poolRefunds}$ is used to calculate the total refunds
+    that must be distributed for stake pools scheduled to retire at an epoch boundary.
+    Note that this calculation takes a slot number corresponding to the epoch boundary slot
+    when the calculation is performed.
+  \item The function $\fun{updateAvgs}$ calculates the new performance moving averages.
+    Note that these values are computed by the $\fun{poolReward}$ function and could be cached
+    in order to prevent calculating them twice.
+\end{itemize}
+
+
+%%
+%% Figure - Functions for Epoch Rules
+%%
+\begin{figure}[htb]
+  \emph{Total possible refunds}
+  \begin{align*}
+      & \fun{obligation} \in \PParams \to \StakeKeys \to \StakePools \to \Slot \to \Coin \\
+      & \obligation{pp}{stkeys}{stpools}{cslot} =\\
+      & \sum\limits_{(\_ \mapsto s) \in \var{stkeys}}
+        \refund{d_{\mathsf{val}}}{d_{\min}}{\lambda_d}{(\slotminus{cslot}{s})}
+        + \sum\limits_{(\_ \mapsto s) \in \var{stpools}}
+        \refund{p_{\mathsf{val}}}{p_{\min}}{\lambda_p}{(\slotminus{cslot}{s})} \\
+      &
+      \begin{array}{lr@{~=~}l}
+        \where
+          & \dval,~d_{\min},~\lambda_d
+          & \fun{keyDeposit}~\var{pp},~\fun{keyMinRefund}~\var{pp},~\fun{keyDecayRate}~\var{pp}
+          \\
+          & p_{\mathsf{val}},~p_{\min},~\lambda_p
+          & \fun{poolDeposit}~\var{pp},~\fun{poolMinRefund}~\var{pp},~\fun{poolDecayRate}~\var{pp}
+      \end{array}\\
+  \end{align*}
+  \emph{Pool refunds}
+  \begin{align*}
+      & \fun{poolRefunds} \in \PParams \to (\HashKey \mapsto \Epoch) \to \Slot \to
+        (\HashKey \mapsto \Coin) \\
+      & \poolRefunds{pp}{retiring}{cslot} = \left\{
+        \var{hk}\mapsto
+          \refund{p_{\mathsf{val}}}{p_{\min}}{\lambda}{(\slotminus{cslot}{(\fun{firstSlot}~e)})}
+          \mid
+          \var{hk}\mapsto e\in\var{retiring}
+        \right\}\\
+      & \where p_{\mathsf{val}},~p_{\min},~\lambda_p =
+          \fun{poolDeposit}~\var{pp},~\fun{poolMinRefund}~\var{pp},~\fun{poolDecayRate}~\var{pp} \\
+  \end{align*}
+
+  \emph{Update Moving Averages}
+  \begin{align*}
+      & \fun{updateAvgs} \in \PParams \to \Avgs \to \BlocksMade \to
+          (\HashKey_{pool}\mapsto \Stake) \to \Avgs \\
+      & \updateAvgs{pp}{avgs}{blocks}{pooledStake} = \\
+      & ~~~ \left\{hk\mapsto \movingAvg{pp}{hk}{n}{\overline{N}}{avgs}
+            \mid
+            hk\mapsto n\in\var{blocks}, hk\mapsto\overline{N}\in\var{expectations}
+            \right\} \\
+      & \where \\
+      & ~~~~~ \var{tot} = \sum_{\_\mapsto st\in \var{pooledStake}}
+                          \left(\sum_{\wcard\mapsto c\in\var{st}}c\right) \\
+      & ~~~~~ \var{expectations} =
+                \left\{
+                  hk\mapsto\left(\sum_{
+                    \wcard\mapsto c\in\var{st}}c\right)*(\fun{slotsPerEpoch}~{pp}) / tot
+                  \mid
+                  hk\mapsto\var{st} \in pooledStake
+                \right\}
+  \end{align*}
+  \caption{Helper Functions used in Accounting}
+  \label{fig:funcs:acnt}
+\end{figure}
+
+
+
+Figure~\ref{fig:ts-types:acnt} gives the definitions for the accounting transition.
+The figure lists the accounting fields, denoted by $\Acnt$, which consists of:
+\begin{itemize}
+  \item The value $\var{treasury}$ tracks the amount of coin currently stored in the treasury.
+    Initially there will be no way to remove these funds.
+  \item The value $\var{reserves}$ tracks the amount of coin currently stored in the reserves.
+    This pot is used to pay rewards.
+  \item The value $\var{rewardPot}$ to tracks the rewards from the previous epoch that were not
+    payed out.
+\end{itemize}
+The figure also defines the accounting environment, $\AcntEnv$, and the accounting state,
+$\AcntState$, which combines the accounting fields described above with the UTxO State,
+the delegation state, and the pool state.
+The accounting state transition type, like all the transition types in this section, has no signal.
 
 %%
 %% Figure - Accounting Defs
@@ -569,7 +505,7 @@ type, as all transition types in this chapter, has no signal.
 \begin{figure}[htb]
   \emph{Accounting Fields}
   \begin{equation*}
-    \Accnt =
+    \Acnt =
     \left(
       \begin{array}{r@{~\in~}ll}
         \var{treasury} & \Coin & \text{treasury pot}\\
@@ -581,7 +517,7 @@ type, as all transition types in this chapter, has no signal.
   %
   \emph{Accounting environment}
   \begin{equation*}
-    \AccntEnv =
+    \AcntEnv =
     \left(
       \begin{array}{r@{~\in~}ll}
         \var{slot} & \Slot & \text{last slot of epoch}\\
@@ -593,10 +529,10 @@ type, as all transition types in this chapter, has no signal.
   %
   \emph{Accounting States}
   \begin{equation*}
-    \AccntState =
+    \AcntState =
     \left(
       \begin{array}{r@{~\in~}ll}
-        \var{accnt} & \Accnt & \text{accounting}\\
+        \var{acnt} & \Acnt & \text{accounting}\\
         \var{dstate} & \DState & \text{delegation state}\\
         \var{pstate} & \PState & \text{pool state}\\
         \var{utxoSt} & \UTxOState & \text{utxo state}\\
@@ -607,40 +543,43 @@ type, as all transition types in this chapter, has no signal.
   \emph{Accounting transitions}
   \begin{equation*}
     \_ \vdash
-    \var{\_} \trans{accnt}{} \var{\_}
-    \subseteq \powerset (\AccntEnv \times \AccntState \times \AccntState)
+    \var{\_} \trans{acnt}{} \var{\_}
+    \subseteq \powerset (\AcntEnv \times \AcntState \times \AcntState)
   \end{equation*}
   %
   \caption{Accounting transition-system types}
-  \label{fig:ts-types:accnt}
+  \label{fig:ts-types:acnt}
 \end{figure}
 
+\clearpage
 
-The accounting epoch boundary rule in Figure~\ref{fig:rules:accnt} is the rule
-where the most attention to detail is required in order to adhere to the
-preservation of value condition. In this rule, the funds in each of the
-accounting variables, as well as the individual reward addresses, are adjusted
-as follows:
+Figure~\ref{fig:rules:acnt} defines the accounting transition rule.  Value is moved between
+accounting pots, but the total amount of value in the system remains constant.
+The accounting transition has no preconditions.
 
 \begin{itemize}
-\item To the $\var{treasury}$ we add a fraction $\tau$ of the sum of
-the fees accumulated from transactions this epoch, the decay amount
-of all current deposits, the total reward pool, and the expansion (how much
-coin is added to circulation each epoch)
-\item A fraction $\rho$ of the $\var{reserves}$ comes into circulation (i.e.
-is removed from $\var{reserves}$)
-\item The value added to $\var{treasury}$ is removed from the $\var{rewardPot}$
-\item The sum total of rewards accumulated for all addresses this epoch
-is removed from the $\var{rewardPot}$
-\item The accumulated fees, deposit decay, and circulation expansion is
-added to the $\var{rewardPot}$
-\item The rewards accumulated this epoch are distributed by
-adding the amount computed for each reward address (by the $\fun{reward}$ calculation)
-to the value of coin corresponding to that address
-\item The $\var{avgs}$ value in the delegation state is re-calculated and
-updated by the $\fun{reward}$ map also
-\item The deposit pot is set to the current obligation.
-\item The fee pot is set to zero.
+  \item First we calculate $\var{totalPot}$, the total amount of coin available for rewards this epoch,
+    , as described in section 6.4 of \cite{delegation_design}. It consists of four pots:
+    \begin{itemize}
+      \item The fee pot, containing the transaction fees from the epoch.
+      \item The amount of coin in the deposit pot that is no longer needed, due to decay.
+      \item The reward pot, which is the left-over rewards from the previous epoch.
+      \item Some amount of monetary expansion from the reserves, as determined by the
+        $\rho$ protocol parameter.
+    \end{itemize}
+  \item Some proportion of the total pot is moved to the treasury,
+    as determined by the $\tau$ protocol parameter. The remaining pot is called the
+    $\var{availablePool}$, which is also called $R$ in section 6.5 of \cite{delegation_design}.
+  \item The stake distribution is calculated based on the UTxO and the delegation and pool state.
+  \item The $\var{availablePool}$ is now distributed as rewards. As given by $\fun{maxPool}$,
+    each pool can receive a maximal amount, as determined by its performance.
+    The difference between the maximal amount and the actual amount received is
+    moved to the treasury.
+  \item The reward pot is now set to the $\var{availablePool}$ minus the total amount of rewards
+    actually paid out and the unrealized rewards given to the treasury.
+  \item The moving averages are updated.
+  \item The deposit pot is set to the minimal amount to cover the total refund obligation.
+  \item The fee pot is set to zero.
 \end{itemize}
 
 Note that fees and deposit decay, above, are not explicitly removed from any account:
@@ -648,18 +587,11 @@ the fees come from transactions paying them, and are accounted for whenever
 transactions are processed, and the deposit decay value comes from returning
 smaller refunds for deposits than were paid upon depositing.
 
-Recall also that in Section~\ref{sec:reward-dist}, we used $R$ to represent
-the total available rewards. Here, we present the calculation of the value
-passed to $\fun{rewards}$ as $R$, denoted $\var{availablePool}$ above.
-This value is a fraction $1-\tau$ of the sum of fees collected this epoch, the
-deposit decay, leftover rewards from
-the previous epoch, and this epoch's circulation expansion. The rest of this
-value (i.e. $\tau$) goes into the $\var{treasury}$, as stated above.
-
 Figure \ref{fig:fund-preservation} captures the potential movement of funds
 between these various locations during the epoch transition and transaction
 processing. In particular, the red subgraph represents the inputs and outputs to
-the ``total pot'' used during the epoch transition in Figure \ref{fig:rules:accnt}.
+the ``total pot'' used during the epoch transition in Figure \ref{fig:rules:acnt}.
+The blue arrows represent the movement of funds that pass through the ``total pot''.
 
 \begin{figure}[htb]
   \begin{center}
@@ -713,70 +645,13 @@ the ``total pot'' used during the epoch transition in Figure \ref{fig:rules:accn
   \label{fig:fund-preservation}
 \end{figure}
 
-%%
-%% Figure - Functions for Epoch Rules
-%%
-\begin{figure}[htb]
-  \emph{Total possible refunds}
-  \begin{align*}
-      & \fun{obligation} \in \PParams \to \StakeKeys \to \StakePools \to \Slot \to \Coin \\
-      & \obligation{pp}{stkeys}{stpools}{cslot} =\\
-      & \sum\limits_{(\_ \mapsto s) \in \var{stkeys}}
-        \refund{d_{\mathsf{val}}}{d_{\min}}{\lambda_d}{(\slotminus{cslot}{s})}
-        + \sum\limits_{(\_ \mapsto s) \in \var{stpools}}
-        \refund{p_{\mathsf{val}}}{p_{\min}}{\lambda_p}{(\slotminus{cslot}{s})} \\
-      &
-      \begin{array}{lr@{~=~}l}
-        \where
-          & \dval,~d_{\min},~\lambda_d
-          & \fun{keyDeposit}~\var{pp},~\fun{keyMinRefund}~\var{pp},~\fun{keyDecayRate}~\var{pp}
-          \\
-          & p_{\mathsf{val}},~p_{\min},~\lambda_p
-          & \fun{poolDeposit}~\var{pp},~\fun{poolMinRefund}~\var{pp},~\fun{poolDecayRate}~\var{pp}
-      \end{array}\\
-  \end{align*}
-  \emph{Pool refunds}
-  \begin{align*}
-      & \fun{poolRefunds} \in \PParams \to (\HashKey \mapsto \Epoch) \to \Slot \to
-        (\HashKey \mapsto \Coin) \\
-      & \poolRefunds{pp}{retiring}{cslot} = \left\{
-        \var{hk}\mapsto
-          \refund{p_{\mathsf{val}}}{p_{\min}}{\lambda}{(\slotminus{cslot}{(\fun{slot}~e)})}
-          \mid
-          \var{hk}\mapsto e\in\var{retiring}
-        \right\}\\
-      & \where p_{\mathsf{val}},~p_{\min},~\lambda_p =
-          \fun{poolDeposit}~\var{pp},~\fun{poolMinRefund}~\var{pp},~\fun{poolDecayRate}~\var{pp} \\
-  \end{align*}
-
-  \emph{Update Moving Averages}
-  \begin{align*}
-      & \fun{updateAvgs} \in \PParams \to \Avgs \to \BlocksMade \to
-          (\HashKey_{pool}\mapsto \Stake) \to \Avgs \\
-      & \updateAvgs{pp}{avgs}{blocks}{pooledStake} = \\
-      & ~~~ \left\{hk\mapsto \movingAvg{pp}{hk}{n}{\overline{N}}{avgs}
-            \mid
-            hk\mapsto n\in\var{blocks}, hk\mapsto\overline{N}\in\var{expectations}
-            \right\} \\
-      & \where \\
-      & ~~~~~ \var{tot} = \sum_{\_\mapsto st\in \var{pooledStake}}
-                          \left(\sum_{\wcard\mapsto c\in\var{st}}c\right) \\
-      & ~~~~~ \var{expectations} =
-                \left\{
-                  hk\mapsto\left(\sum_{\wcard\mapsto c\in\var{st}}c\right)*\slotsPer / tot
-                  \mid
-                  hk\mapsto\var{st} \in pooledStake
-                \right\}
-  \end{align*}
-  \caption{Functions used in Accounting}
-  \label{fig:functions:epoch}
-\end{figure}
+\clearpage
 
 %%
 %% Figure - Accounting Rules
 %%
 \begin{figure}[htb]
-  \begin{equation}\label{eq:accnt}
+  \begin{equation}\label{eq:acnt}
     \inference[Accounting]
     {
       {
@@ -784,13 +659,15 @@ the ``total pot'' used during the epoch transition in Figure \ref{fig:rules:accn
         \var{obl} & \obligation{pp}{stkeys}{stpools}{slot} \\
         \var{decayed} & \var{deposits} - \var{obl} \\
         \var{expansion} & \floor*{(\fun{rho}~{pp}) \cdot \var{reserves}} \\
-        \var{totalPool} & \var{fees} + \var{decayed} + \var{rewardPot} + \var{expansion} \\
-        \var{newTreasury} & \floor*{(\fun{tau}~{pp}) \cdot \var{totalPool}} \\
-        \var{availablePool} & \var{totalPool} - \var{newTreasury} \\
+        \var{totalPot} & \var{fees} + \var{decayed} + \var{rewardPot} + \var{expansion} \\
+        \var{newTreasury} & \floor*{(\fun{tau}~{pp}) \cdot \var{totalPot}} \\
+        \var{availablePool} & \var{totalPot} - \var{newTreasury} \\
         \var{pooledStake} & \poolDistr{utxo}{dstate}{pstate} \\
         \var{rewards'},~\var{unrealized} & \reward{pp}{blocks}{availablePool}{dpstate}{pooledStake}\\
         \var{newTreasury'} & \var{newTreasury} + \var{unrealized} \\
-        \var{paidRewards} & \sum\limits_{\_\mapsto c\in\var{rewards'}}c \\
+        \var{paidRewards} & \left(
+                            \sum\limits_{\_\mapsto c\in\var{rewards'}}c
+                            \right) + \var{unrealized} \\
         \var{avgs'} & \updateAvgs{pp}{avgs}{blocks}{pooledStake} \\
       \end{array}
       }
@@ -820,7 +697,7 @@ the ``total pot'' used during the epoch transition in Figure \ref{fig:rules:accn
           \var{fees} \\
         \end{array}
       \right)
-      \trans{accnt}{}
+      \trans{acnt}{}
       \left(
         \begin{array}{rcl}
           \varUpdate{\var{treasury}} & \varUpdate{+} & \varUpdate{\var{newTreasury'}} \\
@@ -842,55 +719,84 @@ the ``total pot'' used during the epoch transition in Figure \ref{fig:rules:accn
     }
   \end{equation}
   \caption{Accounting Epoch inference rules}
-  \label{fig:rules:accnt}
+  \label{fig:rules:acnt}
 \end{figure}
 
-\subsection{Epoch Boundary Pool Cleanup}
-\label{sec:pool-clean}
+\subsection{Epoch Boundary Pool Reaping}
+\label{sec:pool-reap}
 
-Next, we discuss the epoch boundary pool retirement in
-Figure~\ref{fig:ts-types:pool-clean}. The type of this transition is similar
-to the other $\PState$ transition type we defined earlier, which is triggered
-by a signal certificate,
-however, this one has an empty signal (as it happens at the boundary).
+Figure~\ref{fig:ts-types:pool-reap} defines the types for the pool reap transition,
+which is responsible for removing pools slated for retirement in the given epoch.
 
 %%
-%% Figure - Pool Clean Defs
+%% Figure - Pool Reap Defs
 %%
 \begin{figure}[htb]
+  \emph{Pool Reap State}
   \begin{equation*}
-    \_ \vdash \_ \trans{poolclean}{} \_ \in
-    \powerset (\Slot \times \PState \times \PState)
+    \PlReapState =
+    \left(
+      \begin{array}{r@{~\in~}ll}
+        \var{acnt} & \Acnt & \text{accounting}\\
+        \var{dstate} & \DState & \text{delegation state}\\
+        \var{pstate} & \PState & \text{pool state}\\
+      \end{array}
+    \right)
   \end{equation*}
   %
-  \caption{Pool Clean Transition}
-  \label{fig:ts-types:pool-clean}
+  \emph{Pool Reap transitions}
+  \begin{equation*}
+    \_ \vdash \_ \trans{poolreap}{} \_ \in
+    \powerset (\Slot \times \PlReapState \times \PlReapState)
+  \end{equation*}
+  %
+  \caption{Pool Reap Transition}
+  \label{fig:ts-types:pool-reap}
 \end{figure}
 
 
-We now present the pool-cleanup transition rule in Figure~\ref{fig:rules:pool-clean}.
-This rule will be applied whenever there is one or more stake pools scheduled
-to retire this epoch. If so, all of the entries in $\var{stpools}$,
-$\var{poolParams}$, and $\var{retiring}$ which correspond to any of the hash keys
-of the stake pools scheduled to retire this epoch are removed from
-these variables.
+The pool-reap transition rule is given in Figure~\ref{fig:rules:pool-reap}.
+This transition has no preconditions and results in the following state change:
 
-It is important to note here that we \textit{do not} clean up delegations to
-retired stake pools. While we do not allow registration to non-existent
-stake pools (because that is a meaningless operation likely to be the result
-of an error), delegating to a pool that was once active means that there may
-be stake associated with this delegation. While this stake becomes inactive when
-the pool is retired, the delegations to that pool must remain on the ledger
-for potential future use.
+\begin{itemize}
+  \item For each retiring pool, the refund for the pool registration deposit is added to the
+    pool's registered reward account, provided the reward account is still registered.
+  \item The sum of all the pool deposit refunds for pools without a registered reward
+    accounts is added to the treasury.
+  \item Any delegation to a retiring pool is removed.
+  \item Each retiring pool is removed from all the four maps in the pool state.
+\end{itemize}
 
 %%
-%% Figure - Pool Clean Rule
+%% Figure - Pool Reap Rule
 %%
 \begin{figure}[htb]
-  \begin{equation}\label{eq:pool-clean}
-    \inference[Pool-Clean]
+  \begin{equation}\label{eq:pool-reap}
+    \inference[Pool-Reap]
     {
-      \var{retired} = \var{retiring}^{-1}~\var{(\epoch{slot})}
+      {
+      \begin{array}{r@{=}l}
+        \var{retired} & \var{retiring}^{-1}~\var{(\epoch{slot})} \\
+        \var{pr} & \poolRefunds{pp}{retiring}{cslot} \\
+        \var{rewardAcnts} & \{\var{hk}\mapsto \fun{poolAcntHK}~\var{pool} \mid
+                            \var{hk}\mapsto\var{pool} \in \var{poolParams},
+                            ~\var{hk}\in\var{retired}\} \\
+        \var{refunds} & \left\{
+                        \addrRw{hk'} \mapsto c
+                        \mathrel{\Bigg|}
+                        \begin{array}{r@{~\in~}l}
+                          \var{hk} \mapsto c & \var{pr}, \\
+                          \var{hk}\mapsto\var{hk'} & \var{rewardAcnts}, \\
+                          \var{hk'} & \dom\var{stkeys}
+                        \end{array}
+                      \right\} \\
+        \var{unclaimed} & \sum\limits_{\substack{
+                          hk \mapsto c \in \var{pr} \\
+                          \var{hk}\mapsto\var{hk'} \in \var{rewardAcnts}, \\
+                          \var{hk'} \notin \var{stkeys}
+                          }} c
+      \end{array}
+      }
     }
     {
       \begin{array}{l}
@@ -899,15 +805,29 @@ for potential future use.
       \vdash
       \left(
         \begin{array}{r}
+          \var{treasury} \\
+          \var{reserves} \\
+          \var{rewardPot} \\
+          \var{stkeys} \\
+          \var{rewards} \\
+          \var{delegations} \\
+          \var{ptrs} \\
           \var{stpools} \\
           \var{poolParams} \\
           \var{retiring} \\
           \var{avgs} \\
         \end{array}
       \right)
-      \trans{poolclean}{}
+      \trans{poolreap}{}
       \left(
         \begin{array}{rcl}
+          \varUpdate{\var{treasury}} & \varUpdate{+} & \varUpdate{\var{unclaimed}} \\
+          \var{reserves} \\
+          \var{rewardPot} \\
+          \var{stkeys} \\
+          \varUpdate{\var{rewards}} & \varUpdate{\unionoverridePlus} & \varUpdate{\var{refunds}} \\
+          \varUpdate{\var{delegations}} & \varUpdate{\subtractrange} & \varUpdate{\var{retiring}} \\
+          \var{ptrs} \\
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{stpools}} \\
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{poolParams}} \\
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{retiring}} \\
@@ -916,30 +836,32 @@ for potential future use.
       \right)
     }
   \end{equation}
-  \caption{Pool Clean Inference Rule}
-  \label{fig:rules:pool-clean}
+  \caption{Pool Reap Inference Rule}
+  \label{fig:rules:pool-reap}
 \end{figure}
 
+\clearpage
+
 \subsection{Epoch Boundary Protocol Constants Update}
-\label{sec:prot-const-epoch}
+\label{sec:prot-param-epoch}
 
 Finally, reaching the epoch boundary may trigger a change in the protocol
 parameters. Besides the current slot number, delegation and pool states, the
-protocol constant environment includes the old and new protocol parameters.
-The state change is a change of the $\UTxOState$ and the $\Accnt$ states.
-The type of this state transition is given in Figure~\ref{fig:ts-types:new-proto-consts}.
+protocol parameters environment includes new protocol parameters.
+The state change is a change of the $\UTxOState$, the $\Acnt$ states, and the current
+$\PParams$.
+The type of this state transition is given in Figure~\ref{fig:ts-types:new-proto-param}.
 
 %%
-%% Figure - New Proto Consts Defs
+%% Figure - New Proto Param Defs
 %%
 \begin{figure}[htb]
-  \emph{New Proto Consts environment}
+  \emph{New Proto Param environment}
   \begin{equation*}
-    \NewProtoConstsEnv =
+    \NewPParamEnv =
     \left(
       \begin{array}{r@{~\in~}ll}
         \var{slot} & \Slot & \text{current slot}\\
-        \var{ppOld} & \PParams & \text{old protocol parameters}\\
         \var{ppNew} & \PParams & \text{new protocol parameters}\\
         \var{dstate} & \DState & \text{delegation state}\\
         \var{pstate} & \PState & \text{pool state}\\
@@ -947,70 +869,70 @@ The type of this state transition is given in Figure~\ref{fig:ts-types:new-proto
     \right)
   \end{equation*}
   %
-  \emph{New Proto Consts States}
+  \emph{New Proto Param States}
   \begin{equation*}
-    \NewProtoConstsState =
+    \NewPParamState =
     \left(
       \begin{array}{r@{~\in~}ll}
         \var{utxoSt} & \UTxOState & \text{utxo state}\\
-        \var{accnt} & \Accnt & \text{accounting}\\
+        \var{acnt} & \Acnt & \text{accounting}\\
+        \var{pp} & \PParams & \text{current protocol parameters}\\
       \end{array}
     \right)
   \end{equation*}
   %
-  \emph{New Proto Consts transitions}
+  \emph{New Proto Param transitions}
   \begin{equation*}
     \_ \vdash
-    \var{\_} \trans{newpc}{} \var{\_}
-    \subseteq \powerset (\NewProtoConstsEnv \times
-    \NewProtoConstsState \times \NewProtoConstsState)
+    \var{\_} \trans{newpp}{} \var{\_}
+    \subseteq \powerset (\NewPParamEnv \times \NewPParamState \times \NewPParamState)
   \end{equation*}
   %
-  \caption{New Proto Consts transition-system types}
-  \label{fig:ts-types:new-proto-consts}
+  \caption{New Proto Param transition-system types}
+  \label{fig:ts-types:new-proto-param}
 \end{figure}
 
 
-The inference rule for changing protocol parameters does one of the following:
+Figure~\ref{fig:rules:new-proto-param} defines the new protocol parameter transition.
+The transition has two rules, depending on whether or not the new protocol parameters
+would incur a debt on the system that could not be covered by the reserves.
+The transition has two rules, each with one precondition. The preconditions are
+negations of each other, so that exactly one rule will have its precondition met.
+This transition results in the following state change:
 
 \begin{itemize}
-\item if there are more (or the same amount of) total possible refunds
-available calculated based on the old protocol parameters than the new ones,
-moves the difference between the two values into the $\var{reserves}$
-from the $\var{deposits}$ variable, \textit{or}
+  \item If the new protocol parameters mean that \textbf{fewer} funds are required in the
+    deposit pot to cover all possible refunds, then Rule~\ref{eq:new-pc-accepted} meets
+    the precondition. The excess is moved to the reserves and the protocol parameters are updated.
 
-\item if there are more refunds available based on the new parameters, it moves
-the difference between the two calculations from $\var{deposits}$
-to $\var{reserves}$, \textit{provided that} there is enough coin in the
-$\var{reserves}$ to cover the entire value of the transfer
+  \item If the new protocol parameters mean that \textbf{more} funds are required in the
+    deposit pot to cover all possible refunds, and the difference is \textbf{less} than
+    the reserve pot, then Rule~\ref{eq:new-pc-accepted} meets the precondition.  Funds are moved
+    from the reserve pot to cover the difference and the protocol parameters are updated.
 
-\item if there are more refunds available based on the new parameters,
-but there is \textit{not} enough coin in the $\var{reserves}$ to cover
-the entire value of the transfer, the update is ignored entirely.
+  \item If the new protocol parameters mean that \textbf{more} funds are required in the
+    deposit pot to cover all possible refunds, and the difference is \textbf{more} than
+    the reserve pot, then Rule~\ref{eq:new-pc-denied} meets the precondition and no state change happens.
 \end{itemize}
 
-This update of protocol parameters ensures that any time a deposit refund is
-requested, the necessary amount of funds is available in the $\var{deposits}$
-pool.
-
 Note that here, unlike most of the inference rules in this document,
-the $\var{utxoSt'}$ and the $\var{accnt'}$ do not come from valid UTxO or
+the $\var{utxoSt'}$ and the $\var{acnt'}$ do not come from valid UTxO or
 accounts transitions in the antecedent. We simply define the consequent
 transition using these directly (instead of listing all the fields in both
 states in the consequent transition). It is done this way here
 for ease of reading.
 
 %%
-%% Figure - New Proto Consts Rule
+%% Figure - New Proto Param Rule
 %%
 \begin{figure}[htb]
   \begin{equation}\label{eq:new-pc-accepted}
-    \inference[New-Proto-Consts-Accepted]
+    \inference[New-Proto-Param-Accepted]
     {
-      \var{oblgOld} = \obligation{ppOld}{stkeys}{stpools}{slot} \\
+      \var{oblgCur} = \obligation{pp}{stkeys}{stpools}{slot} \\
       \var{oblgNew} = \obligation{ppNew}{stkeys}{stpools}{slot} \\
       ~\\
-      \var{diff} = \var{oblgOld} - \var{oblgNew} \\
+      \var{diff} = \var{oblgCur} - \var{oblgNew} \\
       \var{reserves} + \var{diff} \geq 0\\
       ~\\
       \var{utxoSt'} =
@@ -1024,7 +946,7 @@ for ease of reading.
         }
       \right)
       &
-      \var{accnt'} =
+      \var{acnt'} =
       \left(
         {
           \begin{array}{r}
@@ -1039,7 +961,6 @@ for ease of reading.
     {
       \begin{array}{l}
         \var{slot}\\
-        \var{ppOld}\\
         \var{ppNew}\\
         \var{dstate}\\
         \var{pstate}\\
@@ -1048,14 +969,16 @@ for ease of reading.
       \left(
         \begin{array}{r}
           \var{utxoSt} \\
-          \var{accnt}
+          \var{acnt} \\
+          \var{pp}
         \end{array}
       \right)
-      \trans{newpc}{}
+      \trans{newpp}{}
       \left(
         \begin{array}{rcl}
           \varUpdate{utxoSt'}\\
-          \varUpdate{accnt'} \\
+          \varUpdate{acnt'} \\
+          \varUpdate{\var{ppNew}} \\
         \end{array}
       \right)
     }
@@ -1064,18 +987,17 @@ for ease of reading.
   \nextdef
 
   \begin{equation}\label{eq:new-pc-denied}
-    \inference[New-Proto-Consts-Denied]
+    \inference[New-Proto-Param-Denied]
     {
-      \var{oblgOld} = \obligation{ppOld}{stkeys}{stpools}{slot} \\
+      \var{oblgCur} = \obligation{pp}{stkeys}{stpools}{slot} \\
       \var{oblgNew} = \obligation{ppNew}{stkeys}{stpools}{slot} \\
       ~\\
-      \var{diff} = \var{oblgOld} - \var{oblgNew} \\
+      \var{diff} = \var{oblgCur} - \var{oblgNew} \\
       \var{reserves} + \var{diff} < 0\\
     }
     {
       \begin{array}{l}
         \var{slot}\\
-        \var{ppOld}\\
         \var{ppNew}\\
         \var{dstate}\\
         \var{pstate}\\
@@ -1084,30 +1006,35 @@ for ease of reading.
       \left(
         \begin{array}{r}
           \var{utxoSt} \\
-          \var{accnt}
+          \var{acnt} \\
+          \var{pp}
         \end{array}
       \right)
-      \trans{newpc}{}
+      \trans{newpp}{}
       \left(
         \begin{array}{rcl}
           \var{utxoSt} \\
-          \var{accnt}
+          \var{acnt} \\
+          \var{pp}
         \end{array}
       \right)
     }
   \end{equation}
-  \caption{New Proto Consts Inference Rule}
-  \label{fig:rules:new-proto-consts}
+  \caption{New Proto Param Inference Rule}
+  \label{fig:rules:new-proto-param}
 \end{figure}
+
+\clearpage
 
 \subsection{Complete Epoch Boundary Transition}
 \label{sec:total-epoch}
 
-Finally, it is possible to define the complete epoch boundary transition type.
-In the environment of this transition, we have the slot number, blocks made
-this epoch, and both the old and the new protocol parameters. The state is
-made up of the accounting state, the UTxO, the delegation state and the
-pool state.
+Finally, it is possible to define the complete epoch boundary transition type,
+which is defined in Figure~\ref{fig:ts-types:epoch}.
+In the environment of this transition, we have the slot number, potentially new
+protocol parameters, and the blocks made this epoch.  The state is made up of the
+the UTxO state, the accounting state, the delegation state, the pool state, and
+the current protocol parameters.
 
 %%
 %% Figure - Epoch Defs
@@ -1119,7 +1046,6 @@ pool state.
     \left(
       \begin{array}{r@{~\in~}ll}
         \var{slot} & \Slot & \text{current slot}\\
-        \var{ppOld} & \PParams & \text{old protocol parameters}\\
         \var{ppNew} & \PParams & \text{new protocol parameters}\\
         \var{blocks} & \HashKey \mapsto \N & \text{blocks made in the epoch}\\
       \end{array}
@@ -1132,9 +1058,10 @@ pool state.
     \left(
       \begin{array}{r@{~\in~}ll}
         \var{utxoSt} & \UTxOState & \text{utxo state}\\
-        \var{accnt} & \Accnt & \text{accounting}\\
+        \var{acnt} & \Acnt & \text{accounting}\\
         \var{dstate} & \DState & \text{delegation state}\\
         \var{pstate} & \PState & \text{pool state}\\
+        \var{pp} & \PParams & \text{current protocol parameters}\\
       \end{array}
     \right)
   \end{equation*}
@@ -1151,11 +1078,8 @@ pool state.
 \end{figure}
 
 
-The epoch transition rule is a composition of all the state transition rules
-we have defined above. That is, whenever the UTXOEP, ACCNT, POOLCLEAN, and
-NEWPC are all valid transitions between their respective pairs of sets of
-state variables, the total transition epoch boundary ledger state transition
-is a composition of these four rules in that order.
+The epoch transition rule is a composition of all the state transition rules we have defined above.
+It calls $\mathsf{ACNT}$, $\mathsf{POOLREAP}$, and $\mathsf{NEWPP}$ in sequence.
 
 Note that the slot number used as \textit{current slot number}
 for the epoch boundary calculations where a slot number is required is set to
@@ -1171,7 +1095,7 @@ be the \textit{last slot of the epoch before the boundary}.
       {
         \begin{array}{l}
           \var{slot}\\
-          \var{ppOld}\\
+          \var{pp}\\
           \var{blocks}\\
         \end{array}
       }
@@ -1179,18 +1103,18 @@ be the \textit{last slot of the epoch before the boundary}.
       \left(
         {
           \begin{array}{r}
-            \var{accnt} \\
+            \var{acnt} \\
             \var{dstate} \\
             \var{pstate} \\
             \var{utxoSt} \\
           \end{array}
         }
       \right)
-      \trans{accnt}{}
+      \trans{acnt}{}
       \left(
       {
         \begin{array}{rcl}
-          \var{accnt'} \\
+          \var{acnt'} \\
           \var{dstate'} \\
           \var{pstate'} \\
           \var{utxoSt'} \\
@@ -1207,14 +1131,18 @@ be the \textit{last slot of the epoch before the boundary}.
       \left(
         {
           \begin{array}{r}
+            \var{acnt'} \\
+            \var{dstate'} \\
             \var{pstate'} \\
           \end{array}
         }
       \right)
-      \trans{poolclean}{}
+      \trans{poolreap}{}
       \left(
       {
         \begin{array}{rcl}
+            \var{acnt''} \\
+            \var{dstate''} \\
             \var{pstate''} \\
         \end{array}
       }
@@ -1223,7 +1151,6 @@ be the \textit{last slot of the epoch before the boundary}.
       {
         \begin{array}{l}
           \var{slot}\\
-          \var{ppOld}\\
           \var{ppNew}\\
           \var{dstate'}\\
           \var{pstate''}\\
@@ -1234,16 +1161,18 @@ be the \textit{last slot of the epoch before the boundary}.
         {
           \begin{array}{r}
             \var{utxoSt'} \\
-            \var{accnt'} \\
+            \var{acnt''} \\
+            \var{pp}\\
           \end{array}
         }
       \right)
-      \trans{newpc}{}
+      \trans{newpp}{}
       \left(
       {
         \begin{array}{rcl}
             \var{utxoSt''} \\
-            \var{accnt''} \\
+            \var{acnt'''} \\
+            \var{pp'}\\
         \end{array}
       }
       \right)
@@ -1251,7 +1180,6 @@ be the \textit{last slot of the epoch before the boundary}.
     {
       \begin{array}{l}
         \var{slot}\\
-        \var{ppOld}\\
         \var{ppNew}\\
         \var{blocks}\\
       \end{array}
@@ -1259,18 +1187,20 @@ be the \textit{last slot of the epoch before the boundary}.
       \left(
       \begin{array}{r}
         \var{utxoSt} \\
-        \var{accnt} \\
+        \var{acnt} \\
         \var{dstate} \\
-        \var{pstate}
+        \var{pstate} \\
+        \var{pp} \\
       \end{array}
       \right)
       \trans{epoch}{}
       \left(
       \begin{array}{rcl}
         \varUpdate{\var{utxoSt''}} \\
-        \varUpdate{\var{accnt''}} \\
-        \varUpdate{\var{dstate'}} \\
-        \varUpdate{\var{pstate''}}
+        \varUpdate{\var{acnt'''}} \\
+        \varUpdate{\var{dstate''}} \\
+        \varUpdate{\var{pstate''}} \\
+        \varUpdate{\var{pp'}}
       \end{array}
       \right)
     }

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -128,7 +128,7 @@
 \newcommand{\Delegate}[1]{\textsc{Delegate}(#1)}
 \newcommand{\RegPool}[1]{\textsc{RegPool}(#1)}
 \newcommand{\RetirePool}[1]{\textsc{RetirePool}(#1)}
-\newcommand{\cauthor}[1]{\fun{author}~ \var{#1}}
+\newcommand{\cwitness}[1]{\fun{cwitness}~ \var{#1}}
 \newcommand{\dpool}[1]{\fun{dpool}~ \var{#1}}
 \newcommand{\poolParam}[1]{\fun{poolParam}~ \var{#1}}
 \newcommand{\retire}[1]{\fun{retire}~ \var{#1}}
@@ -172,7 +172,6 @@
 \newcommand{\genesisTxOut}{\ensuremath{Genesis_{Out}}}
 \newcommand{\genesisUTxO}{\ensuremath{Genesis_{UTxO}}}
 \newcommand{\emax}{\ensuremath{\mathsf{E_{max}}}}
-\newcommand{\slotsPer}{\ensuremath{\mathsf{slotsPerEpoch}}}
 
 \newcommand{\unitInterval}{\ensuremath{[0,~1]}}
 \newcommand{\nonnegReals}{\ensuremath{[0,~\infty)}}
@@ -225,7 +224,7 @@ The transition system is explained in \cite{small_step_semantics}.
 In Figure~\ref{fig:notation:nonstandard}, we specify the notation we use in
 the rest of the document.
 
-\begin{figure}
+\begin{figure}[htb]
   \begin{align*}
     \var{set} \restrictdom \var{map}
     & = \{ k \mapsto v \mid k \mapsto v \in \var{map}, ~ k \in \var{set} \}
@@ -288,7 +287,23 @@ and signatures. The constraint we introduce states that a signature of
 some data signed with a (private) key is only correct whenever we can verify
 it using the corresponding public key.
 
-\begin{figure}
+Besides basic cryptographic abstractions, we also make use of some abstract
+data storage properties in this document in order to build necessary definitions
+and make judgement calls about them.
+
+Abstract data types in this paper are essentially placeholders with names
+indicating the data types they are meant to represent in an implementation.
+Derived types are made up of data structures (i.e. products, lists, finite
+maps, etc.) built from abstract types. The underlying structure of a data type
+is implementation-dependent, and furthermore, the way the data is stored on
+physical storage can vary as well.
+
+Serialization is a physical manifestation of data on a given storage device.
+In this document, the properties and rules we state involving serialization are
+assumed to hold true independently of the storage medium and style of data
+organization chosen for an implementation.
+
+\begin{figure}[htb]
   \emph{Abstract types}
   %
   \begin{equation*}
@@ -337,36 +352,35 @@ it using the corresponding public key.
 
 \clearpage
 
-\section{Serialization}
-\label{sec:serialization}
-
-
-Besides basic cryptographic abstractions, we also make use of some abstract
-data storage properties in this document in order to build necessary definitions
-and make judgement calls about them.
-
-Abstract data types in this paper are essentially placeholders with names
-indicating the data types they are meant to represent in an implementation.
-Derived types are made up of data structures (i.e. products, lists, finite
-maps, etc.) built from abstract types. The underlying structure of a data type
-is implementation-dependent, and furthermore, the way the data is stored on
-physical storage can vary as well.
-
-Serialization is a physical manipulation of data on a given storage device.
-In this document, the properties and rules we state involving serialization are
-assumed to hold true independently of the storage medium and style of data
-organization chosen for an implementation.
-
-\clearpage
-
 \section{Addresses}
 \label{sec:addresses}
+Addresses are described in section 4.2 of the delegation design document \cite{delegation_design}.
+The types needed for the addresses are defined in Figure~\ref{fig:defs:addresses}.
+There are three types of UTxO addresses:
+\begin{itemize}
+  \item Base addresses, $\AddrB$,
+        containing the hash of a payment key and the hash of a staking key,
+  \item Pointer addresses, $\AddrP$,
+        containing the hash of a payment key and a pointer to a stake key registration certificate,
+  \item Enterprise addresses, $\AddrE$,
+        containing only the hash of a payment key (and which have no staking rights).
+\end{itemize}
+Together, these three address types make up the $\Addr$ type, which will be used
+in transaction outputs in Section~\ref{sec:ledger}.
 
-\begin{todo}
-Move address explanations here.
-\end{todo}
+Note that for security, privacy, and usability reasons, the staking (delegating)
+key pair associated with an address should be different from its payment key pair.
+Before the stake key is registered and delegated to an existing stake pool,
+the payment key can be used for transactions, though it will not receive rewards from staking.
+Once a stake key is registered, the shorter pointer addresses can generated.
 
-\begin{figure*}
+Finally, there is an account style address $\AddrRWD$ which contains the hash of a staking key.
+These account addresses will only be used for receiving rewards from the proof of
+stake leader election.  Apendix A of \cite{delegation_design} explains this design choice.
+The mechanism for transferring rewards from these accounts will be explained in
+Section~\ref{sec:ledger}, and follows \cite{chimeric}.
+
+\begin{figure*}[hbt]
   \emph{Abstract types}
   %
   \begin{equation*}
@@ -385,11 +399,6 @@ Move address explanations here.
       & \Slot\times\Ix\times\Ix
       & \text{certificate pointer}
       \\
-      \var{acct}
-      & \AddrRWD
-      & \HashKey_{stake}
-      & \text{reward account}
-      \\
       \var{addr}
       & \AddrB
       & \HashKey_{pay}\times\HashKey_{stake}
@@ -405,11 +414,15 @@ Move address explanations here.
       & \HashKey_{pay}
       & \text{enterprise address}
       \\
-
       \var{addr}
       & \Addr
       & \AddrB \uniondistinct \AddrP \uniondistinct \AddrE
       & \text{output address}
+      \\
+      \var{acct}
+      & \AddrRWD
+      & \HashKey_{stake}
+      & \text{reward account}
       \\
     \end{array}
   \end{equation*}
@@ -447,21 +460,28 @@ Move address explanations here.
 \section{Protocol Parameters}
 \label{sec:protocol-parameters}
 
-The $\PParams$ is
-an abstract type that will represent an environment variable that contains
-values on which the functionality of the blockchain protocol depends, such
-as the fees transactions are obligated to pay to be processed.
+The rules for the ledger depend on several parameters and are contained in the $\PParams$ type
+defined in Figure~\ref{fig:defs:protocol-parameters}.
 
-\begin{todo}
-Move explanations of indididual parameters explanation here.
-\end{todo}
+The type $\Coin$ is defined as an alias for the integers.
+Negative values will not be allowed in UTxO outputs or reward accounts,
+and $\Z$ is only chosen over $\N$ for its additive inverses.
 
-\begin{figure*}
+The $\fun{minfee}$ function calculates the minimum fee that must be paid by a transaction.
+This value depends on the protocol parameters and the size of the transaction.
+
+Two time related types are introduced, $\Epoch$ and $\type{Duration}$.
+A $\type{Duration}$ is the difference between two slots, as given by $\slotminus{}{}$.
+
+
+\begin{figure*}[htb]
   \emph{Abstract types}
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \var{fparams} & \type{FeeParams} & \text{min fee parameters}\\
+      \var{dur} & \Duration & \text{difference between slots}\\
+      \var{epoch} & \Epoch & \text{epoch} \\
     \end{array}
   \end{equation*}
   %
@@ -483,6 +503,7 @@ Move explanations of indididual parameters explanation here.
     \PParams =
     \left(
       \begin{array}{r@{~\in~}lr}
+        \var{slotsPerEpoch} & \N & \text{slots per epoch} \\
         \var{fparams} & \type{FeeParams} & \text{min fee parameters}\\
         \var{keyDeposit} & \Coin & \text{stake key deposit}\\
         \var{keyMinRefund} & \unitInterval & \text{stake key min refund}\\
@@ -504,6 +525,7 @@ Move explanations of indididual parameters explanation here.
   \emph{Accessor Functions}
   %
   \begin{center}
+    \fun{slotsPerEpoch},
     \fun{fparams},
     \fun{keyDeposit},
     \fun{keyMinRefund},
@@ -525,7 +547,16 @@ Move explanations of indididual parameters explanation here.
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \fun{minfee} & \PParams \to \Tx \to \Coin
-                   & \text{minimum fee calculation}\\
+                   & \text{minimum fee calculation}
+      \\
+      (\slotminus{}{}) & \Slot \to \Slot \to \Duration
+                       & \text{duration between slots}
+      \\
+      \fun{epoch} & \Slot \to \Epoch
+                  & \text{epoch of a slot}
+      \\
+      \fun{firstSlot} & \Epoch \to \Slot
+                 & \text{first slot of an epoch}
     \end{array}
   \end{equation*}
   \caption{Definitions used in Protocol Parameters}
@@ -534,353 +565,41 @@ Move explanations of indididual parameters explanation here.
 
 \clearpage
 
-\section{Delegation}
-\label{sec:delegation}
-\input{delegation.tex}
+\section{Transactions}
 
-\clearpage
+Transactions are defined in Figure~\ref{fig:defs:utxo}.
+A transaction body, $\TxBody$, is made up of six pieces:
 
-\section{UTxO}
-\label{sec:utxo}
+\begin{itemize}
+  \item A set of transaction inputs.
+    The $\TxIn$ derived type identifies an output from a previous transaction.
+    It consists of a transaction id and an index to uniquely identify the output.
+  \item An indexed collection of transaction outputs.
+    The $\TxOut$ type is an address paired with a coin value.
+  \item A list of certificates, which will be explained in detail in Section~\ref{sec:delegation}.
+  \item A transaction fee. This value will be added to the fee pot and eventually handed out
+    as stake rewards.
+  \item A time to live. A transaction will be deemed invalid if processed after this slot.
+  \item A mapping of reward account withdrawals.  The type $\Wdrl$ is a finite map that maps
+    a reward address to the coin value to be withdrawn. The coin value must be equal
+    to the full value contained in the account. Explicitly stating these values ensures
+    that error messages can be precise about why a transaction is invalid.
+\end{itemize}
+A transaction, $\Tx$, is a transaction body together with:
 
-A key constraint that must always be satisfied as a result and precondition of
-a valid ledger state transition is called the \textit{general accounting
-property}, or the \textit{preservation of value} condition. Every piece of
-software that is a part of the implementation of the
-Cardano cryptocurrency must function in such a way as to not result in
-a violation of this rule.
-If this condition is not satisfied, it is an indicator of
-incorrect accounting, potentially due to
-malicious disruption or a bug.
+\begin{itemize}
+  \item A collection of witnesses, represented as a finite map from payment verification keys
+    to signatures.
+\end{itemize}
 
-The preservation of value is expressed as an equality that uses values in
-the ledger state and the environment, as well as the values in the body of
-the signal transaction.
-We have defined the rules of the delegation protocol in a way that should
-consistently satisfy the preservation of value. In the future, we hope to
-give a formally-verified proof that every \textit{valid} ledger state satisfies
-this property.
+Additionally, the $\UTxO$ type will be used by the ledger state to store all the
+unspent transaction outputs. It is a finite map from transaction inputs
+to transaction outputs that are available to be spent.
 
-In this section, we discuss the relevant accounting that needs to be done
-as a result of processing a transaction, i.e. the deposits for all certificates,
-transaction fees, transaction withdrawals, and refunds for individual
-deregistration, so that we may keep track of whether the preservation of
-value is satisfied. Stake pool retirement refunds are not triggered by a
-transaction (but rather, happen at the epoch boundary), and are therefore
-not considered in our state change rules invoked due to a signal transaction.
+Finally, $\fun{txid}$ computes the transaction id of a given transaction.
+This function must produce a unique id for each unique transaction.
 
-Note, that when a transaction is issued by a wallet to be applied to the ledger
-state (i.e. processed),
-we define the rules in this section in such a way that it is impossible to
-apply only some parts of a transaction (e.g. only certain certificates).
-Every part of the transaction must be valid and it must be live, otherwise
-it is ignored entirely. It is the wallet's responsibility to inform the user
-that a transaction failed to be processed.
-
-\subsection{Deposits and Refunds}
-\label{sec:deps-refunds}
-
-The map $\fun{decay}$
-represents the rate of decrease of the value of a unit of $\Coin$.
-The constant returned by $\fun{decay}$ consists of two values. The first is
-a natural number which determines the minimal proportion of a deposit that will
-be refunded on resource release. The second is a positive rational number
-used to determine the rate of (exponential) decrease of the value.
-
-For a given transaction and protocol parameters, the map $\fun{dresource}$
-returns all the certificates of that transaction which allocate resources
-(i.e. the stake key and stake pool registration certificates). The map
-$\fun{dderegister}$ returns the resource release certificates for the
-deregistration of a stake key. The map which returns only
-the retirement type certificates is $\fun{dretire}$. The function $\fun{txttl}$ gives the
-time slot in which the validity of a given transaction will expire. That is,
-after slot number $\fun{txttl}~\var{tx}$, the transaction will not be processed.
-This value is generated by the wallet.
-
-The functions used in refund calculations are presented in
-Figure~\ref{fig:functions:deposits-refunds}.
-The function
-$\fun{deposits}$ returns the total deposits that have to be made by a transaction.
-This calculation is based on the protocol parameters.
-Specifically, for a given transaction,
-it sums up the values of the stake key deposits and the stake pool deposits.
-Those certificates which are
-updates of stake pool parameters of already registered pool keys should not
-(and are, in fact, not allowed to) make a deposit.
-
-The $\fun{isReleasing}~\var{c}$ is true for deregistration and retirement
-certificates. The refund calculation gives the decayed value of a
-certificate to be refunded. This fraction is calculated
-based on the coin value of the registration deposit $d_{val}$, the minimum
-refund coefficient $d_{min}$, the
-duration between the given slot number and the slot number in
-which a given resource was allocated $\delta$, and a decay rate constant $\lambda$.
-The larger the duration, the more
-the value of the deposit decays, down to a minimum refund value.
-
-The function $\fun{keyRefund}$, given a set of protocol parameters, resource
-allocations, slot number, and certificate, uses the refund calculation to
-assign a non-zero refund to a resource releasing certificate if
-the certificate’s author is listed in the provided resource allocations.
-The certificate value passed to the $\fun{refund}$ calculation is obtained from
-the protocol parameters based on the type of certificate (i.e. individual or pool).
-The minimum and decay values are also found in the protocol parameters, while
-the duration is the difference between given slot number and the slot
-number associated with the author's key in the resource allocation argument.
-
-The function $\fun{keyRefunds}$, in turn, uses $\fun{keyRefund}$ to calculate
-the total value to be refunded to all individual key deregistration
-certificate authors in a transaction.
-Given protocol parameters, resource allocations, and a transaction,
-this calculation sums up all the refunds for the individual key
-deregistration certificates
-carried by the given transaction by passing the relevant parameters to the
-$\fun{keyRefund}$ function.
-
-It is important to note here that instead of the \textit{current} slot number,
-the time to live of $\var{tx}$ is passed to the $\fun{certRefunds}$ function
-within the summation in $\fun{keyRefunds}$. The reason for this is that the
-refunds for any key deregistration certificates are, in fact, included in
-the $\var{tx}$ itself --- meaning that the coin value of the refund must be
-explicitly specified in the outputs of the transaction. So,
-the value of the included refund must be calculated before this transaction
-is ever processed, and be the same \textit{no matter when} the $\var{tx}$
-\textit{is actually processed} in order to allow the system to continue to
-satisfy the general accounting property.
-
-It is impossible to predict the exact slot
-number in which $\var{tx}$ will be processed, but it will be some time before
-slot number $\fun{txttl}~\var{tx}$. So, this is the slot number value used in both
-the calculation to generate the refund coin value in the outputs of $\var{tx}$
-and in the general accounting property equation.
-
-Note that since the refund is based
-on the original deposit paid (as indicated in the protocol parameters that
-were valid in the time slot the deposit was made), the accounting or the slot
-number do not also need to be updated in any way when updating pool constants with
-a certificate.
-
-Note also that
-$\fun{keyRefunds}$ calculates the total individual refunds for a transaction
-based on \textit{current} protocol parameters. This means that any deposits
-made prior to a change will be different from their corresponding
-(decayed) refunds in the case of key deregistration after a change in
-protocol parameters. Constants may only change at the epoch boundary, and
-ensuring there are always sufficient funds for all
-refunds in the $\var{deposits}$ pool is part of the protocol constant
-change transition, described in Section~\ref{sec:epoch}.
-
-The protocol parameters are not
-expected to change often, and using the current ones for the calculation
-is a deliberate simplification choice, which does not introduce any inconsistencies
-into the system rules or properties. In particular, the general accounting
-property is not violated.
-
-Finally, note that a refund for a resource-releasing certificate in a
-transaction can only be issued if the refund is bigger than the minimum
-transaction fee. In order to receive a refund in this case, the transaction
-body must also contain inputs onto which this refund can be added.
-
-
-\begin{figure}
-  \begin{align*}
-    & \fun{deposits} \in \PParams \to \StakePools \to \seqof{\DCert} \to \Coin
-    & \text{total deposits for transaction} \\
-    & \fun{deposits}~{pp}~{stpools}~{certs} = \\
-    &  \sum\limits_{\substack{c\in\var{certs} \\ c\in\DCertRegKey}}(\fun{keyDeposit}~pp)
-    +  \sum\limits_{\substack{c\in\var{certs} \\ c\in\DCertRegPool \\ (\cauthor{c})\notin \var{stpools}}}
-            (\fun{poolDeposit}~pp)
-      \nextdef
-      & \fun{refund} \in \Coin \to \unitInterval \to \posReals \to \Duration \to \Coin
-      & \text{refund calculation} \\
-      & \refund{\dval}{d_{\min}}{\lambda}{\delta} =
-            \floor*{
-              \dval \cdot
-            \left(d_{\min}+(1-d_{\min})\cdot e^{-\lambda\cdot\delta}\right)}
-      \nextdef
-      & \fun{keyRefund} \in \Coin \to \unitInterval \to \posReals \to \\
-      & ~~~~~\StakeKeys \to \Slot \to \DCertDeRegKey \to \Coin
-      & \text{key refund for a certificate} \\
-      & \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{slot}{c} =\\
-      & ~~~~~\begin{cases}
-            0 & \text{if}~\cauthor c \notin \dom stkeys\\
-            \refund{\dval}{d_{\min}}{\lambda}{\delta}
-            & \text{otherwise}
-        \end{cases}\\
-      &
-      \begin{array}{lr@{~=~}l}
-        \where
-        &\delta & \slotminus{slot}{(stkeys~(\cauthor c))}\\
-      \end{array}\\
-      \nextdef
-      & \fun{keyRefunds} \in \PParams \to \StakeKeys \to \Tx \to \Coin
-      & \text{key refunds for a transaction} \\
-      & \keyRefunds{pp}{stkeys}{tx} =\\
-      & ~~~~~ \sum\limits_{\substack{c \in \fun{dcerts}~tx \\ c\in\DCertDeRegKey}}
-              \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{(\txttl{tx})}{c}\\
-      &
-      \begin{array}{lr@{~=~}l}
-        \where \\
-        & \dval & \fun{keyDeposit}~\var{pp}\\
-        & d_{\min} & \fun{keyMinRefund}~\var{pp}\\
-        & \lambda & \fun{keyDecayRate}~\var{pp}\\
-      \end{array}\\
-  \end{align*}
-  \caption{Functions used in Deposits - Refunds}
-  \label{fig:functions:deposits-refunds}
-\end{figure}
-
-
-We define the functions used in calculating deposits in
-Figure~\ref{fig:functions:deposits-refunds}.
-The $\fun{lastEpoch}$ function
-returns the number of the last slot in the previous epoch.
-
-In order to give the full expression of the general accounting property,
-we need the value of the total amount of decay for all the resource releasing
-certificates of a transaction whose authors key is registered. For each
-certificate in this calculation, the value is computed by the map $\fun{decayed}$.
-Given a set of protocol parameters, resource allocations, and a slot
-number, this map outputs the difference between the decayed refund calculated from
-the last slot of the previous epoch of the given slot number
-(or the certificate creation slot, if it is created in the same epoch as the
-given slot number) and the
-full-duration decayed refund value ($\fun{currentRefund}$) calculated based on
-the given slot number.
-
-The amount decayed for individual keys is then computed by adding the values of
-$$\fun{decayed}~\var{stkeys}~\var{pc}~(\fun{txttl}~\var{tx})~\var{c}$$
-for each deregistration certificate in a given transaction, and is given by
-$$\fun{decatedTx}~\var{pc}~\var{stkeys}~\var{cslot}~\var{c}$$
-Here, again, we use the $\fun{txttl}~\var{tx}$ value in the calculation instead of the current
-slot number in order to match with the one in the $\fun{keyRefunds}$
-calculation.
-
-Note that the decayed amount here is only the amount that decayed \textit{within
-the epoch until which the signal transaction is live}, i.e. since the end of the
-last epoch before $\fun{txttl}~\var{tx}$, or, if the key was
-registered in the same epoch as the $\fun{txttl}~\var{tx}$ slot,
-since the registration certificate slot number.
-
-Recall that the stake pool retirement refunds are issued not when a certificate
-scheduling the retirement is processed, but at the epoch boundary for which
-the retirement is scheduled. The decayed value over the full previous epoch is
-also accounted for at the boundary change. For details of this accounting, see
-Section~\cref{sec:epoch}.
-
-
-\begin{figure}
-  \begin{align*}
-      & \fun{decayedKey} \in
-      \PParams \to \StakeKeys \to \Slot \to \DCertDeRegKey \to \Coin
-      & \text{decayed since epoch} \\
-      & \decayedKey{pp}{stkeys}{cslot}{c} =\\
-      & \begin{cases}
-            0 & \text{if}~\cauthor c \notin \dom stkeys\\
-            \var{epochRefund} - \var{currentRefund}
-            & \text{otherwise}
-        \end{cases}\\
-      &
-      \begin{array}{lr@{~=~}l}
-        \where
-          & \var{created} & \var{stkeys}~(\cauthor~\var{c}) \\
-          & \var{start} & \mathsf{max}~(\fun{slot}~\epoch{cslot})~created \\
-          & \var{epochRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{start}{c} \\
-          & \var{currentRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{cslot}{c} \\
-          & \dval & \fun{keyDeposit}~\var{pp}\\
-          & d_{\min} & \fun{keyMinRefund}~\var{pp}\\
-          & \lambda & \fun{keyDecayRate}~\var{pp}\\
-      \end{array}\\
-      \nextdef
-      & \fun{decayedTx} \in \PParams \to \StakeKeys \to \Tx \to \Coin
-      & \text{decayed deposit portions} \\
-      & \decayedTx{pp}{stkeys}{tx} =\\
-      &   \sum\limits_{\substack{c \in \fun{dcerts}~tx \\ c \in\DCertDeRegKey}}
-          \decayedKey{pp}{stkeys}{(\txttl{tx})}{c}\\
-  \end{align*}
-  \caption{Functions used in Deposits - Decay}
-  \label{fig:functions:deposits-decay}
-\end{figure}
-
-\clearpage
-
-\subsection{UTxO Transitions}
-\label{sec:state-trans-utxo-1}
-
-The types involved in defining a UTxO and its transitions are presented in
-Figure~\ref{fig:defs:utxo}. Note that here, among other primitive types,
-we introduce $\Addr_{base}$. This is the usual type of address used for
-coin transfers by the transactions. We also introduce the derived type $\Addr$,
-which is a disjoint union of base-type and reward addresses. Using this type,
-it is possible to do rewards accounting (which we discuss later in this chapter)
-in the same $\UTxO$ style as the base address coin transfers, as well as
-the usual base address lookups and calculations.
-Similar to the certificate structure, each address is either a reward or a base
-address.
-
-The $\TxIn$ derived type represents the inputs of a transaction, i.e. a list of
-previous transactions identified by $\var{txid}$, paired with an index
-$\var{ix}$ to
-uniquely identify the input (as there may be several inputs from the same
-transaction). The $\TxOut$ type is a pair of an address and a coin value,
-which is a record of what address the given coin amount is intended for.
-
-The $\UTxO$ type is the main record type stored on the ledger to keep track of
-unspent transaction outputs. It does so by using a finite map which pairs
-a transaction ID with \textit{its own outputs} (by using the $\var{ix}$ indices),
-thus indicating that these
-can now be spent by another transaction.
-
-The type $\Wdrl$ is a finite map that maps a reward address to a coin value to
-be withdrawn from the rewards awarded to that address. We have made the decision
-to structure the withdrawals in this way to adhere as closely as possible
-to the structure presented in~\cite{chimeric}.
-
-The map $\fun{txid}$ is a one-way function which computes the $\var{txid}$
-of a given transaction. A transaction can be uniquely identified
-by its $\var{txid}$ in a given context.
-
-The $\fun{txbody}$ map gives the body of the transaction, i.e. the data that is
-used to update the UTxO on the ledger. The way this data is stored is in
-a pair of a set of terms of type $\TxIn$ representing the inputs of the
-transaction, and a finite map $\Ix \mapsto \TxOut$ representing the outputs.
-Each term in the input list
-corresponds to those $\TxOut$ terms in the outputs list indexed by the same
-$\Ix$ as in the second coordinate of the input. This way, a transaction can have
-inputs from multiple prior transactions and outputs to multiple addresses
-from each of the input transactions.
-
-The transaction fee $\fun{txfee}$ is the
-fee a transaction contributes to the system (this value depends only on
-the transaction itself). The fee does not need to have an explicit output
-specified, and are currently implicitly included in the total input value of
-a transaction.
-
-Note that transaction fees, which can be greater than the minimum fee, are
-indicated in the transactions themselves. This is different from
-the deposit amounts for registration certificates, which are
-indicated explicitly in the protocol parameters,
-and must be paid as an amount exactly matching the protocol's requirement.
-For this reason, a refund calculation for given certificate does not need to look up the deposit
-amount in the data of the transaction
-that paid the original registration deposit (such data is not even stored),
-but instead looks in the protocol
-parameters for this information.
-
-The $\fun{minfee}$ is the minimum
-fee that must be paid by a transaction to be applied to the current UTxO.
-This minimum fee
-is calculated based on the context of the transaction (i.e. a collection of
-values the blockchain protocol keeps track of, $\PParams$), as well as
-the contents of the transaction itself.
-
-The $\fun{txwdrls}$ function returns a list of reward addresses provided by a
-given transaction, each paired with the coin value the transaction is requesting
-be reaped, i.e. removed from the total coin accumulated in the rewards
-account for this address and added to the UTxO.
-
-
-\begin{figure*}
+\begin{figure*}[htb]
   \emph{Abstract types}
   %
   \begin{equation*}
@@ -954,76 +673,84 @@ account for this address and added to the UTxO.
   \label{fig:defs:utxo}
 \end{figure*}
 
+\clearpage
 
-A set of functions on UTxOs and transactions appearing in this document,
-along with their types are defined in Figure~\ref{fig:derived-defs:utxo}.
-The map $\fun{txins}$ returns the list of inputs of a given transactions, i.e.
-the pairs type $\TxIn$ within that transaction.
+\section{Ledger State Transitions}
+\label{sec:ledger}
 
-The map $\fun{outs}~ \var{tx}$ builds a UTxO using the
-list of outputs of $\var{tx}$. It builds a pair for the resulting UTxO
-finite map by making a $txin$ out of the $txid$ of $tx$ and an index in the output $ix \mapsto (a,c)$, to give a $txin = (txid, ix)$ and the
-$txout=(a,c)$.
+A key constraint that must always be satisfied as a result and precondition of
+a valid ledger state transition is called the \textit{general accounting
+property}, or the \textit{preservation of value} condition. Every piece of
+software that is a part of the implementation of the
+Cardano cryptocurrency must function in such a way as to not result in
+a violation of this rule.
+If this condition is not satisfied, it is an indicator of
+incorrect accounting, potentially due to
+malicious disruption or a bug.
 
-The $\fun{balance}$ map, as expected, gives the sum total of all the coin in
-a given UTxO. The calculation $\fun{consumed}$ gives the value consumed
-by the transaction $\var{tx}$ in the context of the relevant protocol
-parameters, the current UTxO on the ledger, and the resource allocation for
-$\DState$, i.e. $\var{stkeys}$. This calculation is a sum of all coin in the inputs of
-$\var{tx}$  and the individual key
-deregistration refunds of the $\var{tx}$ in this context.
+The preservation of value is expressed as an equality that uses values in
+the ledger state and the environment, as well as the values in the body of
+the signal transaction.
+We have defined the rules of the delegation protocol in a way that should
+consistently satisfy the preservation of value. In the future, we hope to
+give a formally-verified proof that every \textit{valid} ledger state satisfies
+this property.
 
-Next, we define the function $\fun{reapRewards}$. The purpose of this map is
-to update all the rewards accounts associated with the addresses for which
-reward withdrawals are requested. Since we do only allow withdrawal of reward
-amount which is exactly equal to the value in the reward account (we
-give details about this below), this update explicitly sets the values
-associated to the requested addresses to zero.
+In this section, we discuss the relevant accounting that needs to be done
+as a result of processing a transaction, i.e. the deposits for all certificates,
+transaction fees, transaction withdrawals, and refunds for individual
+deregistration, so that we may keep track of whether the preservation of
+value is satisfied. Stake pool retirement refunds are not triggered by a
+transaction (but rather, happen at the epoch boundary), and are therefore
+not considered in our state change rules invoked due to a signal transaction.
 
-The $\fun{consumed}$ calculation sums up all the unspent outputs that
-have been removed from the ledger. This includes the outputs spent directly
-(made available to the owner of another address), and also, implicitly,
-the outputs which are spent on transaction fees. In order to balance
-the preservation of value equation, we must also add the following values
-to this (the LHS, i.e. $\fun{consumed}$) side of the equation as they are
-accounted for implicitly (as
-part of appending to the UTxO the entries of $\fun{outs}~{tx}$), on the
-other side (RHS):
+Note, that when a transaction is issued by a wallet to be applied to the ledger
+state (i.e. processed),
+we define the rules in this section in such a way that it is impossible to
+apply only some parts of a transaction (e.g. only certain certificates).
+Every part of the transaction must be valid and it must be live, otherwise
+it is ignored entirely. It is the wallet's responsibility to inform the user
+that a transaction failed to be processed.
 
-\begin{itemize}
-\item The total value of all individual key refunds the transaction is taking from
-the (common) $\var{deposit}$ pool
-\item The total value of all the rewards the transaction is withdrawing from
-the individual $\var{rewards}$ accounts
-\end{itemize}
+\subsection{UTxO Transitions}
+\label{sec:utxo-trans}
 
-The total rewards value above is calculated by subtracting the sum total value in the
-updated (after payout) rewards addresses from sum total of the current (pre-rewards
-payout state) of the $\var{rewards}$ map.
-
-The $\fun{consumed}$ calculation, on the other hand, sums up the total
-value of all unspent outputs added to the UTxO on the ledger. As stated
-above, this value implicitly includes all the unspent outputs generated
-by this transaction for the withdrawing the refunds and the rewards
-(from the corresponding ledger accounts). In addition, this (RHS) of the
-equation must account for the value implicitly removed from the UTxO. That is why
-two more values are added to this side of the equation:
+Figure~\ref{fig:functions:utxo} defines functions needed for the UTxO transition system.
 
 \begin{itemize}
-\item the fee the transaction pays (in unspent outputs)
-\item all registration
-deposits the transaction pays (also in unspent outputs)
+
+  \item
+    The function $\fun{outs}$ creates unspent outputs generated by a transaction, so that
+    they can be added to the ledger state.  For each output in the transaction,
+    $\fun{outs}$ maps the transaction id and output index to the output.
+
+  \item
+    The $\fun{balance}$ function calculates sum total of all the coin in a given UTxO.
+
+  \item The calculation $\fun{consumed}$ gives the value consumed by the transaction $\var{tx}$
+    in the context of the protocol parameters, the current UTxO on the ledger, and the registered
+    stake keys.  This calculation is a sum of all coin in the inputs of $\var{tx}$,
+    reward withdrawals, and stake key deposit refunds. The method $\fun{keyRefunds}$ used
+    to calculate the refunds will be defined in Section~\ref{sec:deps-refunds}.
+
+  \item The calculation $\fun{produced}$ gives the value produced by the transaction $\var{tx}$
+    in the context of the protocol parameters and the registered stake pools.
+    This calculation is a sum of all coin in the outputs of $\var{tx}$,
+    the transaction fee, and all needed deposits. The method $\fun{deposits}$ used
+    to calculate the deposits will be defined in Section~\ref{sec:deps-refunds}.
 \end{itemize}
 
-We remind the reader here that even though the $\fun{consumed}$ calculation
-takes $\var{stpools}$ as a parameter, this is only in order to determine,
-within the $\fun{deposits}$ calculation, which
-pool registration certificates are new registrations, and which ones are updates
-(and do not require a deposit payment). The $\fun{deposits}$ calculation is
-a sum of \textit{all} deposits a transaction is making, and the value of these
-deposits is found in the protocol parameters, not in $\var{stkeys}$ or $\var{stpools}$.
+The preservation of value property holds for a transaction, for a given ledger state,
+exactly when the results of $\fun{consumed}$ equal the results of $\fun{produced}$.
+Moreover, when the property holds, value is only moved between transaction outputs,
+the reward accounts, the fee pot, and the deposit pot.
 
-\begin{figure}
+Note that the $\fun{consumed}$ function takes the registered stake pools ($\var{stpools}$)
+as a parameter only in order to determine which pool registration certificates are
+new (and thus require a deposit) and which ones are updates.
+Registration will be discussed more in Section~\ref{sec:delegation}.
+
+\begin{figure}[htb]
   \begin{align*}
     & \fun{outs} \in \Tx \to \UTxO
     & \text{tx outputs as UTxO} \\
@@ -1037,10 +764,6 @@ deposits is found in the protocol parameters, not in $\var{stkeys}$ or $\var{stp
     & \fun{balance} \in \UTxO \to \Coin
     & \text{UTxO balance} \\
     & \fun{balance} ~ utxo = \sum_{(~\wcard ~ \mapsto (\wcard, ~c)) \in \var{utxo}} c
-    \nextdef
-    & \fun{reapRewards} \in \Wdrl \to \Wdrl \to \Wdrl \\
-        & \fun{reapRewards}~\var{rewards}~\var{wdrls} =
-         \var{rewards} \unionoverrideRight \{(w, 0) \mid w \in \dom \var{wdrls}\} \\
     \nextdef
     & \fun{consumed} \in \PParams \to \UTxO \to \StakeKeys \to \Wdrl \to \Tx \to \Coin
     & \text{value consumed} \\
@@ -1057,27 +780,32 @@ deposits is found in the protocol parameters, not in $\var{stkeys}$ or $\var{stp
   \end{align*}
 
   \caption{Functions used in UTxO rules}
-  \label{fig:derived-defs:utxo}
+  \label{fig:functions:utxo}
 \end{figure}
 
+\clearpage
+The types for the UTxO transition are given in Figure~\ref{fig:ts-types:utxo}.
+The environment, $\UTxOEnv$, consists of:
 
-The type of the transition of a UTxO is presented in Figure
-~\ref{fig:ts-types:utxo}. A
-transition can be valid in the context of a given environment, $\UTxOEnv$.
-This environment is made up of several variables.
-The $\PParams$ is needed as part of the environment here in order to
-keep track of parameters such as the $\fun{minfee}$ value, deposits, etc.
-The environment also has variables $\var{stkeys}$ and $\var{stpools}$
-to keep track of the current individual and pool resource allocations,
-and the current slot number.
+\begin{itemize}
+  \item The current slot.
+  \item The protocol parameters.
+  \item The registered stake keys (which will be explained in Section~\ref{sec:delegation}).
+  \item The registered stake pools (which will be explained in Section~\ref{sec:delegation}).
+\end{itemize}
+The current slot and the registrations are need for the refund calculations
+described in Section~\ref{sec:deps-refunds}.
 
-The relevant state variables for a UTxO transition include the UTxO itself,
-as well as the value in the deposits pool and the fees pool.
-The type of UTxO update is a $\UTxOState$ transition signaled by
-a transaction $\var{tx}$ in the environment $\UTxOEnv$.
+The state needed for the UTxO transition, $\UTxOState$, consists of:
 
+\begin{itemize}
+  \item The current UTxO.
+  \item The deposit pot.
+  \item The fee pot.
+\end{itemize}
+The signal for the UTxO transition is a transaction.
 
-\begin{figure}
+\begin{figure}[htb]
   \emph{UTxO environment}
   \begin{equation*}
     \UTxOEnv =
@@ -1114,55 +842,55 @@ a transaction $\var{tx}$ in the environment $\UTxOEnv$.
   \label{fig:ts-types:utxo}
 \end{figure}
 
-\clearpage
-
-\subsection{UTxO, Fees, and Deposits Ledger Update}
-\label{sec:utxo-ufd}
-
-The inference rule for the UTxO, fees, and deposits update is presented in
-Figure~\ref{fig:rules:utxo}.
+The UTxO transition system is given in Figure~\ref{fig:rules:utxo}.
 Rule~\ref{eq:utxo-inductive} specifies the conditions under which a transaction can
 be applied to a particular $\UTxOState$ in environment $\UTxOEnv$:
 
-\begin{itemize}
-\item The transaction is live (its time to live is less than the current slot)
-\item The transaction has at least one input
-\item The fee paid by the transaction has to be greater than or equal to the
-minimum fee.
-\item Each input spent in the transaction must be in the set of unspent
-  outputs
-\item The amount of coin produced by the transaction must be the same as
-the amount consumed (i.e. the \textit{preservation of value} must hold)
-\end{itemize}
-
-Note that the fee paid by a transaction is required to be greater than or
-equal to the minim fee. The reason for allowing it to be greater is to have
-the option for the implementation to make processing decisions based on the
-size of the fee. Such as, a larger fee would result in faster processing of
-a transaction.
-
-The transaction is required to have at least one input to avoid a situation
-where the witnessing replay protection may fail. Specifically, when a transaction is
-spending only refunds from deregistration or retirement certificates it is
-carrying (or withdrawn rewards).
-
-Here we again emphasize the importance of the \textit{preservation of value}
-condition. No valid UTxO state can be reached without this condition
-being satisfied at every step of the transitions leading to a given UTxO state.
-Since the total amout of Ada at genesis is known, this property can be
-checked for arbitrarily generated valid ledgers.
-
-According to this complete ledger state transition rule, when a UTxO state update
-is triggered by a
-transaction (signal) $\var{tx}$, and the above conditions are met, the UTxO
-changes as follows:
+The transition contains the following predicates:
 
 \begin{itemize}
-\item remove from the UTxO all the $(\var{txin}, \var{txout})$ pairs
-associated with the $\var{txins}$'s in the $\var{inputs}$ list of $\var{tx}$.
-\item add all the $\var{outputs}$ of $\var{tx}$ to the
-UTxO, associated with the $\fun{txid}~\var{tx}$
+  \item
+    The transaction is live (its time to live is less than the current slot).
+  \item
+    The transaction has at least one input.
+    The global uniqueness of transaction inputs prevents replay attacks.
+    By requiring that all transactions spend at least one input,
+    the entire transaction is safe from such attacks.
+    A delegation certificate by itself, for example, does not have this property.
+  \item
+    The fee paid by the transaction has to be greater than or equal to the minimum fee,
+    which is based on the size of the transaction.
+    A user or wallet might choose to create a fee larger than necessary
+    in exchange for a faster processing time.
+  \item
+    Each input spent in the transaction must be in the set of unspent
+    outputs.
+  \item
+    The \textit{preservation of value} property must hold.
+    In other words, the amount of value produced by the transaction must be the same as
+    the amount consumed.
 \end{itemize}
+If all the predicates are satisfied, the state is updated as follows:
+
+\begin{itemize}
+  \item Update the UTxO:
+    \begin{itemize}
+      \item Remove from the UTxO all the $(\var{txin}, \var{txout})$ pairs
+        associated with the $\var{txins}$'s in the $\var{inputs}$ list of $\var{tx}$.
+      \item Add all the $\var{outputs}$ of $\var{tx}$ to the
+        UTxO, associated with the $\fun{txid}~\var{tx}$
+    \end{itemize}
+  \item Add all new deposits to the deposit pot and subtract all refunds.
+  \item Add the transaction fee to the fee pot. Additionally, for any refund
+    returned by this transaction, add the amount of the original deposit
+    which has decayed to the fee pot.
+    The amount decayed will depend on the time to live of the transaction
+    and will be explained further in Section~\ref{sec:deps-refunds}.
+\end{itemize}
+
+The accounting for the reward withdrawals is not done in this transition system.
+The rewards are tracked with the delegation state and will
+be removed in the final delegation transition, see ~\ref{eq:delegs-base}.
 
 Note here that output entries for both the deposit refunds and the rewards
 withdrawals must be included in the body of the transaction
@@ -1199,23 +927,10 @@ come from a $\var{deposits}$ pool, which is a single coin value indicating
 the total decayed amount of all the deposits ever made, while rewards come from individual
 accounts where a reward is accumulated to a specific address.
 
-The $\var{deposits}$ is updated by:
-
-\begin{itemize}
-\item add all the deposits for individual and key registration certificates
-carried by the signal transaction to the current $\var{deposits}$ value on the ledger
-\item subtract from the current $\var{deposits}$ value on the ledger
-the amount by which the deposits for the individual key allocations
-for which $\var{tx}$ carries the deregistration certificates have
-decayed \textit{this epoch}
-\item subtract any individual key refunds for deregistration certificates
-in $\var{tx}$ from the current $\var{deposits}$ value on the ledger
-\end{itemize}
-
 Note that the $\var{refunded}$ and $\var{decayed}$ values added together give what the
 full, non-decayed refund for all the key deregistration certificates in $\var{tx}$
 would be, and this total value is always removed from the $\var{deposits}$
-amount on the leger. The $\var{refunded}$ amount is returned to the certificate
+amount on the ledger. The $\var{refunded}$ amount is returned to the certificate
 author, and the $\var{decayed}$ amount is transferred over to $\var{fees}$
 (this allows the ledger to adhere to the preservation of value).
 
@@ -1225,16 +940,7 @@ boundary, the total decayed value for the whole epoch for both the individual
 and pool deposits is transferred into the fees (independent of refund
 requests).
 
-Now, the fees are updated by:
-
-\begin{itemize}
-\item add the transaction fee paid by the signal transaction to the ledger $\var{fees}$
-variable
-\item add the decayed value of key refunds in certificates in $\var{tx}$ to $\var{fees}$
-\end{itemize}
-
-
-\begin{figure}
+\begin{figure}[htb]
   \begin{equation}\label{eq:utxo-inductive}
     \inference[UTxO-inductive]
     { \txttl tx \geq \var{slot}
@@ -1285,97 +991,214 @@ variable
   \label{fig:rules:utxo}
 \end{figure}
 
+\clearpage
+
+\subsection{Deposits and Refunds}
+\label{sec:deps-refunds}
+
+Deposits are described in appendix B.2 of the delegation design document \cite{delegation_design}.
+These deposit functions were used above in the UTxO transition, \ref{sec:utxo-trans}.
+Deposits are used for stake key registration certificate and pool
+registration certificates, which will be explained in Section~\ref{sec:delegation}.
+In particular, the function $\cwitness{}$, which gets the certificate witness
+from a certificate, will be defined later.
+Figure~\ref{fig:functions:deposits-refunds} defines the deposit and refund functions.
+\begin{itemize}
+  \item The function $\fun{deposits}$ returns the total deposits that have to be made
+    by a transaction.  This calculation is based on the protocol parameters.
+    Specifically, for a given transaction, it sums up the values of the stake key deposits
+    and the stake pool deposits.  Those certificates which are
+    updates of stake pool parameters of already registered pool keys should not
+    (and are, in fact, not allowed to) make a deposit.
+  \item The function $\fun{refund}$ calculates the deposit refund with an exponential decay.
+  \item The function $\fun{keyRefund}$, calculates the refund for an individual
+    stake key registration deposit, based on the slot when it was created and
+    the slot passed to the function. The creation slot should always exist in the map
+    $\var{stkeys}$ passed to the function, and this would be a good property
+    to prove about the transition system.
+  \item The function $\fun{keyRefunds}$, in turn, uses $\fun{keyRefund}$ to calculate
+    the total value to be refunded to all individual key deregistration certificate authors
+    in a transaction.
+
+    It is important to note here that instead of the \textit{current} slot number,
+    the time to live of $\var{tx}$ is passed to the $\fun{certRefunds}$ function
+    within the summation in $\fun{keyRefunds}$. The reason for this is that the
+    refunds for any key deregistration certificates are, in fact, included in
+    the $\var{tx}$ itself --- meaning that the coin value of the refund must be
+    explicitly specified in the outputs of the transaction. So,
+    the value of the included refund must be calculated before this transaction
+    is ever processed, and be the same \textit{no matter when} the $\var{tx}$
+    \textit{is actually processed} in order to allow the system to continue to
+    satisfy the general accounting property.
+
+    It is impossible to predict the exact slot number in which $\var{tx}$ will be processed,
+    but it will be some time before slot number $\fun{txttl}~\var{tx}$. So, this is the slot
+    number value used in both the calculation to generate the refund coin value in the outputs
+    of $\var{tx}$ and in the general accounting property equation.
+
+    Note also that
+    $\fun{keyRefunds}$ calculates the total individual refunds for a transaction
+    based on \textit{current} protocol parameters. This means that any deposits
+    made prior to a change will be different from their corresponding
+    (decayed) refunds in the case of key deregistration after a change in
+    protocol parameters. Constants may only change at the epoch boundary, and
+    ensuring there are always sufficient funds for all
+    refunds in the $\var{deposits}$ pool is part of the protocol constant
+    change transition, described in Section~\ref{sec:epoch}.
+
+    The protocol parameters are not
+    expected to change often, and using the current ones for the calculation
+    is a deliberate simplification choice, which does not introduce any inconsistencies
+    into the system rules or properties. In particular, the general accounting
+    property is not violated.
+\end{itemize}
+Figure~\ref{fig:functions:deposits-decay} defines the decays functions.
+\begin{itemize}
+
+  \item The function $\fun{decayedKey}$ calculates how much of a stake key deposit
+    has decayed since the last epoch. Again, this is done using the time to live of
+    the transaction (and not the current slot, as explained above).
+    At the epoch boundaries, decayed portions of deposits are moved to the reward pot,
+    so between epochs we need only account for what has decayed since the last epoch.
+    The value is calculated by subtracting the refund calculation based at the epoch boundary
+    from the refund calculation based at the time to live of the transaction.
+  \item The function $\fun{decayedTx}$ calculates the total decayed deposits associated
+    with all the refunds in a given transaction.
+
+\end{itemize}
+
+Recall that the stake pool retirement refunds are issued not when a certificate
+scheduling the retirement is processed, but at the epoch boundary for which
+the retirement is scheduled. The decayed value over the full previous epoch is
+also accounted for at the boundary change. For details of this accounting, see
+Section~\cref{sec:epoch}.
+
+\begin{figure}[htb]
+  \begin{align*}
+    & \fun{deposits} \in \PParams \to \StakePools \to \seqof{\DCert} \to \Coin
+    & \text{total deposits for transaction} \\
+    & \fun{deposits}~{pp}~{stpools}~{certs} = \\
+    &  \sum\limits_{\substack{c\in\var{certs} \\ c\in\DCertRegKey}}(\fun{keyDeposit}~pp)
+    +  \sum\limits_{\substack{c\in\var{certs} \\ c\in\DCertRegPool \\ (\cwitness{c})\notin \var{stpools}}}
+            (\fun{poolDeposit}~pp)
+      \nextdef
+      & \fun{refund} \in \Coin \to \unitInterval \to \posReals \to \Duration \to \Coin
+      & \text{refund calculation} \\
+      & \refund{\dval}{d_{\min}}{\lambda}{\delta} =
+            \floor*{
+              \dval \cdot
+            \left(d_{\min}+(1-d_{\min})\cdot e^{-\lambda\cdot\delta}\right)}
+      \nextdef
+      & \fun{keyRefund} \in \Coin \to \unitInterval \to \posReals \to \\
+      & ~~~~~\StakeKeys \to \Slot \to \DCertDeRegKey \to \Coin
+      & \text{key refund for a certificate} \\
+      & \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{slot}{c} =\\
+      & ~~~~~\begin{cases}
+            0 & \text{if}~\cwitness c \notin \dom stkeys\\
+            \refund{\dval}{d_{\min}}{\lambda}{\delta}
+            & \text{otherwise}
+        \end{cases}\\
+      &
+      \begin{array}{lr@{~=~}l}
+        \where
+        &\delta & \slotminus{slot}{(stkeys~(\cwitness c))}\\
+      \end{array}\\
+      \nextdef
+      & \fun{keyRefunds} \in \PParams \to \StakeKeys \to \Tx \to \Coin
+      & \text{key refunds for a transaction} \\
+      & \keyRefunds{pp}{stkeys}{tx} =\\
+      & ~~~~~ \sum\limits_{\substack{c \in \fun{dcerts}~tx \\ c\in\DCertDeRegKey}}
+              \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{(\txttl{tx})}{c}\\
+      &
+      \begin{array}{lr@{~=~}l}
+        \where \\
+        & \dval & \fun{keyDeposit}~\var{pp}\\
+        & d_{\min} & \fun{keyMinRefund}~\var{pp}\\
+        & \lambda & \fun{keyDecayRate}~\var{pp}\\
+      \end{array}\\
+  \end{align*}
+  \caption{Functions used in Deposits - Refunds}
+  \label{fig:functions:deposits-refunds}
+\end{figure}
+
+\begin{figure}[htb]
+  \begin{align*}
+      & \fun{decayedKey} \in
+      \PParams \to \StakeKeys \to \Slot \to \DCertDeRegKey \to \Coin
+      & \text{decayed since epoch} \\
+      & \decayedKey{pp}{stkeys}{cslot}{c} =\\
+      & \begin{cases}
+            0 & \text{if}~\cwitness c \notin \dom stkeys\\
+            \var{epochRefund} - \var{currentRefund}
+            & \text{otherwise}
+        \end{cases}\\
+      &
+      \begin{array}{lr@{~=~}l}
+        \where
+          & \var{created} & \var{stkeys}~(\cwitness~\var{c}) \\
+          & \var{start} & \mathsf{max}~(\fun{firstSlot}~\epoch{cslot})~created \\
+          & \var{epochRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{start}{c} \\
+          & \var{currentRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{cslot}{c} \\
+          & \dval & \fun{keyDeposit}~\var{pp}\\
+          & d_{\min} & \fun{keyMinRefund}~\var{pp}\\
+          & \lambda & \fun{keyDecayRate}~\var{pp}\\
+      \end{array}\\
+      \nextdef
+      & \fun{decayedTx} \in \PParams \to \StakeKeys \to \Tx \to \Coin
+      & \text{decayed deposit portions} \\
+      & \decayedTx{pp}{stkeys}{tx} =\\
+      &   \sum\limits_{\substack{c \in \fun{dcerts}~tx \\ c \in\DCertDeRegKey}}
+          \decayedKey{pp}{stkeys}{(\txttl{tx})}{c}\\
+  \end{align*}
+  \caption{Functions used in Deposits - Decay}
+  \label{fig:functions:deposits-decay}
+\end{figure}
 
 \clearpage
 
 \subsection{Witnesses}
 \label{sec:witnesses}
 
-A transaction is witnessed by
-a signature and a verification key corresponding to this signature, which can
-be obtained from the transaction by applying the $\fun{txwits}$ function.
-The witnesses for each certificate in a transaction are obtained by applying $\fun{dwits}$
-to the certificate.
+The purpose of witnessing is make sure that the intended action is authorized by
+the holder of the signing key, providing replay protection as a consequence.
+Replay prevention is an inherent property of UTxO type accounting
+since transaction IDs are unique, and we require all transaction to
+consume at least one input.
 
-In Figure~\ref{fig:derived-defs:utxow}, we give the definitions of two maps
-associated with input and reward addresses and their keys.
-The first, $\fun{addr}$, gives the finite map
-which associates to a given $\var{txin}$ in the UTxO the address of the
-corresponding $\var{txout}$.
+A transaction is witnessed by a signature and a verification key corresponding to this signature.
+The witnesses, together with the transaction body, form a full transaction.
+Every witness in a transaction signs the transaction body.
+Moreover, the witnesses are represented as finite maps from verification keys to signatures,
+so that any key that is required to sign a transaction only provides a single witness.
+This means that, for example, transaction which includes a delegation certificate and
+a reward withdrawal corresponding to the same stake key still only includes one signature.
 
-The map $\fun{addr_h}$, given a UTxO, returns the
-finite map which associates $\var{txin}$ with the hash of a spending key in
-the address in the corresponding $\var{txout}$ in the UTxO. The way this is
-done is by performing a lookup of the address owner using the
-$\fun{paymentHK}$ function,
-which retrieves the hash of the key of
-the owner from the data stored at the given address.
+Figure~\ref{fig:functions-witnesses} defines the function which
+gathers all the (hashes of) verification keys needed to witness a given transaction.
+This consists of:
+\begin{itemize}
+  \item payment keys for outputs being spent
+  \item stake keys for reward withdrawals
+  \item stake keys for delegation certificates
+  \item stake keys for the pool owners in a pool registration certificate
+\end{itemize}
 
-\begin{figure}
+\begin{figure}[htb]
   \begin{align*}
     & \fun{witsNeeded} \in \UTxO \to \Tx \to \powerset{\HashKey}
     & \text{hashkeys for needed witnesses} \\
     & \fun{witsNeeded}~{utxo}~{tx} = \\
     & ~~\{ \fun{paymentHK}~a \mid i \mapsto (a, \wcard) \in \var{utxo},~i\in\txins{tx} \}~\cup \\
     & ~~\{\fun{stakeHK_r}~a \mid a\mapsto \wcard \in \txwdrls{tx}\}~\cup \\
-    & ~~\{\cauthor{c} \mid c \in \txcerts{tx}\}~\cup \\
-    & ~~\bigcup_{\substack{c \in \txcerts{tx} \\ ~c \in\DCertRegPool}} \fun{poolowners}~{c} \\
+    & ~~\{\cwitness{c} \mid c \in \txcerts{tx}\}~\cup \\
+    & ~~\bigcup_{\substack{c \in \txcerts{tx} \\ ~c \in\DCertRegPool}} \fun{poolOwners}~{c} \\
   \end{align*}
   \caption{Functions used in witness rule}
-  \label{fig:derived-defs:utxow}
+  \label{fig:functions-witnesses}
 \end{figure}
 
-
-Note that the UTxO transitions with and without witnesses have the same type
-(see Figure~\ref{fig:ts-types:utxo} and Figure~\ref{fig:ts-types:utxow}).
-The witnessed transition rule, in fact, defines the same UTxO update as the
-non-witnessed rule. Essentially, the witnessed rule says we may only apply the non-witnessed rule whenever the following
-additional preconditions are satisfied
-(stated in Rule~\ref{eq:utxo-witness-inductive} in
-Figure~\ref{fig:rules:utxow}):
-
-\begin{itemize}
- \item For each input $\var{i}$ of the signal transaction $\var{tx}$,
- there exists a (unique) verifiable witness (there could be more than one valid
- key-signature pair serving as a witness) such that the hash of the spending key
- of the address corresponding to the output of $\var{i}$ in the current UTxO
- is the same as the hash of the verification key of the witness.
-
- \item For each certificate in $\var{tx}$, the signature of the transaction
- and certificate must be witnessed by the
-   verification key with which the certificate is associated
-
- \item For every withdrawal request address of $\var{tx}$,
- there exists a (unique) verifiable witness such that the hash of the spending key of the
- withdrawal address is the same as the hash of the verification key of the witness.
-\end{itemize}
-
-The purpose of witnessing is make sure that the intended action is authorized by
-the holder of the signing key, providing replay protection as a consequence.
-Replay prevention is an inherent property of UTxO type accounting
-since transaction IDs are unique.
-Delegation certificates and reward withdrawals do not share this property,
-though if we require all witnesses to sign at least one transaction input,
-the replay prevention of UTxO accounting is then provided to any transaction.
-This is achieved by the above precondition by requiring a valid signature
-from the author of every certificate in a transaction, the
-holder of the key for every reward account emptied, as well as
-hash keys of each of the inputs addresses.
-
-Furthermore, expressing
-accounting as a preservation of total value of Ada allows the withdrawals
-and refunds to be sent to any address the transaction indicates
-(such as a different wallet operated by the same or another owner).
-Because of witnessing, we know that all the value withdrawn from ledger
-pools ($\var{rewards}$ and $\var{deposits}$) is going to the address intended
-(i.e signed) by the deregistration certificate author
-(or the key holder for the addresses from which the withdrawal is made,
-respectively).
-
-Here, we also enforce the condition that only one witness per each input,
-as well as one
-witness per withdrawal address is allowed. We do so to prevent transactions
-being unnecessarily large and full of redundant witnessing.
+The UTxOW transition system adds witnessing to the previous UTxO transition system.
+Figure~\ref{fig:ts-types:utxow} defines the type for this transition.
 
 \begin{figure}
   \emph{UTxO with witness transitions}
@@ -1388,6 +1211,14 @@ being unnecessarily large and full of redundant witnessing.
   \label{fig:ts-types:utxow}
 \end{figure}
 
+Figure~\ref{fig:rules:utxow} defines UTxOW transition.
+It has two predicates:
+\begin{itemize}
+  \item Every signature in the transaction is a valid signature of the transaction body.
+  \item The set of (hashes of) verification keys given by the transaction is exactly
+    the set of needed (hashes of) verification keys.
+\end{itemize}
+If the predicates are satisfied, the state is transitioned by the UTxO transition rule.
 
 \begin{figure}
   \begin{equation}
@@ -1418,22 +1249,32 @@ being unnecessarily large and full of redundant witnessing.
 
 \clearpage
 
+\section{Delegation}
+\label{sec:delegation}
+\input{delegation.tex}
+
+\clearpage
+
 \subsection{Ledger State Transition}
-\label{sec:ledger}
+\label{sec:ledger-trans}
 
-Having formalized the transitions of state variables above, we can
-now combine these into a single a ledger transition type (and inference rule).
-The environment for this rule is parametrized by the current slot number and
-protocol parameters.
+The entire state transformation of the ledger state caused by a valid transaction
+can now be given as the combination of the UTxO transition and the delegation transitions.
 
-The full ledger state consists of a $\UTxOState$ state variable (keeping track of
-the UTxO, deposits, fees, etc.), as well as
-a $\DPState$ state variable (which keeps track of registered keys and pools).
-This state type and the type of the transition rule is given in
-(see Figure~\ref{fig:ts-types:ledger}). The ledger state transition is signaled
-by a transaction.
+Figure~\ref{fig:ts-types:ledger} defines the types for this transition.
+The environment for this rule is consists of:
+\begin{itemize}
+  \item The current slot.
+  \item The transaction index within the current block.
+  \item The protocol parameters.
+\end{itemize}
+The ledger state consists of:
+\begin{itemize}
+  \item The UTxO state.
+  \item The delegation and pool states.
+\end{itemize}
 
-\begin{figure}
+\begin{figure}[htb]
   \emph{Ledger environment}
   \begin{equation*}
     \LEnv =
@@ -1467,25 +1308,9 @@ by a transaction.
   \label{fig:ts-types:ledger}
 \end{figure}
 
-
-The inference rule describing the complete ledger state transition is given in
-Figure~\ref{fig:rules:ledger}. The consequent of the rule is triggered by
-a transaction $\var{tx}$ such that both the (witnessed) ledger state transition
-and the complete delegation state transition in the antecedent are
-triggered by that same transaction.
-
-Note that the context for the consequent transaction is made up of only the
-protocol parameters and slot number, and so is the delegation state transition in
-the antecedent. However, the $\UTxOState$ transition also contains the
-stake keys and stake pools resource allocations in the context. This is not
-an issue since all this difference is highlighting is that in a $\UTxOState$
-transition, these variables are immutable (but they do change in the full
-ledger state and the $\DPState$ transitions).
-
-The full ledger state transition combines the UTxO transition and the
-delegation transition into a single transition
-in the consequent, presented as a transition of both state variables signaled
-by the given transaction.
+Figure~\ref{fig:ts-types:ledger} defines the ledger state transition.
+It has a single rule, which first calls the $\mathsf{UTXOW}$ transition,
+and then calls the $\mathsf{DELEGS}$ transition.
 
 \begin{figure}
   \begin{equation}

--- a/latex/properties.tex
+++ b/latex/properties.tex
@@ -8,7 +8,7 @@ property-based testing or formal verification.
 Many properties only make sense when applied to a valid ledger state. In
 informal terms, a valid ledger state $l$ can only be reached when starting from
 an initial state $l_{0}$ (genesis state) and only executing state transition
-rules as specified in Section~\ref{sec:state-trans-utxo-1} for UTxO or
+rules as specified in Section~\ref{sec:ledger} for UTxO or
 Section~\ref{sec:delegation} for delegation.
 
 \begin{figure}[ht]


### PR DESCRIPTION
In the many changes to the spec recently, the prose became further out of sync with the tables.  This PR is a large overhaul of the prose which mostly lines things back up again.

Additionally, there is a much heavier use bullet point lists, as per #193.  The lists should make comparing the prose with the tables much easier, since they correspond very closely now.

Over the past several previous PRs, helper functions have been separated and labeled as such. This is completed now, see #182 

The `POOLCLEAN` rule needed a bit of redoing, so I took the opportunity to rename it `POOLREAP` and have it remove delegations to retiring pools, as in #179.  The transition needed redoing since it was missing pool cert refunds, which are now added.  It was decided that these refunds will go to the reward accounts listed in the pool certificate, provided the account is still active. Otherwise it goes to the treasury.

![poolreap](https://user-images.githubusercontent.com/943479/51935795-be0be400-23d4-11e9-93f2-6f82a2136e2e.png)

I also took the opportunity to make the pool parameter record a derived type, such as was done recently for transactions.

![poolparam](https://user-images.githubusercontent.com/943479/51935812-c2380180-23d4-11e9-9c4a-bce49d96d773.png)

Lastly, as I was redoing the prose, I realized that it was weird that the new protocol parameter transition did not actually update the parameters. So now it does.  The "oldPP" was removed from the environment and added to the state as "pp".

![newpp](https://user-images.githubusercontent.com/943479/51935829-cbc16980-23d4-11e9-9982-4dba7e7eca97.png)