### PR TITLE
Add an example of the operational rules for a process registry

### DIFF
--- a/specs/semantics/hs/small-steps.cabal
+++ b/specs/semantics/hs/small-steps.cabal
@@ -72,6 +72,7 @@ test-suite examples
   hs-source-dirs:      test
   main-is:             examples/Main.hs
   other-modules:       Control.State.Transition.Examples.Register
+                     , Control.State.Transition.Examples.Registry
   type:                exitcode-stdio-1.0
   default-language:    Haskell2010
   build-depends:       base

--- a/specs/semantics/hs/small-steps.cabal
+++ b/specs/semantics/hs/small-steps.cabal
@@ -76,6 +76,7 @@ test-suite examples
   default-language:    Haskell2010
   build-depends:       base
                      , containers
+                     , hedgehog
                      --
                      , small-steps
   if (!flag(development))

--- a/specs/semantics/hs/small-steps.cabal
+++ b/specs/semantics/hs/small-steps.cabal
@@ -67,3 +67,16 @@ test-suite doctests
 
   if (!flag(development))
     ghc-options:      -Werror
+
+test-suite examples
+  hs-source-dirs:      test
+  main-is:             examples/Main.hs
+  other-modules:       Control.State.Transition.Examples.Register
+  type:                exitcode-stdio-1.0
+  default-language:    Haskell2010
+  build-depends:       base
+                     , containers
+                     --
+                     , small-steps
+  if (!flag(development))
+    ghc-options:      -Werror

--- a/specs/semantics/hs/small-steps.cabal
+++ b/specs/semantics/hs/small-steps.cabal
@@ -71,8 +71,8 @@ test-suite doctests
 test-suite examples
   hs-source-dirs:      test
   main-is:             examples/Main.hs
-  other-modules:       Control.State.Transition.Examples.Register
-                     , Control.State.Transition.Examples.Registry
+  other-modules:       Control.State.Transition.Examples.Registry
+                     , Control.State.Transition.Examples.RegistryModel
   type:                exitcode-stdio-1.0
   default-language:    Haskell2010
   build-depends:       base

--- a/specs/semantics/hs/src/Control/State/Transition/Generator.hs
+++ b/specs/semantics/hs/src/Control/State/Transition/Generator.hs
@@ -88,7 +88,8 @@ genTrace
   -> (Environment s -> State s -> Gen (Signal s))
   -> Gen (Trace s)
 genTrace env st aSigGen =
-  Gen.shrink shrinkTrace $ Gen.prune $ do
+  Gen.shrink shrinkTrace $ do
+  do
     d <- Gen.integral (linear 0 100)
     mkTrace env st <$> go d st []
   where
@@ -118,6 +119,19 @@ shrinkTrace tr = mkTrace env st0 <$> stSigs
     env = tr ^. traceEnv
     st0 = tr ^. traceInitState
     sigs = traceSignals OldestFirst tr
+
+shrinkSigSts
+  :: forall s
+   . STS s
+  => Environment s
+  -> State s
+  -> [(State s, Signal s)]
+  -> [[(State s, Signal s)]]
+shrinkSigSts env st0 sigs = stSigs
+  where
+    (_, stSigs) = partitionEithers applied
+    applied = ((runTrace @s env st0) . fmap snd) <$> (subsequences sigs)
+
 
   -- An alternate way to generate a trace of the size of the generator might
   -- be:

--- a/specs/semantics/hs/src/Control/State/Transition/Generator.hs
+++ b/specs/semantics/hs/src/Control/State/Transition/Generator.hs
@@ -87,9 +87,10 @@ genTrace
   -> State s
   -> (Environment s -> State s -> Gen (Signal s))
   -> Gen (Trace s)
-genTrace env st aSigGen = Gen.shrink shrinkTrace $ do -- TODO: use prune and shrink!
-  d <- Gen.integral (linear 0 100)
-  mkTrace env st <$> go d st []
+genTrace env st aSigGen =
+  Gen.shrink shrinkTrace $ Gen.prune $ do
+    d <- Gen.integral (linear 0 100)
+    mkTrace env st <$> go d st []
   -- Gen.sized $ \d -> mkTrace env st <$> go d st []
   where
     -- go d sti acc =

--- a/specs/semantics/hs/src/Control/State/Transition/Generator.hs
+++ b/specs/semantics/hs/src/Control/State/Transition/Generator.hs
@@ -34,11 +34,11 @@ where
 
 import Control.Lens ((^.))
 import Control.Monad (forM)
-import Data.Either (isRight, partitionEithers)
+import Data.Either (partitionEithers)
 import Data.List (subsequences)
 import Hedgehog (Gen)
 import qualified Hedgehog.Gen as Gen
-import Hedgehog.Range (Size(Size), unSize, linear)
+import Hedgehog.Range (Size(Size), linear)
 
 import Control.State.Transition
   ( Environment
@@ -91,22 +91,7 @@ genTrace env st aSigGen =
   Gen.shrink shrinkTrace $ Gen.prune $ do
     d <- Gen.integral (linear 0 100)
     mkTrace env st <$> go d st []
-  -- Gen.sized $ \d -> mkTrace env st <$> go d st []
   where
-    -- go d sti acc =
-    --   Gen.frequency [ (5, return acc)
-    --                 -- The probability of continue with the recursion depends
-    --                 -- on the size parameter of the generator. Here the
-    --                 -- constant factor is determined ad-hoc.
-    --                 , (unSize d * 2, do
-    --                       mStSig <- genSigSt @s env sti aSigGen
-    --                       case mStSig of
-    --                         Nothing ->
-    --                           go d sti acc
-    --                         Just (stNext, sig) ->
-    --                           go d stNext ((stNext, sig): acc)
-    --                   )
-    --                 ]
     go
       :: Int
       -> State s

--- a/specs/semantics/hs/test/Control/State/Transition/Examples/Register.hs
+++ b/specs/semantics/hs/test/Control/State/Transition/Examples/Register.hs
@@ -1,0 +1,150 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Control.State.Transition.Examples.Register where
+
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set, notMember)
+import qualified Data.Set as Set
+
+import Control.State.Transition
+
+type AThreadId = Int
+
+data SPAWN
+
+instance STS SPAWN where
+  type Environment SPAWN = ()
+
+  type State SPAWN = Set AThreadId
+
+  type Signal SPAWN = AThreadId
+
+  data PredicateFailure SPAWN = NoFailure deriving (Eq, Show)
+
+  initialRules = []
+
+  transitionRules =
+    [ do
+        TRC ((), tids, tid) <- judgmentContext
+        return $! Set.insert tid tids
+    ]
+
+data DOREG
+
+instance STS DOREG where
+  type Environment DOREG = Set AThreadId
+
+  type State DOREG = Map String AThreadId
+
+  type Signal DOREG = (String, AThreadId)
+
+  data PredicateFailure DOREG
+    = NameAlreadyRegistered String
+    | ThreadIdAlreadyRegistered AThreadId
+    | ThreadDoesntExist AThreadId
+    deriving (Eq, Show)
+
+  initialRules = []
+
+  transitionRules =
+    [ do
+        TRC (tids, regs, (n, t)) <- judgmentContext
+        t `notMember` tids ?! ThreadDoesntExist t
+        n `notElem` Map.keys regs ?! NameAlreadyRegistered n
+        t `notElem` Map.elems regs ?! ThreadIdAlreadyRegistered t
+        return $! Map.insert n t regs
+    ]
+
+
+data DOUNREG
+
+instance STS DOUNREG where
+  type Environment DOUNREG = ()
+
+  type State DOUNREG = Map String AThreadId
+
+  type Signal DOUNREG = String
+
+  data PredicateFailure DOUNREG
+    = NameNotRegistered String
+    deriving (Eq, Show)
+
+  initialRules = []
+
+  transitionRules =
+    [ do
+        TRC ((), regs, n) <- judgmentContext
+        n `elem` Map.keys regs ?! NameNotRegistered n
+        return $! Map.delete n regs
+    ]
+
+-- | WhereIs becomes a function!
+whereIs :: String -> Map String AThreadId -> Maybe AThreadId
+whereIs = Map.lookup
+
+data KILL
+
+data REGISTER
+
+data RegCmd
+  = Spawn AThreadId
+  | WhereIs String AThreadId
+  | Register String AThreadId
+  | Unregister String
+--  | KillThread AThreadId
+  deriving (Eq, Show)
+
+instance STS REGISTER where
+
+  type Environment REGISTER = ()
+
+  type State REGISTER
+    = ( Set AThreadId
+      , Map String AThreadId
+      )
+
+  type Signal REGISTER = RegCmd
+
+  data PredicateFailure REGISTER
+    = SpawnFailure (PredicateFailure SPAWN)
+    | DoRegFailure (PredicateFailure DOREG)
+    | DoUnregFailure (PredicateFailure DOUNREG)
+    | WhereIsFailure String
+    deriving (Eq, Show)
+
+  initialRules = []
+
+  transitionRules =
+    [ do
+        TRC ((), (tids, regs), cmd) <- judgmentContext
+        case cmd of
+          Spawn tid -> do
+            tids' <- trans @SPAWN $ TRC ((), tids, tid)
+            return $! (tids', regs)
+          Register n t -> do
+            regs' <- trans @DOREG $ TRC (tids, regs, (n, t))
+            return $! (tids, regs')
+          WhereIs n t -> do
+            case whereIs n regs of
+              Nothing -> do
+                failBecause $! WhereIsFailure n
+                return $! (tids, regs)
+              Just t' -> do
+                t == t' ?! undefined
+                return $! (tids, regs)
+          Unregister n -> do
+            regs' <- trans @DOUNREG $ TRC ((), regs, n)
+            return $! (tids, regs')
+
+    ]
+instance Embed SPAWN REGISTER where
+  wrapFailed = SpawnFailure
+
+instance Embed DOREG REGISTER where
+  wrapFailed = DoRegFailure
+
+instance Embed DOUNREG REGISTER where
+  wrapFailed = DoUnregFailure

--- a/specs/semantics/hs/test/Control/State/Transition/Examples/Registry.hs
+++ b/specs/semantics/hs/test/Control/State/Transition/Examples/Registry.hs
@@ -1,0 +1,59 @@
+-- | Copyright 2017-2019 QuviQ - Courtesy of John Hughes.
+--
+-- A simple local name service for threads... behaves like the Erlang
+-- process registry.
+--
+-- If you are doing the associated QuickCheck exercises, DO NOT READ
+-- THIS CODE!!! The exercise is one in black box testing.
+
+module Control.State.Transition.Examples.Registry where
+
+import Data.IORef
+import Control.Monad
+import Control.Concurrent
+import System.IO.Unsafe
+import GHC.Conc
+
+alive :: ThreadId -> IO Bool
+alive tid = do
+  s <- threadStatus tid
+  return $ s /= ThreadFinished && s /= ThreadDied
+
+{-# NOINLINE registry #-}
+registry :: IORef [(String,ThreadId)]
+registry = unsafePerformIO (newIORef [])
+
+whereis :: String -> IO (Maybe ThreadId)
+whereis name = do
+  reg <- readRegistry
+  return $ lookup name reg
+
+register :: String -> ThreadId -> IO ()
+register name tid = do
+  ok <- alive tid
+  reg <- readRegistry
+  if ok && name `notElem` map fst reg && tid `notElem` map snd reg
+    then atomicModifyIORef registry $ \reg' ->
+           if name `notElem` map fst reg' && tid `notElem` map snd reg'
+             then ((name,tid):reg',())
+             else (reg',badarg)
+    else badarg
+
+unregister :: String -> IO ()
+unregister name = do
+  reg <- readRegistry
+  if name `elem` map fst reg
+    then atomicModifyIORef registry $ \reg' ->
+           (filter ((/=name).fst) reg',
+            ())
+    else badarg
+
+readRegistry :: IO [(String, ThreadId)]
+readRegistry = do
+  reg <- readIORef registry
+  garbage <- filterM (fmap not.alive) (map snd reg)
+  atomicModifyIORef' registry $ \reg' ->
+    let reg'' = filter ((`notElem` garbage).snd) reg' in (reg'',reg'')
+
+badarg :: a
+badarg = error "bad argument"

--- a/specs/semantics/hs/test/Control/State/Transition/Examples/RegistryModel.hs
+++ b/specs/semantics/hs/test/Control/State/Transition/Examples/RegistryModel.hs
@@ -138,8 +138,8 @@ instance STS REGISTRY where
 
   data PredicateFailure REGISTRY
     = SpawnFailure (PredicateFailure SPAWN)
-    | DoRegFailure (PredicateFailure REGISTER)
-    | DoUnregFailure (PredicateFailure UNREGISTER)
+    | RegFailure (PredicateFailure REGISTER)
+    | UnregFailure (PredicateFailure UNREGISTER)
     | WhereIsFailure String
     deriving (Eq, Show)
 
@@ -174,13 +174,13 @@ instance Embed SPAWN REGISTRY where
   wrapFailed = SpawnFailure
 
 instance Embed REGISTER REGISTRY where
-  wrapFailed = DoRegFailure
+  wrapFailed = RegFailure
 
 instance Embed UNREGISTER REGISTRY where
-  wrapFailed = DoUnregFailure
+  wrapFailed = UnregFailure
 
 allNames :: Set String
-allNames = ["a", "b", "c", "d", "e"]
+allNames = ["a", "b", "c", "d", "e", "f", "g", "h"]
 
 instance HasTrace REGISTRY where
   initEnvGen = return ()

--- a/specs/semantics/hs/test/Control/State/Transition/Examples/RegistryModel.hs
+++ b/specs/semantics/hs/test/Control/State/Transition/Examples/RegistryModel.hs
@@ -223,7 +223,7 @@ instance HasTrace REGISTRY where
 
 prop_generatedTracesAreValid :: Property
 prop_generatedTracesAreValid =
-  withTests 300 $ property $ do
+  withTests 1000 $ property $ do
     tr <- forAll trace
     _ <- evalIO cleanUp
     executeTrace tr

--- a/specs/semantics/hs/test/Control/State/Transition/Examples/RegistryModel.hs
+++ b/specs/semantics/hs/test/Control/State/Transition/Examples/RegistryModel.hs
@@ -5,6 +5,38 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+
+-- | Model of a process registry.
+--
+-- The registry is a simple local name service for threads. See the file
+-- @Registry.hs@ for more information.
+--
+-- In this model we test three operations of the registry:
+--
+-- >>> register name tid
+--
+-- which registers the given thread-id under the given name.
+--
+-- >>> unregister name
+---
+--- which unregisters the thread with the given name.
+--
+-- >>> whereis name
+--
+-- which returns the thread-id that was registered under that name, if any.
+--
+-- The registry is modeled as a state transition system, using
+-- operational-semantics rules, encoding using the 'STS' framework.
+--
+-- The registry is tested using property based tests using two approaches:
+--
+-- - In 'prop_generatedTracesAreValid' we use property based testing without
+--   state machines. Traces are generated, and then executed, checking the
+--   results at each step.
+--
+-- - In 'prop_RegistryImplementsModel' we use state machine testing, where the
+--   'STS' framework is used to compute the update to the abstract state.
+--
 module Control.State.Transition.Examples.RegistryModel where
 
 import Control.Arrow (second)
@@ -126,8 +158,6 @@ instance STS UNREGISTER where
 whereIs :: String -> Map String AThreadId -> Maybe AThreadId
 whereIs = Map.lookup
 
-data KILL
-
 data REGISTRY
 
 data RegCmd
@@ -135,7 +165,6 @@ data RegCmd
   | Register String AThreadId
   | Unregister String
   | WhereIs String (Maybe AThreadId)
---  | KillThread AThreadId
   deriving (Eq, Show)
 
 instance STS REGISTRY where

--- a/specs/semantics/hs/test/examples/Main.hs
+++ b/specs/semantics/hs/test/examples/Main.hs
@@ -1,0 +1,5 @@
+
+module Main where
+
+main :: IO ()
+main = print "WIP"

--- a/specs/semantics/hs/test/examples/Main.hs
+++ b/specs/semantics/hs/test/examples/Main.hs
@@ -1,5 +1,8 @@
-
 module Main where
 
+import Control.Monad (void)
+
+import qualified Control.State.Transition.Examples.RegistryModel as RegistryModel
+
 main :: IO ()
-main = print "WIP"
+main = void $ RegistryModel.tests


### PR DESCRIPTION
This PR adds an example on how we can use operational rules for modelling a process registry, and how this can be used to test the actual system via two mechanisms:

- Normal property based tests: we check that the execution of generated traces do not lead to a mismatch between the trace and the SUT output.
- State machine testing: the STS specification is used to update the model after each action in the state machine.

The two approaches described above are quite similar, the advantage of the latter is that it reuses a stable library, instead of our version. 

For this particular example, state machine testing seems to take more time to test. However once a counterexample is found, a minimal trace can be produced in a small number of shrinks (`5` to `10`). The former approach requires the use of the maximum allowed number of shrinks (`1000`).

The idea of this example is to:

- Show how operational-semantics can be used to specify and test a system.
- Provide us with some common ground (and running example) to discuss which approach we want to take regarding the future tests we will write for `cardano-chain`, which should check that the implementation and the specification match.

Other important changes:

- Implement a shrink function for traces, where actions are removed for the failing trace, to check whether that still gives a failure. This function is still not optimal, but it is still substantially better than the default shrink we get from `hedgehog`, since it will try to shrink the integers that determine the trace length.