### PR TITLE
Updates the block-related types in the Byron era chain spec

### DIFF
--- a/specs/chain/hs/cs-blockchain.cabal
+++ b/specs/chain/hs/cs-blockchain.cabal
@@ -28,6 +28,7 @@ library
                      , Cardano.Spec.Chain.STS.Rule.Chain
                      , Cardano.Spec.Chain.STS.Rule.Epoch
                      , Cardano.Spec.Chain.STS.Rule.SigCnt
+                     , Cardano.Spec.Consensus.Block
   --other-modules:
   -- other-extensions:
   hs-source-dirs:      src

--- a/specs/chain/hs/src/Cardano/Spec/Chain/STS/Rule/BHead.hs
+++ b/specs/chain/hs/src/Cardano/Spec/Chain/STS/Rule/BHead.hs
@@ -57,18 +57,18 @@ instance STS BHEAD where
         let sMax = us ^. maxHdrSz
         bHeaderSize bh <= sMax ?! HeaderSizeTooBig
         -- Check that the previous hash matches
-        bh ^. prevHHash == hLast ?! HashesDontMatch
+        bh ^. bhPrevHash == hLast ?! HashesDontMatch
         -- Check sanity of current slot
-        let sNext = bh ^. bSlot
+        let sNext = bh ^. bhSlot
         sLast < sNext ?! SlotDidNotIncrease
         sNext <= sNow ?! SlotInTheFuture
         -- Perform an epoch transition
         eNext <-  trans @EPOCH $ TRC (us ^. bkSlotsPerEpoch, eLast, sNext)
         -- Perform a signature count transition
-        sgs' <- trans @SIGCNT $ TRC ((us, dms), sgs, bh ^. bIssuer)
+        sgs' <- trans @SIGCNT $ TRC ((us, dms), sgs, bh ^. bhIssuer)
         return $! ( eNext
                   , sNext
-                  , hashHeader bh
+                  , hashHeader bh -- the same as bhToSign bh
                   , sgs'
                   , us
                   )

--- a/specs/chain/hs/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
+++ b/specs/chain/hs/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
@@ -207,11 +207,11 @@ instance HasTrace CHAIN where
           , _dSEnvLiveness = us ^. dLiveness }
     dCerts <- dcertsGen dsEnv
     let bh
-          = BlockHeader
-          { _prevHHash = h
-          , _bSlot = Slot (s + slotInc)
-          , _bIssuer = vkI
-          , _bSig = Sig vkI (owner vkI)
+          = MkBlockHeader
+          { _bhPrevHash = h
+          , _bhSlot = Slot (s + slotInc)
+          , _bhIssuer = vkI
+          , _bhSig = Sig vkI (owner vkI)
           }
         bb
           = BlockBody

--- a/specs/chain/hs/src/Cardano/Spec/Consensus/Block.hs
+++ b/specs/chain/hs/src/Cardano/Spec/Consensus/Block.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies     #-}
+
+-- | Type classes for interfacing with the consensus layer
+module Cardano.Spec.Consensus.Block where
+
+import           Control.Lens ((^.))
+
+import qualified Cardano.Spec.Chain.STS.Block as CBM -- Concrete Block Module
+import           Ledger.Core
+import           Ledger.Delegation
+import           Ledger.Signatures
+
+
+class BlockHeader h where
+  -- | Hash of the previous block header, or 'genesisHash' in case of
+  -- the first block in a chain.
+  bhPrevHash :: h -> Hash -- This is needed in the PBFT rule
+  -- | Signature of the block by its issuer.
+  bhSig :: h -> Sig VKey
+  -- | Block issuer.
+  bhIssuer :: h -> VKey
+  -- | Slot for which this block is issued
+  bhSlot :: h -> Slot
+
+
+class BlockBody bb where
+  -- | Delegation certificates.
+  bbCerts :: bb -> [DCert]
+
+
+class ( BlockHeader (FamBlockHeader b)
+      , BlockBody (FamBlockBody b)
+      ) => Block b where
+  type family FamBlockHeader b :: *
+  type family FamBlockBody   b :: *
+
+  -- | Gets the block header
+  bHeader :: b -> FamBlockHeader b
+  -- | Gets the block body
+  bBody   :: b -> FamBlockBody b
+
+
+instance BlockBody CBM.BlockBody where
+  bbCerts (CBM.BlockBody bDCerts) = bDCerts
+
+instance BlockHeader CBM.BlockHeader where
+  bhPrevHash h = h ^. CBM.bhPrevHash
+  bhSig      h = h ^. CBM.bhSig
+  bhIssuer   h = h ^. CBM.bhIssuer
+  bhSlot     h = h ^. CBM.bhSlot
+
+instance Block CBM.Block where
+  type FamBlockHeader CBM.Block = CBM.BlockHeader
+  type FamBlockBody   CBM.Block = CBM.BlockBody
+
+  bHeader b = b ^. CBM.bHeader
+  bBody   b = b ^. CBM.bBody


### PR DESCRIPTION
This patch both updates block-related types and provides a few new classes for interfacing with the consensus layer.

Closes #238.