### PR TITLE
Dnadales/266 relate moving window size and slots per epoch

### DIFF
--- a/specs/chain/hs/src/Cardano/Spec/Chain/STS/Rule/BBody.hs
+++ b/specs/chain/hs/src/Cardano/Spec/Chain/STS/Rule/BBody.hs
@@ -10,6 +10,14 @@ import Data.Set (Set)
 import Control.State.Transition
 import Ledger.Core
 import Ledger.Delegation
+  ( DELEG
+  , DIState
+  , DSEnv(DSEnv)
+  , _dSEnvAllowedDelegators
+  , _dSEnvEpoch
+  , _dSEnvSlot
+  , _dSEnvStableAfter
+  )
 import Ledger.Update
 
 import Cardano.Spec.Chain.STS.Block
@@ -44,7 +52,7 @@ instance STS BBODY where
               { _dSEnvAllowedDelegators = gks
               , _dSEnvEpoch = e
               , _dSEnvSlot = s
-              , _dSEnvLiveness = pps ^. dLiveness
+              , _dSEnvStableAfter = pps ^. stableAfter
               }
         ds' <- trans @DELEG
                      $ TRC (diEnv, ds, b ^. bBody . bDCerts)

--- a/specs/chain/hs/src/Cardano/Spec/Chain/STS/Rule/BBody.hs
+++ b/specs/chain/hs/src/Cardano/Spec/Chain/STS/Rule/BBody.hs
@@ -8,7 +8,22 @@ import Control.Lens ((^.))
 import Data.Set (Set)
 
 import Control.State.Transition
+  ( Embed
+  , Environment
+  , PredicateFailure
+  , STS
+  , Signal
+  , State
+  , TRC(TRC)
+  , (?!)
+  , initialRules
+  , judgmentContext
+  , trans
+  , transitionRules
+  , wrapFailed
+  )
 import Ledger.Core
+  (Epoch, Slot, VKeyGenesis)
 import Ledger.Delegation
   ( DELEG
   , DIState
@@ -18,9 +33,9 @@ import Ledger.Delegation
   , _dSEnvSlot
   , _dSEnvStableAfter
   )
-import Ledger.Update
+import Ledger.Update (PParams, maxBkSz, stableAfter)
 
-import Cardano.Spec.Chain.STS.Block
+import Cardano.Spec.Chain.STS.Block (Block, bBody, bDCerts, bSize)
 
 data BBODY
 

--- a/specs/chain/hs/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
+++ b/specs/chain/hs/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
@@ -147,8 +147,9 @@ instance HasTrace CHAIN where
     mTxSz <- Gen.integral (Range.constant 0 4000000)
     mPSz <- Gen.integral (Range.constant 0 4000000)
 
-    -- Chain stability.
-    k <- Gen.integral (Range.linear 1 10)
+    -- Chain stability. We set this to an integer between 1 and twice the value
+    -- chosen for the Byron release.
+    k <- Gen.integral (Range.constant 1 (2160 * 2))
 
     -- The percentage of the slots will typically be between 1/5 and 1/4,
     -- however we want to stretch that range a bit for testing purposes.

--- a/specs/chain/latex/blockchain-spec.tex
+++ b/specs/chain/latex/blockchain-spec.tex
@@ -536,8 +536,8 @@ block header, since the block body is entirely concerned with the ledger.
 \newcommand{\BSCState}{\type{BSCState}}
 
 To guard against the compromise of a minority of the genesis keys,
-we require that in the rolling window of the last $w$ blocks, the number of
-blocks signed by keys that $sk_s$ delegated to is no more than a threshold $w
+we require that in the rolling window of the last $k$ blocks, the number of
+blocks signed by keys that $sk_s$ delegated to is no more than a threshold $k
 \cdot t$, where $t$ is a constant that will be picked in the range
 $1/5 \leq t \leq 1/4$. Initial research suggests setting $t=0.22$ as a good
 value. Specifically, given $K=2160$, we would allow a single genesis key to
@@ -548,7 +548,7 @@ rejected. See Appendix \ref{apdx:calculating-t} for the background on this value
   \emph{Protocol parameters}
   \begin{equation*}
     \begin{array}{r@{~\partialf~}l!{~\in~\ProtParams~}r}
-      \pp{blockSignatureCountWindow} & \mathbb{N} & \text{Block signature count window size} \\
+      \pp{stableAfter} & \mathbb{N} & \text{Chain stability parameter} \\
       \pp{blockSignatureCountThreshold} & \left[\frac{1}{5}, \frac{1}{4}\right] & \text{Block signature count threshold} \\
     \end{array}
   \end{equation*}
@@ -562,7 +562,7 @@ more than its allowed threshold of blocks. If there are no delegators for the
 given key, or if there is more than one delegator, the rule will fail to trigger.
 %
 We then update the sequence of signers, and drop those elements that fall
-outside the size of the moving window $w$.
+outside the size of the moving window ($k$).
 
 \begin{figure}[ht]
   \emph{Block signature count environments}
@@ -589,10 +589,10 @@ outside the size of the moving window $w$.
   \begin{equation*}
     \inference
     {
-      \pp{blockSignatureCountWindow} \partialf \var{w} \in pps & \pp{blockSignatureCountThreshold} \partialf \var{t} \in pps \\
+      \pp{stableAfter} \partialf \var{k} \in pps & \pp{blockSignatureCountThreshold} \partialf \var{t} \in pps \\
       \{\var{vk_g}\} \leteq (\fun{dms} ~ \var{ds}) \restrictrange \{\var{vk_d}\}
-      & \var{sgs'} \leteq \var{sgs};_w {vk_g} &
-      \size{\fun{filter}~(=\var{vk_g})~\var{sgs'}} \leq w \cdot t \\
+      & \var{sgs'} \leteq \var{sgs};_k {vk_g} &
+      \size{\fun{filter}~(=\var{vk_g})~\var{sgs'}} \leq k \cdot t \\
     }
     {
       \left(
@@ -1306,14 +1306,14 @@ body according to the rules in figures \ref{fig:rules:bhead} and
   such an invalid chain being produced by the old procedure of randomly selecting
   the slot leaders for each slot. Given the Cardano chain is still federated, the
   likelihood of this happening is the same for each of the 7 stakeholders, and we
-  may model the number of selected slots within a $w$-slot window $X$ as a binomial
-  distribution $X \sim \mathrm{B}\left(w, \frac{1}{7}\right)$.
+  may model the number of selected slots within a $k$-slot window $X$ as a binomial
+  distribution $X \sim \mathrm{B}\left(k, \frac{1}{7}\right)$.
 
-  In each epoch of size $n$ blocks, there are $n-w+1$ such $w$-block windows.
+  In each epoch of size $n$ blocks, there are $n-k+1$ such $w$-block windows.
   Boole's inequality gives us that the likelihood of exceeding the threshold in
   any one of these windows is bounded above by the sum of the likelihoods for each
   window. We may thus consider that the probability of a given stakeholder
-  violating the threshold in an epoch to be bounded by $(n-w+1)\cdot P(X > t*w)$.
+  violating the threshold in an epoch to be bounded by $(n-k+1)\cdot P(X > t*k)$.
   Appealing to Boole's inequality again, we may multiply this by the number of
   epochs and the number of stakeholders to give a bound for the likelihood of
   generating an invalid chain.

--- a/specs/chain/latex/blockchain-spec.tex
+++ b/specs/chain/latex/blockchain-spec.tex
@@ -1313,7 +1313,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
   may model the number of selected slots within a $k$-slot window $X$ as a binomial
   distribution $X \sim \mathrm{B}\left(k, \frac{1}{7}\right)$.
 
-  In each epoch of size $n$ blocks, there are $n-k+1$ such $w$-block windows.
+  In each epoch of size $n$ blocks, there are $n-k+1$ such $k$-block windows.
   Boole's inequality gives us that the likelihood of exceeding the threshold in
   any one of these windows is bounded above by the sum of the likelihoods for each
   window. We may thus consider that the probability of a given stakeholder

--- a/specs/chain/latex/blockchain-spec.tex
+++ b/specs/chain/latex/blockchain-spec.tex
@@ -370,6 +370,9 @@ implementation may of course choose a more compact representation for this
 partial function that only records the changes in epoch length, rather than
 storing a length for each epoch.
 
+It is also worth noticing that in the Byron era, the number of slots per-epoch
+is fixed to $10 \cdot k$, where $k$ is the chain stability parameter.
+
 Figure \ref{fig:rules:epoch} determines when an epoch change has occurred and
 updates the update state to the correct version.
 
@@ -540,9 +543,10 @@ we require that in the rolling window of the last $k$ blocks, the number of
 blocks signed by keys that $sk_s$ delegated to is no more than a threshold $k
 \cdot t$, where $t$ is a constant that will be picked in the range
 $1/5 \leq t \leq 1/4$. Initial research suggests setting $t=0.22$ as a good
-value. Specifically, given $K=2160$, we would allow a single genesis key to
-issue (via delegates) $475$ blocks, but a $476^{\text{th}}$ block would be
-rejected. See Appendix \ref{apdx:calculating-t} for the background on this value.
+value. Specifically, given $k=2160$, we would allow a single genesis key to
+issue (via delegates) $475$ blocks (since $2160 \cdot 0.22 = 475.2$), but a
+$476^{\text{th}}$ block would be rejected. See Appendix
+\ref{apdx:calculating-t} for the background on this value.
 
 \begin{figure}[ht]
   \emph{Protocol parameters}
@@ -1313,7 +1317,10 @@ body according to the rules in figures \ref{fig:rules:bhead} and
   Boole's inequality gives us that the likelihood of exceeding the threshold in
   any one of these windows is bounded above by the sum of the likelihoods for each
   window. We may thus consider that the probability of a given stakeholder
-  violating the threshold in an epoch to be bounded by $(n-k+1)\cdot P(X > t*k)$.
+  violating the threshold in an epoch to be bounded by
+
+  $$(n-k+1)\cdot P(X > t*k)$$
+
   Appealing to Boole's inequality again, we may multiply this by the number of
   epochs and the number of stakeholders to give a bound for the likelihood of
   generating an invalid chain.

--- a/specs/ledger/hs/src/Ledger/Core.hs
+++ b/specs/ledger/hs/src/Ledger/Core.hs
@@ -92,9 +92,10 @@ newtype Slot = Slot { unSlot :: Word64 }
 
 -- | A number of slots.
 --
---   We use this newtype to distinguish between a cardinal slot and a relative
---   period of slots.
-newtype SlotCount = SlotCount Word64
+--  We use this newtype to distinguish between a cardinal slot and a relative
+--  period of slots, and also to distinguish between number of slots and number
+--  of blocks.
+newtype SlotCount = SlotCount { unSlotCount :: Word64}
   deriving (Eq, Ord, Num, Show)
 
 -- | Add a slot count to a slot.
@@ -108,6 +109,9 @@ minusSlot :: Slot -> SlotCount -> Slot
 minusSlot (Slot m) (SlotCount n)
   | m <= n    = Slot 0
   | otherwise = Slot $ m - n
+
+newtype BlockCount = BlockCount { unBlockCount :: Word64}
+  deriving (Eq, Ord, Num, Show)
 
 ---------------------------------------------------------------------------------
 -- Domain restriction and exclusion

--- a/specs/ledger/hs/src/Ledger/Core.hs
+++ b/specs/ledger/hs/src/Ledger/Core.hs
@@ -110,7 +110,7 @@ minusSlot (Slot m) (SlotCount n)
   | m <= n    = Slot 0
   | otherwise = Slot $ m - n
 
-newtype BlockCount = BlockCount { unBlockCount :: Word64}
+newtype BlockCount = BlockCount { unBlockCount :: Word64 }
   deriving (Eq, Ord, Num, Show)
 
 ---------------------------------------------------------------------------------

--- a/specs/ledger/hs/src/Ledger/Update.hs
+++ b/specs/ledger/hs/src/Ledger/Update.hs
@@ -11,7 +11,7 @@
 
 module Ledger.Update where
 
-import Control.Lens
+import Control.Lens hiding (_2)
 import Control.State.Transition
 import Data.Ix (inRange)
 import Data.List (foldl', partition)
@@ -39,11 +39,6 @@ data PParams = PParams -- TODO: this should be a module of @cs-ledger@.
   -- ^ Maximum (abstract) transaction size in words.
   , _maxPropSz :: Natural
   -- ^ Maximum (abstract) update proposal size in words.
-  , _dLiveness :: Core.SlotCount
-  -- ^ Delegation liveness parameter: number of slots it takes a delegation
-  -- certificate to take effect.
-  , _bkSgnCntW :: Int
-  -- ^ Size of the moving window to count signatures.
   , _bkSgnCntT :: Double
   -- ^ Fraction [0, 1] of the blocks that can be signed by any given key in a
   -- window of lenght '_bkSgnCntW'. This value will be typically between 1/5
@@ -58,7 +53,7 @@ data PParams = PParams -- TODO: this should be a module of @cs-ledger@.
   -- ^ Update proposal confirmation threshold (number of votes)
   , _upAdptThd :: Int
   -- ^ Update adoption threshold (number of block issuers)
-  , _chainStability :: Core.SlotCount
+  , _stableAfter :: Core.BlockCount
   -- ^ Chain stability parameter
   } deriving (Eq, Ord, Show)
 
@@ -476,7 +471,7 @@ data UPEND
 
 instance STS UPEND where
   type Environment UPEND =
-    ( Core.SlotCount
+    ( Core.BlockCount
     , Core.Slot
     , (ProtVer, PParams)
     , Map UpId Core.Slot
@@ -504,8 +499,8 @@ instance STS UPEND where
             , (bv, _vk)
             ) <- judgmentContext
         case (Map.lookup bv (invertBijection $ fst <$> rpus)) of
-          Just pid -> do
-            pid `Map.notMember` (Map.filter (<= sn `Core.minusSlot` (2*k)) cps) ?! NotAFailure
+          Just pid ->
+            pid `Map.notMember` (Map.filter (<= sn `Core.minusSlot` _2 k) cps) ?! NotAFailure
           Nothing -> True ?! NotAFailure
         return (fads, bvs)
     , do
@@ -517,7 +512,7 @@ instance STS UPEND where
         (not $ canAdopt pps bvs' bv) ?! CanAdopt
         case (Map.lookup bv (invertBijection $ fst <$> rpus)) of
           Just pid ->
-            pid `Map.member` (Map.filter (<= sn `Core.minusSlot` (2*k)) cps) ?! ProtVerTooRecent
+            pid `Map.member` (Map.filter (<= sn `Core.minusSlot` _2 k) cps) ?! ProtVerTooRecent
           Nothing -> True ?! ProtVerUnknown
         return (fads, bvs')
     , do
@@ -531,7 +526,7 @@ instance STS UPEND where
           Just pid -> do
             -- This is safe by virtue of the fact we've just inverted the map and found this there
             let (_, ppsc) = fromJust $ Map.lookup pid rpus
-            pid `Map.member` (Map.filter (<= sn `Core.minusSlot` (2*k)) cps) ?! ProtVerTooRecent
+            pid `Map.member` (Map.filter (<= sn `Core.minusSlot` _2 k) cps) ?! ProtVerTooRecent
             fads' <- trans @FADS $ TRC ((), fads, (sn, (bv, ppsc)))
             return (fads', bvs')
           Nothing -> do
@@ -539,6 +534,10 @@ instance STS UPEND where
             return (fads, bvs)
 
     ]
+    where
+
+_2 :: Core.BlockCount -> Core.SlotCount
+_2 = Core.SlotCount . (2 *) . Core.unBlockCount
 
 instance Embed FADS UPEND where
   wrapFailed = error "No possible failures in FADS"
@@ -684,7 +683,7 @@ instance STS UPIEND where
               , bvs
               , pws)
             , (bv,vk)) <- judgmentContext
-        let k = pps ^. chainStability
+        let k = pps ^. stableAfter
             u = pps ^. upTtl
         (fads', bvs') <- trans @UPEND $ TRC ((k, sn, (pv, pps), cps, rpus), (fads, bvs), (bv,vk))
         let pidskeep = dom (Map.filter (>= (sn `Core.minusSlot` u)) pws) `Set.union` dom cps
@@ -711,7 +710,7 @@ data PVBUMP
 
 instance STS PVBUMP where
   type Environment PVBUMP =
-    ( Core.SlotCount
+    ( Core.BlockCount
     , Core.Slot
     )
   type State PVBUMP =
@@ -734,7 +733,7 @@ instance STS PVBUMP where
     , do
         TRC ((k, sn), (ep, (pv, pps), fads), en) <- judgmentContext
         ep < en ?! OldEpoch
-        return $ case (partition (\(s, _) -> s <= sn `Core.minusSlot` (2*k)) fads) of
+        return $ case (partition (\(s, _) -> s <= sn `Core.minusSlot` _2 k) fads) of
           ([], _) -> (ep, (pv, pps), fads)
           ((_, (pvc, ppsc)):_, rest) -> (en, (pvc, ppsc), rest)
     ]
@@ -764,7 +763,7 @@ instance STS UPIEC where
               , bvs
               , pws)
             , en) <- judgmentContext
-        let k = pps ^. chainStability
+        let k = pps ^. stableAfter
         (e', (pv', pps'), fads') <- trans @PVBUMP $ TRC ((k, sn), (ep, (pv, pps), fads), en)
         let pidskeep = Set.fromList [ pid | pid <- Set.toList . foldl' Set.union Set.empty
                                      . Map.elems . Map.filterWithKey (\pvi _ -> pv' < pvi)

--- a/specs/ledger/hs/test/Ledger/Delegation/Examples.hs
+++ b/specs/ledger/hs/test/Ledger/Delegation/Examples.hs
@@ -17,7 +17,7 @@ import Ledger.Core
   , Owner(Owner)
   , Sig(Sig)
   , Slot(Slot)
-  , SlotCount(SlotCount)
+  , BlockCount(BlockCount)
   , VKey(VKey)
   , VKeyGenesis(VKeyGenesis)
   , owner
@@ -54,7 +54,7 @@ deleg =
     ]
 
   , testGroup "Scheduling"
-    [ testCase "Example 0" $ checkTrace @SDELEG (DSEnv [gk 0, gk 1, gk 2] (e 8) (s 2) (sc 10)) $
+    [ testCase "Example 0" $ checkTrace @SDELEG (DSEnv [gk 0, gk 1, gk 2] (e 8) (s 2) (bc 5)) $
 
       pure (DSState [] [])
 
@@ -78,8 +78,9 @@ deleg =
     gk :: Natural -> VKeyGenesis
     gk = VKeyGenesis . k
 
-    sc :: Word64 -> SlotCount
-    sc = SlotCount
+    bc :: Word64 -> BlockCount
+    bc = BlockCount
+
 
     e :: Word64 -> Epoch
     e = Epoch

--- a/specs/ledger/latex/blockchain-interface.tex
+++ b/specs/ledger/latex/blockchain-interface.tex
@@ -54,12 +54,12 @@
     \label{eq:rule:delegation-interface}
     \inference
     {
-      \var{certificateLiveness} \mapsto d \in \var{pps} \\
+      \var{stableAfter} \mapsto k \in \var{pps} & d \leteq 2 \cdot k \\
       {\begin{array}{l}
          \mathcal{K} \\
          e\\
          s\\
-         d
+         k
        \end{array}}
       \vdash
       {
@@ -132,30 +132,6 @@
   \caption{Delegation interface rules}
   \label{fig:rules:delegation-interface}
 \end{figure}
-
-\subsubsection{Delegation interface functions}
-\label{sec:delegation-interface-functions}
-
-\begin{figure}[htb]
-  \begin{align*}
-    & \fun{delegates} \in \DIState \to (\VKeyGen \times \VKey) \to \Bool & \text{delegation relationship}\\
-    & \fun{delegates}~s~(\var{vk_s}, \var{vk_d}) = \var{vk_s} \mapsto \var{vk_d} \in (\var{dms}~s)\\
-    \nextdef
-    & \fun{initialDS} \in \VKeyGen \to \DIState & \text{initial delegation state}\\
-    & \fun{initialDS}~\var{ks} =
-      \left(
-      \begin{array}{l}
-        \var{ks} \mapsto \var{ks}\\
-        \emptyset\\
-        \epsilon\\
-        \emptyset\\
-      \end{array}
-      \right)
-  \end{align*}
-  \caption{Delegation interface functions}
-\end{figure}
-
-\clearpage
 
 \subsection{Update-proposals interface}
 \label{sec:update-proposals-interface}
@@ -506,7 +482,7 @@ the end on an epoch.
           \end{array}
         \right)
       }\\
-      \var{chainStability} \mapsto k \in  \var{pps} &
+      \var{stableAfter} \mapsto k \in  \var{pps} &
       \var{upropTTL} \mapsto u \in \var{pps} \\
       {
         \begin{array}{r@{~=~}l}
@@ -707,7 +683,7 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
     \label{eq:rule:upi-ec}
     \inference
     {
-      \var{chainStability} \mapsto k \in  \var{pps} &
+      \var{stableAfter} \mapsto k \in  \var{pps} &
       {\begin{array}{l}
          k\\
          s_n

--- a/specs/ledger/latex/delegation.tex
+++ b/specs/ledger/latex/delegation.tex
@@ -73,7 +73,7 @@ $\trans{sdeleg}{\wcard}$ are presented in
         \mathcal{K} & \powerset{\VKeyGen} & \text{allowed delegators}\\
         \var{e} & \Epoch & \text{epoch}\\
         \var{s} & \Slot & \text{slot}\\
-        \var{d} & \SlotCount & \text{certificate liveness parameter}
+        \var{k} & \SlotCount & \text{chain stability parameter}
       \end{array}
     \right)
   \end{equation*}
@@ -129,14 +129,14 @@ $\trans{sdeleg}{\wcard}$ are presented in
       & \verify{vk_s}{\serialised{\dbody{c}}}{\sigma} & vk_s \in \mathcal{K}\\ ~ \\
       (\var{vk_s},~ \var{vk_d}) = \dwho{c} & e_d = \depoch{c}
       & (e_d,~ \var{vk_s}) \notin \var{eks} & e \leq e_d \\ ~ \\
-      (s + d,~ (\var{vk_s},~ \wcard)) \notin \var{sds}\\
+      d \leteq 2 \cdot k & (s + d,~ (\var{vk_s},~ \wcard)) \notin \var{sds}\\
     }
     {
       {\begin{array}{l}
        \mathcal{K}\\
         e\\
         s\\
-        d
+        k
       \end{array}}
       \vdash
       {

--- a/specs/ledger/latex/frontmatter.tex
+++ b/specs/ledger/latex/frontmatter.tex
@@ -1,5 +1,5 @@
 \hypersetup{
-  pdftitle={A Simplified Formal Specification of a UTxO Ledger},
+  pdftitle={A Formal Specification of the Cardano Ledger (Byron Release)},
   breaklinks=true,
   bookmarks=true,
   colorlinks=false,

--- a/specs/ledger/latex/ledger-spec.tex
+++ b/specs/ledger/latex/ledger-spec.tex
@@ -1,4 +1,5 @@
 \documentclass[11pt,a4paper]{article}
+\usepackage[utf8]{inputenc}
 \usepackage[margin=2.5cm]{geometry}
 \usepackage{iohk}
 \usepackage{microtype}

--- a/specs/ledger/latex/update-mechanism.tex
+++ b/specs/ledger/latex/update-mechanism.tex
@@ -138,8 +138,9 @@ this specification can be extended to incorporate the research results.
   \label{fig:defs:update-proposals}
 \end{figure}
 
-The set of protocol parameters ($\ProtPm$) is assumed to contain the following keys, which
-correspond with fields of the current `BlockVersionData` structure:
+The set of protocol parameters ($\ProtPm$) is assumed to contain the following
+keys, some of which correspond with fields of the current `BlockVersionData`
+structure:
 \begin{itemize}
 \item Slot duration: $\var{slotDuration}$
 \item Maximum block size: $\var{maxBlockSize}$
@@ -152,9 +153,9 @@ correspond with fields of the current `BlockVersionData` structure:
 \item Update adoption threshold: $\var{upAdptThd}$. This would correspond with
   `srInitThd` in `SoftForkRule`, if we set `srMinThd` to `srInitThd` and
   `srThdDecrement` to $0$.
-\item Chain stability parameter: $\var{chainStabilityParameter}$.
+\item Chain stability parameter: $\var{stableAfter}$.
 \item Update proposal time-to-live: $\var{upropTTL}$.
-\item Certificate liveness: $\var{certificateLiveness}$.
+\item Delegation certificate liveness: $\var{certificateLiveness}$.
 \end{itemize}
 In addition we make use of the $\var{cfmThd}$ key, which determines the portion
 of the stakeholders that have to vote for a proposal to consider it confirmed.

--- a/specs/ledger/latex/update-mechanism.tex
+++ b/specs/ledger/latex/update-mechanism.tex
@@ -155,7 +155,6 @@ structure:
   `srThdDecrement` to $0$.
 \item Chain stability parameter: $\var{stableAfter}$.
 \item Update proposal time-to-live: $\var{upropTTL}$.
-\item Delegation certificate liveness: $\var{certificateLiveness}$.
 \end{itemize}
 In addition we make use of the $\var{cfmThd}$ key, which determines the portion
 of the stakeholders that have to vote for a proposal to consider it confirmed.


### PR DESCRIPTION
In the current version of the spec we have parameters which in practice are all related to `k`. It does not make sense to keep this relation implicit, since this introduces unnecessary complexity in our spec and in our models. 

This PR makes the relation between moving-window-size, slots-per-epoch, and delegation-certificate-liveness explicit.

Closes #266.
