### PR TITLE
Fix: Various features of the nix build.

### DIFF
--- a/docs/delegation_design_spec/Makefile
+++ b/docs/delegation_design_spec/Makefile
@@ -18,7 +18,7 @@ all: $(DOCNAME).pdf
 
 ##
 ## CUSTOM BUILD RULES
-## 
+##
 
 ##
 ## MAIN LATEXMK RULE
@@ -39,3 +39,8 @@ watch: $(DOCNAME).tex
 
 clean:
 	latexmk -CA
+
+install:
+	mkdir -pv ${out}/nix-support/
+	cp $(DOCNAME).pdf ${out}/
+	echo "doc-pdf $(DOCNAME)" > ${out}/nix-support/hydra-build-products

--- a/specs/chain/hs/default.nix
+++ b/specs/chain/hs/default.nix
@@ -1,4 +1,4 @@
 let
-  pkgs = import ../../../pkgs.nix;
+  pkgs = import ../../../default.nix {};
 in
-  pkgs.haskell.packages.ghc861.cs-blockchain
+  pkgs.nix-tools.libs.cs-blockchain

--- a/specs/chain/hs/shell.nix
+++ b/specs/chain/hs/shell.nix
@@ -1,5 +1,0 @@
-let
-  pkgs = import ../../../pkgs.nix;
-in pkgs.lib.overrideDerivation ((import ./.).env) (old: {
-  nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.cabal-install pkgs.haskell.packages.ghc861.ghcid ];
-})

--- a/specs/ledger/hs/default.nix
+++ b/specs/ledger/hs/default.nix
@@ -1,4 +1,4 @@
 let
-  pkgs = import ../../../pkgs.nix;
+  pkgs = import ../../../default.nix {};
 in
-  pkgs.haskell.packages.ghc861.cs-ledger
+  pkgs.nix-tools.libs.cs-ledger

--- a/specs/ledger/hs/shell.nix
+++ b/specs/ledger/hs/shell.nix
@@ -1,5 +1,0 @@
-let
-  pkgs = import ../../../pkgs.nix;
-in pkgs.lib.overrideDerivation ((import ./.).env) (old: {
-  nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.cabal-install pkgs.haskell.packages.ghc861.ghcid ];
-})

--- a/specs/semantics/hs/default.nix
+++ b/specs/semantics/hs/default.nix
@@ -1,4 +1,4 @@
 let
-  pkgs = import ../../../pkgs.nix;
+  pkgs = import ../../../default.nix {};
 in
-  pkgs.haskell.packages.ghc861.small-steps
+  pkgs.nix-tools.libs.small-steps

--- a/specs/semantics/hs/shell.nix
+++ b/specs/semantics/hs/shell.nix
@@ -1,5 +1,0 @@
-let
-  pkgs = import ../../../pkgs.nix;
-in pkgs.lib.overrideDerivation ((import ./.).env) (old: {
-  nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.cabal-install pkgs.haskell.packages.ghc861.ghcid ];
-})


### PR DESCRIPTION
- Delegation design spec now builds correctly.
- Fix up the individual nix files in various haskell subdirs.
- Remove the corresponding shell.nix files in those subdirs. I could have fixed
  them, but I'm unconvinced anyone is using them, so I'd rather have less to
  bitrot. We can add them back if needed/wanted.

Addresses #304