### PR TITLE
Fix compilation error on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,6 @@ addons:
       - libgmp-dev
 
 before_install:
-# Run CI only on code changes. We use the convention that code feature branches
-# start with `haskell` and latex spec ones with `latex`.
-- if [[ ! ($TRAVIS_PULL_REQUEST_BRANCH =~ ^haskell.* ||
-           $TRAVIS_BRANCH =~ ^haskell.*)
-     ]]; then travis_terminate 0; fi
 # Download and unpack the stack executable
 - mkdir -p ~/.local/bin
 - export PATH=$HOME/.local/bin:$PATH

--- a/specs/chain/hs/test/Cardano/Spec/Chain/STS/Properties.hs
+++ b/specs/chain/hs/test/Cardano/Spec/Chain/STS/Properties.hs
@@ -20,7 +20,7 @@ slotsIncrease = property $ forAll trace >>= slotsIncreaseInTrace
 slotsIncreaseInTrace :: MonadTest m => Trace CHAIN -> m ()
 slotsIncreaseInTrace tr = assert $ slots == sortedSlots && nub slots == slots
   where blocks = traceSignals OldestFirst tr
-        slots = blocks ^.. traverse . bHeader . bSlot
+        slots = blocks ^.. traverse . bHeader . bhSlot
         sortedSlots = sort slots
 
 blockIssuersAreDelegates :: Property
@@ -37,5 +37,5 @@ blockIssuersAreDelegates =
              Just _ -> pure $! ()
              Nothing -> failure
            where
-             issuer = bk ^. bHeader . bIssuer
+             issuer = bk ^. bHeader . bhIssuer
              dm = st ^. disL . delegationMap


### PR DESCRIPTION
Before we ran Travis only on branches with `haskell` prefix, this prevented the compilation error to be caught. This also removes this behavior.