### PR TITLE
Bring the required changes for pr308 to this repo

### DIFF
--- a/specs/chain/hs/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
+++ b/specs/chain/hs/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
@@ -6,7 +6,7 @@
 
 module Cardano.Spec.Chain.STS.Rule.Chain where
 
-import Control.Lens ((^.))
+import Control.Lens ((^.), _1, _3, _5, Getter)
 import qualified Crypto.Hash
 import Data.ByteString (ByteString)
 import qualified Data.Map.Strict as Map
@@ -106,6 +106,26 @@ instance Embed BBODY CHAIN where
 genesisHash :: Hash
 -- Not sure we need a concrete hash in the specs ...
 genesisHash = Crypto.Hash.hash ("" :: ByteString)
+
+--------------------------------------------------------------------------------
+-- Chain environment getters.
+--------------------------------------------------------------------------------
+
+-- | Getter for the protocol parameters contained in the environment.
+pps :: Getter (Environment CHAIN) PParams
+pps = _3
+
+--------------------------------------------------------------------------------
+-- Chain state getters.
+--------------------------------------------------------------------------------
+
+-- | Getter for the epoch contained in the chain state.
+epoch :: Getter (State CHAIN) Epoch
+epoch = _1
+
+-- | Getter for the delegation interface state contained in the chain state.
+dis :: Getter (State CHAIN) DIState
+dis = _5
 
 --------------------------------------------------------------------------------
 -- Generators

--- a/specs/chain/hs/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
+++ b/specs/chain/hs/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
@@ -114,13 +114,13 @@ genesisHash = Crypto.Hash.hash ("" :: ByteString)
 
 -- | Getter for the protocol parameters contained in the environment.
 --
--- We want to use the getter with lens operations such as '(^.)', however we do
+-- We want to use the getter with lens operations such as '^.', however we do
 -- not want the getter to be able to modify the environment using lens
--- operators such as `.~`.
+-- operators such as '.~'
 --
--- The type of '(^.)', which is just `view` with the arguments flipped, is:
+-- The type of '^.', which is just `view` with the arguments flipped, is:
 --
--- (^.) :: s -> Getting a s a -> a
+-- > (^.) :: s -> Getting a s a -> a
 --
 -- Hence the type we gave to 'getPps'.
 --
@@ -131,7 +131,7 @@ genesisHash = Crypto.Hash.hash ("" :: ByteString)
 -- which is equivalent to:
 --
 -- > forall f . (Contravariant f, Functor f)
---   => (PParams -> f PParams) -> (Environment CHAIN) -> f (Environment CHAIN)
+-- > => (PParams -> f PParams) -> (Environment CHAIN) -> f (Environment CHAIN)
 --
 -- However @Contravariant f@ is a redundant constraint, and GHC will give a warning.
 --

--- a/specs/chain/hs/test/Cardano/Spec/Chain/STS/Properties.hs
+++ b/specs/chain/hs/test/Cardano/Spec/Chain/STS/Properties.hs
@@ -22,6 +22,6 @@ slotsIncrease = property $ forAll trace >>= slotsIncreaseInTrace
 
 slotsIncreaseInTrace :: MonadTest m => Trace CHAIN -> m ()
 slotsIncreaseInTrace tr = assert $ slots == sortedSlots && nub slots == slots
-  where blocks = traceSignals NewestFirst tr
+  where blocks = traceSignals OldestFirst tr
         slots = blocks ^.. traverse . bHeader . bSlot
         sortedSlots = sort slots

--- a/specs/ledger/hs/src/Ledger/Core.hs
+++ b/specs/ledger/hs/src/Ledger/Core.hs
@@ -6,9 +6,10 @@ import qualified Crypto.Hash as Crypto
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString.Char8 as BS
 import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
-import qualified Data.Map.Strict as Map
+import Data.Word (Word64)
 import GHC.Generics (Generic)
 import GHC.Natural (minusNaturalMaybe)
 import Numeric.Natural (Natural)
@@ -83,17 +84,17 @@ verify (VKey vk) vd (Sig sd sk) = vk == sk && vd == sd
 -- Slots and Epochs
 ---------------------------------------------------------------------------------
 
-newtype Epoch = Epoch Natural
+newtype Epoch = Epoch Word64
   deriving (Eq, Ord, Show, HasTypeReps)
 
-newtype Slot = Slot Natural
+newtype Slot = Slot { getValue :: Word64 }
   deriving (Eq, Ord, Show, HasTypeReps)
 
 -- | A number of slots.
 --
 --   We use this newtype to distinguish between a cardinal slot and a relative
 --   period of slots.
-newtype SlotCount = SlotCount Natural
+newtype SlotCount = SlotCount Word64
   deriving (Eq, Ord, Show)
 
 -- | Add a slot count to a slot.
@@ -104,9 +105,9 @@ addSlot (Slot n) (SlotCount m) = Slot $ m + n
 --
 --   This is bounded below by 0.
 minusSlot :: Slot -> SlotCount -> Slot
-minusSlot (Slot n) (SlotCount m) = case minusNaturalMaybe m n of
-  Nothing -> Slot 0
-  Just k  -> Slot k
+minusSlot (Slot n) (SlotCount m)
+  | m <= n = Slot 0
+  | n < m  = Slot $ m - n
 
 ---------------------------------------------------------------------------------
 -- Domain restriction and exclusion

--- a/specs/ledger/hs/src/Ledger/Core.hs
+++ b/specs/ledger/hs/src/Ledger/Core.hs
@@ -11,7 +11,6 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Word (Word64)
 import GHC.Generics (Generic)
-import GHC.Natural (minusNaturalMaybe)
 import Numeric.Natural (Natural)
 
 import Data.AbstractSize
@@ -87,7 +86,7 @@ verify (VKey vk) vd (Sig sd sk) = vk == sk && vd == sd
 newtype Epoch = Epoch Word64
   deriving (Eq, Ord, Show, HasTypeReps)
 
-newtype Slot = Slot { getValue :: Word64 }
+newtype Slot = Slot { unSlot :: Word64 }
   deriving (Eq, Ord, Show, HasTypeReps)
 
 -- | A number of slots.
@@ -106,8 +105,8 @@ addSlot (Slot n) (SlotCount m) = Slot $ m + n
 --   This is bounded below by 0.
 minusSlot :: Slot -> SlotCount -> Slot
 minusSlot (Slot n) (SlotCount m)
-  | m <= n = Slot 0
-  | n < m  = Slot $ m - n
+  | m <= n    = Slot 0
+  | otherwise = Slot $ m - n
 
 ---------------------------------------------------------------------------------
 -- Domain restriction and exclusion

--- a/specs/ledger/hs/src/Ledger/Core.hs
+++ b/specs/ledger/hs/src/Ledger/Core.hs
@@ -100,11 +100,11 @@ newtype SlotCount = SlotCount Word64
 addSlot :: Slot -> SlotCount -> Slot
 addSlot (Slot n) (SlotCount m) = Slot $ m + n
 
--- | Subtract a slot count from a slot.
+-- | Subtract a slot from a slot count.
 --
 --   This is bounded below by 0.
-minusSlot :: Slot -> SlotCount -> Slot
-minusSlot (Slot n) (SlotCount m)
+minusSlot :: SlotCount -> Slot -> Slot
+minusSlot (SlotCount m) (Slot n)
   | m <= n    = Slot 0
   | otherwise = Slot $ m - n
 

--- a/specs/ledger/hs/src/Ledger/Delegation.hs
+++ b/specs/ledger/hs/src/Ledger/Delegation.hs
@@ -435,7 +435,7 @@ instance STS DELEG where
     ]
     where
       aboutSlot :: Slot -> SlotCount -> (Slot -> Bool)
-      aboutSlot a b c = c >= (a `minusSlot` b) && c <= (a `addSlot` b)
+      aboutSlot a b c = c >= (b `minusSlot` a) && c <= (a `addSlot` b)
 
 instance Embed SDELEGS DELEG where
   wrapFailed = SDelegSFailure

--- a/specs/ledger/hs/src/Ledger/Delegation.hs
+++ b/specs/ledger/hs/src/Ledger/Delegation.hs
@@ -19,6 +19,7 @@ module Ledger.Delegation
   , _dwit
   , _dwho
   , _depoch
+  , mkDCert
   , delegator
   , delegate
   , dbody
@@ -145,6 +146,20 @@ data DCert = DCert
 instance HasTypeReps DCert
 
 makeLenses ''DCert
+
+mkDCert
+  :: VKeyGenesis
+  -> Sig VKeyGenesis
+  -> VKey
+  -> Epoch
+  -> DCert
+mkDCert vkg sigVkg vkd e
+  = DCert
+  { _dbody = (vkd, e)
+  , _dwit = sigVkg
+  , _dwho = (vkg, vkd)
+  , _depoch = e
+  }
 
 -- | Key that is delegating.
 delegator :: DCert -> VKeyGenesis

--- a/specs/ledger/hs/test/Ledger/Delegation/Examples.hs
+++ b/specs/ledger/hs/test/Ledger/Delegation/Examples.hs
@@ -7,6 +7,7 @@ module Ledger.Delegation.Examples
 where
 
 import Data.Set (fromList, Set)
+import Data.Word (Word64)
 import Numeric.Natural (Natural)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase)
@@ -68,7 +69,7 @@ deleg =
     ]
   ]
   where
-    s :: Natural -> Slot
+    s :: Word64 -> Slot
     s = Slot
 
     k :: Natural -> VKey
@@ -77,10 +78,10 @@ deleg =
     gk :: Natural -> VKeyGenesis
     gk = VKeyGenesis . k
 
-    sc :: Natural -> SlotCount
+    sc :: Word64 -> SlotCount
     sc = SlotCount
 
-    e :: Natural -> Epoch
+    e :: Word64 -> Epoch
     e = Epoch
 
     dc :: VKeyGenesis -> VKey -> Epoch -> DCert

--- a/specs/ledger/hs/test/Ledger/Delegation/Properties.hs
+++ b/specs/ledger/hs/test/Ledger/Delegation/Properties.hs
@@ -15,7 +15,6 @@ import Control.Lens ((^.), makeLenses, (&), (.~), view)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import GHC.Natural (minusNaturalMaybe)
 import Hedgehog
   ( MonadTest
   , Property
@@ -212,8 +211,8 @@ expectedDms s d cs = Map.fromList (fmap (delegator &&& delegate) activeCerts)
 
 minusSlotCount :: Slot -> SlotCount -> Slot
 minusSlotCount (Slot s) (SlotCount c)
-  | s <= c = Slot 0
-  | c < s  = Slot $ s - c
+  | s <= c    = Slot 0
+  | otherwise = Slot $ s - c
 
 -- | An initial delegation scheduling environment to be used in the traces
 -- produced by the @DBLOCK@ transition system.

--- a/specs/ledger/hs/test/Ledger/Delegation/Properties.hs
+++ b/specs/ledger/hs/test/Ledger/Delegation/Properties.hs
@@ -56,7 +56,7 @@ import Control.State.Transition.Generator
   )
 import Control.State.Transition.Trace
   ( Trace
-  , TraceOrder(NewestFirst)
+  , TraceOrder(OldestFirst)
   , lastState
   , traceEnv
   , traceSignals
@@ -176,7 +176,7 @@ dcertsAreTriggeredInTrace tr
     lastDms = st ^. delegationMap
 
     trExpectedDms
-      = expectedDms (env ^. slot) (env ^. liveness) (traceSignals NewestFirst tr)
+      = expectedDms (env ^. slot) (env ^. liveness) (traceSignals OldestFirst tr)
 
     (env, st) = lastState tr
 
@@ -211,9 +211,9 @@ expectedDms s d cs = Map.fromList (fmap (delegator &&& delegate) activeCerts)
     activeCerts = concatMap _blockCerts activeBlocks
 
 minusSlotCount :: Slot -> SlotCount -> Slot
-minusSlotCount (Slot s) (SlotCount c) = case s `minusNaturalMaybe` c of
-  Nothing -> Slot 0
-  Just k  -> Slot k
+minusSlotCount (Slot s) (SlotCount c)
+  | s <= c = Slot 0
+  | c < s  = Slot $ s - c
 
 -- | An initial delegation scheduling environment to be used in the traces
 -- produced by the @DBLOCK@ transition system.

--- a/specs/semantics/hs/src/Data/AbstractSize.hs
+++ b/specs/semantics/hs/src/Data/AbstractSize.hs
@@ -17,6 +17,7 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq, (<|), (><), empty)
 import Data.Typeable (TypeRep, Typeable, typeOf)
+import Data.Word (Word64)
 import GHC.Generics
   ( (:*:)((:*:))
   , (:+:)(L1, R1)
@@ -146,4 +147,7 @@ instance HasTypeReps Double where
   typeReps x = [typeOf x]
 
 instance HasTypeReps Natural where
+  typeReps x = [typeOf x]
+
+instance HasTypeReps Word64 where
   typeReps x = [typeOf x]


### PR DESCRIPTION
- Add doctests for `Control.State.Transition.Trace`.
- Replace `Natural` by `Word64` for abstractslots and epochs, otherwise we are making things difficult to ourselves when elaborating this into concrete slots and epochs, since they have type `Word64`
- Correct the meaning of `OldestFirst` and `NewestFirst` which was swapped.
- Add (`lens`) getters for parts of the chain state.
- Add function `preStatesAndSignals` to pair a signal with its pre-state.

Closes #248.