### PR TITLE
Add: Update interface

### DIFF
--- a/.stack-to-nix.cache
+++ b/.stack-to-nix.cache
@@ -3,3 +3,5 @@ https://github.com/nc6/cardano-crypto d46e8a44d85a71f5da03fb6b176e9427c684144b .
 https://github.com/avieth/plutus-prototype d094be301195fcd8ab864d793f114970426a4478 . 1s932rghn4zn441waansp408b5bwk20rc1wsa5693a2nwnp4dijw plutus-prototype .stack.nix/plutus-prototype.nix
 https://github.com/input-output-hk/haskell-hedgehog.git 2e741bb53afb085741807018948ae17d956c53af hedgehog 0l0d1n2b68m0628j4yi214q5fy6pz777qfj1bc1lrra8scs5gcxh hedgehog .stack.nix/hedgehog.nix
 http://github.com/nc6/canonical-json a9dc9b893649bc2e2a770ab22d278a780f7e3a3c . 0alwbi9xqaj6fmwzs6lr2drqrnhlnp13d9k2qkl5ga7h4grz9zcr canonical-json .stack.nix/canonical-json.nix
+https://github.com/input-output-hk/cardano-crypto 3c707936ba0a665375acf5bd240dc4b6eaa6c0bc . 0g8ln8k8wx4csdv92bz09pr7v9dp4lcyv1334b09c9rgwdwhqg1b cardano-crypto .stack.nix/cardano-crypto.nix
+https://github.com/input-output-hk/haskell-hedgehog.git e63fb354bfbad07f3befdd43b382c655944218be hedgehog 1p2yzlaiqj34pkk26cgg0dkvkm1zwjpgx1zk95md5xj0cijb34gj hedgehog .stack.nix/hedgehog.nix

--- a/nix/.stack-pkgs.nix
+++ b/nix/.stack-pkgs.nix
@@ -3,12 +3,13 @@
     {
       packages = {
         "sequence" = (((hackage.sequence)."0.9.8").revisions).default;
+        "tasty-hedgehog" = (((hackage.tasty-hedgehog)."0.2.0.0").revisions).default;
         "tasty-hedgehog-coverage" = (((hackage.tasty-hedgehog-coverage)."0.1.0.0").revisions).default;
-        "aeson-options" = (((hackage.aeson-options)."0.0.0").revisions).default;
         "base58-bytestring" = (((hackage.base58-bytestring)."0.1.0").revisions).default;
         "half" = (((hackage.half)."0.2.2.3").revisions).default;
         "micro-recursion-schemes" = (((hackage.micro-recursion-schemes)."5.0.2.2").revisions).default;
         "streaming-binary" = (((hackage.streaming-binary)."0.3.0.1").revisions).default;
+        "pretty-show" = (((hackage.pretty-show)."1.8.2").revisions).default;
         } // {
         delegation = ./.stack.nix/delegation.nix;
         cs-blockchain = ./.stack.nix/cs-blockchain.nix;
@@ -17,13 +18,12 @@
         non-integer = ./.stack.nix/non-integer.nix;
         cborg = ./.stack.nix/cborg.nix;
         cardano-crypto = ./.stack.nix/cardano-crypto.nix;
-        plutus-prototype = ./.stack.nix/plutus-prototype.nix;
         hedgehog = ./.stack.nix/hedgehog.nix;
         canonical-json = ./.stack.nix/canonical-json.nix;
         };
       compiler.version = "8.6.3";
       compiler.nix-name = "ghc863";
       };
-  resolver = "nightly-2018-12-17";
+  resolver = "lts-13.4";
   compiler = "ghc-8.6.3";
   }

--- a/nix/.stack-pkgs.nix
+++ b/nix/.stack-pkgs.nix
@@ -14,6 +14,7 @@
         cs-blockchain = ./.stack.nix/cs-blockchain.nix;
         cs-ledger = ./.stack.nix/cs-ledger.nix;
         small-steps = ./.stack.nix/small-steps.nix;
+        non-integer = ./.stack.nix/non-integer.nix;
         cborg = ./.stack.nix/cborg.nix;
         cardano-crypto = ./.stack.nix/cardano-crypto.nix;
         plutus-prototype = ./.stack.nix/plutus-prototype.nix;

--- a/nix/.stack.nix/cardano-crypto.nix
+++ b/nix/.stack.nix/cardano-crypto.nix
@@ -81,8 +81,8 @@
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/nc6/cardano-crypto";
-      rev = "d46e8a44d85a71f5da03fb6b176e9427c684144b";
+      url = "https://github.com/input-output-hk/cardano-crypto";
+      rev = "3c707936ba0a665375acf5bd240dc4b6eaa6c0bc";
       sha256 = "0g8ln8k8wx4csdv92bz09pr7v9dp4lcyv1334b09c9rgwdwhqg1b";
       });
     }

--- a/nix/.stack.nix/cs-ledger.nix
+++ b/nix/.stack.nix/cs-ledger.nix
@@ -29,6 +29,14 @@
           ];
         };
       tests = {
+        "doctests" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.doctest)
+            (hsPkgs.doctest-discover)
+            (hsPkgs.cs-ledger)
+            ];
+          };
         "ledger-delegation-test" = {
           depends = [
             (hsPkgs.base)

--- a/nix/.stack.nix/delegation.nix
+++ b/nix/.stack.nix/delegation.nix
@@ -32,6 +32,7 @@
           (hsPkgs.small-steps)
           (hsPkgs.microlens)
           (hsPkgs.microlens-th)
+          (hsPkgs.non-integer)
           ];
         };
       tests = {

--- a/nix/.stack.nix/hedgehog.nix
+++ b/nix/.stack.nix/hedgehog.nix
@@ -61,8 +61,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/haskell-hedgehog.git";
-      rev = "2e741bb53afb085741807018948ae17d956c53af";
-      sha256 = "0l0d1n2b68m0628j4yi214q5fy6pz777qfj1bc1lrra8scs5gcxh";
+      rev = "e63fb354bfbad07f3befdd43b382c655944218be";
+      sha256 = "1p2yzlaiqj34pkk26cgg0dkvkm1zwjpgx1zk95md5xj0cijb34gj";
       });
     postUnpack = "sourceRoot+=/hedgehog; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/non-integer.nix
+++ b/nix/.stack.nix/non-integer.nix
@@ -1,0 +1,28 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.8";
+      identifier = { name = "non-integer"; version = "0.1.0.0"; };
+      license = "NONE";
+      copyright = "";
+      maintainer = "formal.methods@iohk.io";
+      author = "IOHK Formal Methods Team";
+      homepage = "";
+      url = "";
+      synopsis = "";
+      description = "Implementation decision for non-integer calculations";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = { depends = [ (hsPkgs.base) ]; };
+      exes = {
+        "nonInt" = { depends = [ (hsPkgs.base) (hsPkgs.non-integer) ]; };
+        };
+      tests = {
+        "non-integer-test" = {
+          depends = [ (hsPkgs.base) (hsPkgs.non-integer) (hsPkgs.QuickCheck) ];
+          };
+        };
+      };
+    } // rec { src = (pkgs.lib).mkDefault .././../dependencies/non-integer; }

--- a/specs/chain/hs/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
+++ b/specs/chain/hs/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
@@ -181,6 +181,8 @@ instance HasTrace CHAIN where
     ct <- Gen.integral (Range.linear 1 7)
     -- Update adoption threshold
     uat <- Gen.integral (Range.linear 1 7)
+    -- Chain stability
+    cs <- SlotCount <$> Gen.integral (Range.linear 1 1000)
     let initPPs
           = PParams
           { _maxHdrSz = mHSz
@@ -195,6 +197,7 @@ instance HasTrace CHAIN where
           , _scriptVersion = 1
           , _cfmThd = ct
           , _upAdptThd = uat
+          , _chainStability = cs
           }
     initGKeys <- Gen.set (Range.constant 1 70) vkgenesisGen
     -- If we want to generate large traces, we need to set up the value of the

--- a/specs/ledger/hs/src/Ledger/Core.hs
+++ b/specs/ledger/hs/src/Ledger/Core.hs
@@ -119,7 +119,7 @@ newtype PairSet a b = PairSet {unPairSet :: Set (a,b)}
 psSize :: PairSet a b -> Int
 psSize = Set.size . unPairSet
 
-class Maplike m where
+class Relation m where
   singleton :: a -> b -> m a b
 
   -- | Domain
@@ -127,11 +127,11 @@ class Maplike m where
   -- | Range
   range :: Ord b => m a b -> Set b
 
-  -- |Domain restriction
+  -- | Domain restriction
   --
   (◁), (◃) :: Ord a => Set a -> m a b -> m a b
 
-  -- |Domain exclusion
+  -- | Domain exclusion
   --
   (⋪) :: Ord a => Set a -> m a b -> m a b
 
@@ -145,7 +145,7 @@ class Maplike m where
   -- | Union Override
   (⨃) :: (Ord a, Ord b) => m a b -> m a b -> m a b
 
-instance Maplike Map where
+instance Relation Map where
   singleton = Map.singleton
 
   dom = Map.keysSet
@@ -161,7 +161,7 @@ instance Maplike Map where
   d0 ∪ d1 = Map.union d0 d1
   d0 ⨃ d1 = d1 ∪ (Map.keysSet d1 ⋪ d0)
 
-instance Maplike PairSet where
+instance Relation PairSet where
   singleton a b = PairSet $ Set.singleton (a,b)
 
   dom = Set.map fst . unPairSet

--- a/specs/ledger/hs/src/Ledger/UTxO.hs
+++ b/specs/ledger/hs/src/Ledger/UTxO.hs
@@ -10,7 +10,7 @@ import Data.List (find)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (isJust)
 import qualified Data.Set as Set
-import Ledger.Core hiding ((◁), (⋪))
+import Ledger.Core hiding ((◁), (⋪), (∪))
 import Ledger.Signatures
 import Numeric.Natural (Natural)
 import Data.Map.Strict (Map)

--- a/specs/ledger/latex/blockchain-interface.tex
+++ b/specs/ledger/latex/blockchain-interface.tex
@@ -553,7 +553,7 @@ the end on an epoch.
             \var{pids_{keep}} \restrictdom \var{raus}\\
             \var{cps}\\
             \var{pids_{keep}} \restrictdom \var{vts}\\
-            \var{vs_{keep}}  \restrictdom \var{bvs}\\
+            \var{vs_{keep}}  \restrictdom \var{bvs'}\\
             \var{pids_{keep}} \restrictdom \var{pws}
           \end{array}
         \right)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/f2802079ba2c07c4d408e3c0aa000fc363792398/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/ff5fd5f33849be8a826506c34e5b0278f267f804/snapshot.yaml
 
 packages:
 - hs
@@ -9,4 +9,5 @@ packages:
 
 extra-deps:
 - sequence-0.9.8
+- tasty-hedgehog-0.2.0.0
 - tasty-hedgehog-coverage-0.1.0.0


### PR DESCRIPTION
This commit also introduces the `Maplike` class which provides some
functionality to write things abstracted over `Map a b` and `Set (a,b)`, albeit
the latter must be wrapped in a newtype.