### PR TITLE
Issue #276: Allows for using chain STS rules with a polymorphic block

### DIFF
--- a/specs/chain/hs/src/Cardano/Spec/Consensus/Block.hs
+++ b/specs/chain/hs/src/Cardano/Spec/Consensus/Block.hs
@@ -56,3 +56,18 @@ instance Block CBM.Block where
 
   bHeader b = b ^. CBM.bHeader
   bBody   b = b ^. CBM.bBody
+
+
+-- | Turns a generic block to a concrete 'CBM.Block'
+concretiseBlock :: Block b => b -> CBM.Block
+concretiseBlock block = CBM.Block
+  { CBM._bHeader = CBM.MkBlockHeader
+      { CBM._bhPrevHash = bhPrevHash (bHeader block)
+      , CBM._bhSlot     = bhSlot     (bHeader block)
+      , CBM._bhIssuer   = bhIssuer   (bHeader block)
+      , CBM._bhSig      = bhSig      (bHeader block)
+      }
+  , CBM._bBody = CBM.BlockBody
+      { CBM._bDCerts    =  bbCerts   (bBody block)
+      }
+  }


### PR DESCRIPTION
As discussed in the issue #276, to be able to use the STS rules for `cs-blockchain` (the Byron era chain), this PR provides a function that converts a polymorphic block into the concrete block type used by the top-level STS for the chain.

Closes #276.