### PR TITLE
Redo epochs and slots

### DIFF
--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -220,10 +220,10 @@ and the protocol parameters.
     \PState =
     \left(\begin{array}{r@{~\in~}lr}
       \var{stpools} & \StakePools & \text{registered pools to creation time}\\
-      \var{poolParams} & \HashKey \mapsto \PoolParam
+      \var{poolParams} & \HashKey_{pool} \mapsto \PoolParam
         & \text{registered pools to pool parameters}\\
-      \var{retiring} & \HashKey \mapsto \Epoch & \text{retiring stake pools}\\
-      \var{avgs} & \HashKey \mapsto \Rnn & \text{performance moving average}\\
+      \var{retiring} & \HashKey_{pool} \mapsto \Epoch & \text{retiring stake pools}\\
+      \var{avgs} & \HashKey_{pool} \mapsto \Rnn & \text{performance moving average}\\
     \end{array}\right)
     \end{array}
   \end{equation*}
@@ -479,7 +479,7 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
     \inference[Pool-Reg]
     {
       \var{c}\in\DCertRegPool
-      & \cwitness{c} = \var{hk}
+      & \var{hk} = \cwitness{c}
       & hk \notin \dom \var{stpools}
     }
     {
@@ -514,7 +514,7 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
     \inference[Pool-reReg]
     {
       \var{c}\in\DCertRegPool
-      & \cwitness{c} = \var{hk}
+      & \var{hk} = \cwitness{c}
       & hk \in \dom \var{stpools}
     }
     {

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -3,6 +3,7 @@
 \newcommand{\RewardEnv}{\type{RewardEnv}}
 \newcommand{\RewardState}{\type{RewardState}}
 \newcommand{\PlReapState}{\type{PlReapState}}
+\newcommand{\PlReapEnv}{\type{PlReapEnv}}
 \newcommand{\NewPParamEnv}{\type{NewPParamEnv}}
 \newcommand{\Snapshots}{\type{Snapshots}}
 \newcommand{\SnapshotEnv}{\type{SnapshotEnv}}
@@ -174,7 +175,7 @@ throughout the rest of the section.
       & ~~~~~ \fun{expected}~\var{hk} =
                 \begin{cases}
                   \left(\sum\limits_{
-                    \wcard\mapsto c\in\var{st}}c\right)*(\fun{slotsPerEpoch}~{pp}) / tot
+                    \wcard\mapsto c\in\var{st}}c\right)\cdot\SlotsPerEpoch / tot
                   &
                   \text{if } hk\mapsto\var{st} \in pooledStake \\
                   0 & \text{otherwise}
@@ -359,7 +360,7 @@ The type $\type{\Snapshots}$ contains the information needing to be saved on the
     \SnapshotEnv =
     \left(
       \begin{array}{r@{~\in~}ll}
-        \var{slot} & \Slot & \text{current slot}\\
+        \var{e_{new}} & \Epoch & \text{the upcoming epoch}\\
         \var{pp} & \PParams & \text{protocol parameters}\\
         \var{dstate} & \DState & \text{delegation state}\\
         \var{pstate} & \PState & \text{pool state}\\
@@ -419,6 +420,7 @@ This transition has no preconditions and results in the following state change:
   \item In the UTxO state, the decayed deposit amounts are moved from the deposit pool
     to the fee pool. Note that in the reward transition (Section~\ref{sec:reward-trans}),
     the value $\var{feeSS}$ will be removed from the fee pot in the UTxO state.
+    The decay is calculated based on \textit{the first slot in the upcoming epoch}.
 \end{itemize}
 
 %%
@@ -434,6 +436,7 @@ This transition has no preconditions and results in the following state change:
         (\var{stkeys},~\wcard,~\wcard,~\wcard) & \var{dstate}\\
         (\var{stpools},~\var{poolParams},~\wcard,~\wcard) & \var{pstate}\\
         \var{pooledStake} & \poolDistr{utxo}{dstate}{pstate} \\
+        \var{slot} & \firstSlot{e_{new}} \\
         \var{oblg} & \obligation{pp}{stkeys}{stpools}{slot} \\
         \var{decayed} & \var{deposits} - \var{oblg} \\
       \end{array}
@@ -441,7 +444,7 @@ This transition has no preconditions and results in the following state change:
     }
     {
       \begin{array}{l}
-        \var{slot} \\
+        \var{e_{new}} \\
         \var{pp} \\
         \var{dstate} \\
         \var{pstate} \\
@@ -495,6 +498,17 @@ which is responsible for removing pools slated for retirement in the given epoch
 %% Figure - Pool Reap Defs
 %%
 \begin{figure}[htb]
+  \emph{Pool Reap environment}
+  \begin{equation*}
+    \PlReapEnv =
+    \left(
+      \begin{array}{r@{~\in~}ll}
+        \var{e_{new}} & \Epoch & \text{the upcoming epoch}\\
+        \var{pp} & \PParams & \text{protocol parameters}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
   \emph{Pool Reap State}
   \begin{equation*}
     \PlReapState =
@@ -510,7 +524,7 @@ which is responsible for removing pools slated for retirement in the given epoch
   \emph{Pool Reap transitions}
   \begin{equation*}
     \_ \vdash \_ \trans{poolreap}{} \_ \in
-    \powerset (\Slot \times \PlReapState \times \PlReapState)
+    \powerset (\PlReapEnv \times \PlReapState \times \PlReapState)
   \end{equation*}
   %
   \caption{Pool Reap Transition}
@@ -539,11 +553,11 @@ This transition has no preconditions and results in the following state change:
     {
       {
       \begin{array}{r@{=}l}
-        \var{retired} & \var{retiring}^{-1}~\var{(\epoch{slot})} \\
-        \var{pr} & \poolRefunds{pp}{retiring}{cslot} \\
+        \var{retired} & \var{retiring}^{-1}~\var{e_{new}} \\
+        \var{pr} & \poolRefunds{pp}{retiring}{(\firstSlot{e_{new}})} \\
         \var{rewardAcnts}
                  & \{\var{hk}\mapsto \fun{poolRAcnt}~\var{pool} \mid
-                   \var{hk}\mapsto\var{pool} \in \var{poolParams}\restrictdom\var{retiring} \} \\
+                   \var{hk}\mapsto\var{pool} \in \var{retired}\restrictdom\var{poolParams} \} \\
         \var{refunds} & \left\{
                         a \mapsto c
                         \mathrel{\Bigg|}
@@ -563,7 +577,8 @@ This transition has no preconditions and results in the following state change:
     }
     {
       \begin{array}{l}
-        \var{slot}\\
+        \var{e_{new}}\\
+        \var{pp}\\
       \end{array}
       \vdash
       \left(
@@ -592,7 +607,7 @@ This transition has no preconditions and results in the following state change:
           ~ \\
           \var{stkeys} \\
           \varUpdate{\var{rewards}} & \varUpdate{\unionoverridePlus} & \varUpdate{\var{refunds}} \\
-          \varUpdate{\var{delegations}} & \varUpdate{\subtractrange} & \varUpdate{\var{retiring}} \\
+          \varUpdate{\var{delegations}} & \varUpdate{\subtractrange} & \varUpdate{\var{retired}} \\
           \var{ptrs} \\
           ~ \\
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{stpools}} \\
@@ -613,7 +628,7 @@ This transition has no preconditions and results in the following state change:
 \label{sec:pparam-update}
 
 Finally, reaching the epoch boundary may trigger a change in the protocol
-parameters. The protocol parameters environment consists of the current slot number, the new
+parameters. The protocol parameters environment consists of the upcoming epoch number, the new
 protocol parameters, and delegation and pool states.
 The state change is a change of the $\UTxOState$, the $\Acnt$ states, and the current
 $\PParams$.
@@ -628,8 +643,8 @@ The type of this state transition is given in Figure~\ref{fig:ts-types:new-proto
     \NewPParamEnv =
     \left(
       \begin{array}{r@{~\in~}ll}
-        \var{slot} & \Slot & \text{current slot}\\
-        \var{ppNew} & \PParams & \text{new protocol parameters}\\
+        \var{e_{new}} & \Epoch & \text{upcoming epoch}\\
+        \var{pp_{new}} & \PParams & \text{new protocol parameters}\\
         \var{dstate} & \DState & \text{delegation state}\\
         \var{pstate} & \PState & \text{pool state}\\
       \end{array}
@@ -696,18 +711,21 @@ for ease of reading.
   \begin{equation}\label{eq:new-pc-accepted}
     \inference[New-Proto-Param-Accepted]
     {
-      \var{oblgCur} = \obligation{pp}{stkeys}{stpools}{slot} \\
-      \var{oblgNew} = \obligation{ppNew}{stkeys}{stpools}{slot} \\
-      ~\\
-      \var{diff} = \var{oblgCur} - \var{oblgNew} \\
-      \var{reserves} + \var{diff} \geq 0\\
+      {\begin{array}{rcl}
+          \var{slot} & = & \firstSlot{e_{new}} \\
+          \var{oblg_{cur}} & = & \obligation{pp}{stkeys}{stpools}{slot} \\
+          \var{oblg_{new}} & = & \obligation{pp_{new}}{stkeys}{stpools}{slot} \\
+          \var{diff} & = & \var{oblg_{cur}} - \var{oblg_{new}} \\
+          \\
+          \var{reserves} + \var{diff} & \geq & 0\\
+      \end{array}}\\
       ~\\
       \var{utxoSt'} =
       \left(
         {
           \begin{array}{r}
             \var{utxo} \\
-            \varUpdate{oblgNew} \\
+            \varUpdate{oblg_{new}} \\
             \var{fees} \\
           \end{array}
         }
@@ -727,8 +745,8 @@ for ease of reading.
     }
     {
       \begin{array}{l}
-        \var{slot}\\
-        \var{ppNew}\\
+        \var{e_{new}}\\
+        \var{pp_{new}}\\
         \var{dstate}\\
         \var{pstate}\\
       \end{array}
@@ -745,7 +763,7 @@ for ease of reading.
         \begin{array}{rcl}
           \varUpdate{utxoSt'}\\
           \varUpdate{acnt'} \\
-          \varUpdate{\var{ppNew}} \\
+          \varUpdate{\var{pp_{new}}} \\
         \end{array}
       \right)
     }
@@ -756,16 +774,19 @@ for ease of reading.
   \begin{equation}\label{eq:new-pc-denied}
     \inference[New-Proto-Param-Denied]
     {
-      \var{oblgCur} = \obligation{pp}{stkeys}{stpools}{slot} \\
-      \var{oblgNew} = \obligation{ppNew}{stkeys}{stpools}{slot} \\
-      ~\\
-      \var{diff} = \var{oblgCur} - \var{oblgNew} \\
-      \var{reserves} + \var{diff} < 0\\
+      {\begin{array}{rcl}
+          \var{slot} & = & \firstSlot{e_{new}} \\
+          \var{oblg_{cur}} & = & \obligation{pp}{stkeys}{stpools}{slot} \\
+          \var{oblg_{new}} & = & \obligation{pp_{new}}{stkeys}{stpools}{slot} \\
+          \var{diff} & = & \var{oblg_{cur}} - \var{oblg_{new}} \\
+          \\
+          \var{reserves} + \var{diff} & < & 0\\
+      \end{array}}\\
     }
     {
       \begin{array}{l}
-        \var{slot}\\
-        \var{ppNew}\\
+        \var{e_{new}}\\
+        \var{pp_{new}}\\
         \var{dstate}\\
         \var{pstate}\\
       \end{array}
@@ -812,8 +833,8 @@ the current protocol parameters, and the snapshots.
     \EpochEnv =
     \left(
       \begin{array}{r@{~\in~}ll}
-        \var{slot} & \Slot & \text{current slot}\\
-        \var{ppNew} & \PParams & \text{new protocol parameters}\\
+        \var{e_{new}} & \Epoch & \text{upcoming epoch}\\
+        \var{pp_{new}} & \PParams & \text{new protocol parameters}\\
         \var{blocks} & \HashKey \mapsto \N & \text{blocks made in the epoch}\\
       \end{array}
     \right)
@@ -848,9 +869,6 @@ the current protocol parameters, and the snapshots.
 
 The epoch transition rule calls $\mathsf{SNAP}$, $\mathsf{POOLREAP}$, and $\mathsf{NEWPP}$
 in sequence.
-Note that the slot number used as \textit{current slot number}
-for the epoch boundary calculations where a slot number is required is set to
-be the \textit{last slot of the epoch before the boundary}.
 
 %%
 %% Figure - Epoch Rule
@@ -861,7 +879,7 @@ be the \textit{last slot of the epoch before the boundary}.
     {
       {
         \begin{array}{l}
-          \var{slot}\\
+          \var{e_{new}}\\
           \var{pp}\\
           \var{dstate} \\
           \var{pstate} \\
@@ -893,7 +911,7 @@ be the \textit{last slot of the epoch before the boundary}.
       \\~\\~\\
       {
         \begin{array}{l}
-          \var{slot}
+          \var{e_{new}}
         \end{array}
       }
       \vdash
@@ -919,8 +937,8 @@ be the \textit{last slot of the epoch before the boundary}.
       \\~\\~\\
       {
         \begin{array}{l}
-          \var{slot}\\
-          \var{ppNew}\\
+          \var{e_{new}}\\
+          \var{pp_{new}}\\
           \var{dstate'}\\
           \var{pstate''}\\
         \end{array}
@@ -948,8 +966,8 @@ be the \textit{last slot of the epoch before the boundary}.
     }
     {
       \begin{array}{l}
-        \var{slot}\\
-        \var{ppNew}\\
+        \var{e_{new}}\\
+        \var{pp_{new}}\\
         \var{blocks}\\
       \end{array}
       \vdash
@@ -970,8 +988,8 @@ be the \textit{last slot of the epoch before the boundary}.
         \varUpdate{\var{acnt'''}} \\
         \varUpdate{\var{dstate''}} \\
         \varUpdate{\var{pstate''}} \\
-        \varUpdate{\var{pp'}}
-        \varUpdate{\var{ss'}}
+        \varUpdate{\var{pp'}} \\
+        \varUpdate{\var{ss'}} \\
       \end{array}
       \right)
     }
@@ -1263,7 +1281,6 @@ The reward state transition type, like all the transition types in this section,
     \RewardEnv =
     \left(
       \begin{array}{r@{~\in~}ll}
-        \var{slot} & \Slot & \text{last slot of epoch}\\
         \var{pp} & \PParams & \text{protocol parameters}\\
         \var{blocks} & \BlocksMade & \text{blocks made in the epoch}\\
         \var{ss} & \SnapshotState & \text{snapshots}\\
@@ -1425,9 +1442,9 @@ smaller refunds for deposits than were paid upon depositing.
     }
     {
       \begin{array}{l}
-        \var{slot}\\
         \var{pp}\\
         \var{blocks}\\
+        \var{ss}\\
       \end{array}
       \vdash
       \left(

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -1130,6 +1130,8 @@ The calculation is done pool-by-pool.
     Involved in the calculation is:
     \begin{itemize}
       \item $\var{pstake}$, the total amount of stake controlled by the stake pool.
+      \item $\var{ostake}$, the total amount of stake controlled by the stake pool operator
+        and owners
       \item $\sigma$, the total proportion of stake controlled by the stake pool.
       \item $\overline{N}$, the expected number of blocks the pool should have produced.
       \item $\var{pledge}$, the pool's pledge in lovelace.
@@ -1163,14 +1165,15 @@ The calculation is done pool-by-pool.
           (\var{rewards},~\var{unrealized})\\
       & ~~~\where \\
       & ~~~~~~~\var{pstake} = \sum_{\_\mapsto t\in\var{stake}} t \\
+      & ~~~~~~~\var{ostake} = \var{stake}~\var{poolHK} \\
       & ~~~~~~~\sigma = \var{pstake} / tot \\
-      & ~~~~~~~\var{\overline{N}} = \sigma * (\fun{slotsPerEpoch}~{pp})\\
+      & ~~~~~~~\var{\overline{N}} = \sigma * \SlotsPerEpoch\\
       & ~~~~~~~\var{pledge} = \fun{poolPledge}~pool \\
       & ~~~~~~~p_{r} = \var{pledge} / \var{tot} \\
       & ~~~~~~~maxP =
       \begin{cases}
         \fun{maxPool}~\var{pp}~\var{R}~\sigma~\var{p_r}&
-        \var{pledge} \leq \var{pstake}\\
+        \var{pledge} \leq \var{ostake}\\
         0 & \text{otherwise.}
       \end{cases} \\
       & ~~~~~~~\var{poolR} = \poolReward{pp}{hk}{n}{\overline{N}}{avgs}{maxP} \\
@@ -1179,7 +1182,7 @@ The calculation is done pool-by-pool.
                                   ~\Big\vert~
                                   hk\mapsto c\in\var{stake},~~hk \neq\var{poolHK}
                                \right\}\\
-      & ~~~~~~~\var{lReward} = \lReward{poolR}{pool}{\frac{\var{stake}~\var{poolHK}}{tot}}{\sigma} \\
+      & ~~~~~~~\var{lReward} = \lReward{poolR}{pool}{\frac{\var{ostake}}{tot}}{\sigma} \\
       & ~~~~~~~\var{potentialRewards} =
                  \var{mReward} \cup
                  \{(\fun{poolRAcnt}~\var{pool})\mapsto\var{lReward}\} \\

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -50,6 +50,7 @@
 \newcommand{\Coin}{\type{Coin}}
 \newcommand{\PParams}{\type{PParams}}
 \newcommand{\Slot}{\type{Slot}}
+\newcommand{\SlotsPerEpoch}{\mathsf{SlotsPerEpoch}}
 \newcommand{\Duration}{\type{Duration}}
 \newcommand{\StakePools}{\type{StakePools}}
 \newcommand{\StakeKeys}{\type{StakeKeys}}
@@ -116,6 +117,7 @@
 \newcommand{\values}[1]{\fun{values}~ #1}
 \newcommand{\balance}[1]{\fun{balance}~ \var{#1}}
 \newcommand{\txttl}[1]{\fun{txttl}~ \var{#1}}
+\newcommand{\firstSlot}[1]{\fun{firstSlot}~ \var{#1}}
 \newcommand{\deposits}[2]{\fun{deposits}~ \var{#1} ~ \var{#2}}
 \newcommand{\decayedKey}[4]{\fun{decayedKey}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
 \newcommand{\decayedTx}[3]{\fun{decayedTx}~ \var{#1}~ \var{#2}~ \var{#3}}
@@ -477,6 +479,9 @@ This value depends on the protocol parameters and the size of the transaction.
 Two time related types are introduced, $\Epoch$ and $\type{Duration}$.
 A $\type{Duration}$ is the difference between two slots, as given by $\slotminus{}{}$.
 
+Lastly, one global constant is defined, $\SlotsPerEpoch$, representing the number of slots
+in an epoch. As a global constant, this value can only be changed by updating the software.
+
 \begin{figure*}[htb]
   \emph{Abstract types}
   %
@@ -506,7 +511,6 @@ A $\type{Duration}$ is the difference between two slots, as given by $\slotminus
     \PParams =
     \left(
       \begin{array}{r@{~\in~}lr}
-        \var{slotsPerEpoch} & \N & \text{slots per epoch} \\
         \var{fparams} & \type{FeeParams} & \text{min fee parameters}\\
         \var{keyDeposit} & \Coin & \text{stake key deposit}\\
         \var{keyMinRefund} & \unitInterval & \text{stake key min refund}\\
@@ -528,7 +532,6 @@ A $\type{Duration}$ is the difference between two slots, as given by $\slotminus
   \emph{Accessor Functions}
   %
   \begin{center}
-    \fun{slotsPerEpoch},
     \fun{fparams},
     \fun{keyDeposit},
     \fun{keyMinRefund},
@@ -562,6 +565,14 @@ A $\type{Duration}$ is the difference between two slots, as given by $\slotminus
                  & \text{first slot of an epoch}
     \end{array}
   \end{equation*}
+  \emph{Global Constants}
+  %
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      \SlotsPerEpoch & \N & \text{slots per epoch} \\
+    \end{array}
+  \end{equation*}
+  %
   \caption{Definitions used in Protocol Parameters}
   \label{fig:defs:protocol-parameters}
 \end{figure*}
@@ -1139,7 +1150,7 @@ Section~\cref{sec:epoch}.
       \begin{array}{lr@{~=~}l}
         \where
           & \var{created} & \var{stkeys}~(\cwitness~\var{c}) \\
-          & \var{start} & \mathsf{max}~(\fun{firstSlot}~\epoch{cslot})~created \\
+          & \var{start} & \mathsf{max}~(\firstSlot{\epoch{cslot}})~created \\
           & \var{epochRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{start}{c} \\
           & \var{currentRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{cslot}{c} \\
           & \dval & \fun{keyDeposit}~\var{pp}\\


### PR DESCRIPTION
This PR redoes the translations between epochs and slots.  #180 

The number of slots in an epoch is now defined as a global constant (in table 4, along with the protocol parameters).

It is now explicit that the decayed deposit amounts that are moved to the rewards pot at the epoch boundary are always calculated based on the first slot of the upcoming epoch.

In fact, in the epoch boundary transition (Fig 34), and also all three transitions that it depends on it (Figs 29, 31, and 33), the slot in the environment has been replaced with `e_new`, hopefully making it clear that the calculations are done based on the upcoming epoch number. Moreover, when a slot number is needed in these transitions, `firstSlot e_new` is always used.

![enew](https://user-images.githubusercontent.com/943479/52288796-d92da500-293a-11e9-99ff-0a0db7252a7b.png)

There were also a couple cosmetic changes. I've switched the camel case `ppNew` and `oblgNew` to using subscripts, such as `pp_{new}`. There were a couple of backwards let bindings that I flipped.

I realized that the `REWARD` transition no longer needed the slot in the environment, so that was removed.

Lastly, there was a mistake in the `rewardOnePool` function that was fixed: the pledge should be compared against the pool operator's stake, not the total pool stake.  #222 