### PR TITLE
using := for let binding symbol

### DIFF
--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -324,7 +324,7 @@ a stake pool, though these concerns are independent of the ledger rules.
   \begin{equation}\label{eq:deleg-reg}
     \inference[Deleg-Reg]
     {
-    \var{c}\in\DCertRegKey & hk = \cwitness{c} & hk \notin \dom \var{stkeys}
+    \var{c}\in\DCertRegKey & hk \leteq \cwitness{c} & hk \notin \dom \var{stkeys}
     }
     {
       \begin{array}{r}
@@ -355,7 +355,7 @@ a stake pool, though these concerns are independent of the ledger rules.
   \begin{equation}\label{eq:deleg-dereg}
     \inference[Deleg-Dereg]
     {
-      \var{c}\in \DCertDeRegKey  & hk = \cwitness{c} \\
+      \var{c}\in \DCertDeRegKey  & hk \leteq \cwitness{c} \\
     hk \in \dom \var{stkeys} & \addrRw \var{hk} \mapsto 0 \in \var{rewards}
     }
     {
@@ -387,7 +387,7 @@ a stake pool, though these concerns are independent of the ledger rules.
   \begin{equation}\label{eq:deleg-deleg}
     \inference[Deleg-Deleg]
     {
-      \var{c}\in \DCertDeleg & hk = \cwitness{c} & hk \in \dom \var{stkeys}
+      \var{c}\in \DCertDeleg & hk \leteq \cwitness{c} & hk \in \dom \var{stkeys}
     }
     {
       \begin{array}{r}
@@ -482,7 +482,7 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
     \inference[Pool-Reg]
     {
       \var{c}\in\DCertRegPool
-      & \var{hk} = \cwitness{c}
+      & \var{hk} \leteq \cwitness{c}
       & hk \notin \dom \var{stpools}
     }
     {
@@ -517,7 +517,7 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
     \inference[Pool-reReg]
     {
       \var{c}\in\DCertRegPool
-      & \var{hk} = \cwitness{c}
+      & \var{hk} \leteq \cwitness{c}
       & hk \in \dom \var{stpools}
     }
     {
@@ -551,10 +551,10 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
     \inference[Pool-Retire]
     {
     \var{c} \in \DCertRetirePool
-    & hk = \cwitness{c}
+    & hk \leteq \cwitness{c}
     & \var{hk} \in \dom \var{stpools} \\
-    \var{e} = \retire{c}
-    & \var{cepoch} = \epoch{slot}
+    \var{e} \leteq \retire{c}
+    & \var{cepoch} \leteq \epoch{slot}
     & \var{cepoch} < \var{e} < \var{cepoch} + (\fun{emax}~{pp})
   }
   {
@@ -778,11 +778,11 @@ will be invalid.
     \label{eq:delegs-base}
     \inference[Seq-delg-base]
     {
-      \var{wdrls} = \txwdrls{tx}
+      \var{wdrls} \leteq \txwdrls{tx}
       &
       \var{wdrls} \subseteq \var{rewards}
       \\
-      \var{rewards'} = \var{rewards} \unionoverrideRight \{(w, 0) \mid w \in \dom \var{wdrls}\}
+      \var{rewards'} \leteq \var{rewards} \unionoverrideRight \{(w, 0) \mid w \in \dom \var{wdrls}\}
     }
     {
       \left(
@@ -828,7 +828,7 @@ will be invalid.
     \inference[Seq-delg-ind]
     {
       \var{c}\in\DCertDeleg \Rightarrow \fun{dpool}~{c} \in \dom \var{stpools} \\
-        ptr = (\var{slot},~\var{txIx},~\mathsf{len}~\Gamma - 1) \\~\\
+        ptr \leteq (\var{slot},~\var{txIx},~\mathsf{len}~\Gamma - 1) \\~\\
         {
           \left(
             \begin{array}{r}

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -386,7 +386,7 @@ This transition has no preconditions and results in the following state change:
     \inference[Snapshot]
     {
       {
-      \begin{array}{r@{=}l}
+      \begin{array}{r@{~\leteq~}l}
         (\var{utxo},~\var{deposits},~\var{fees}) & \var{utxoSt}\\
         (\var{stkeys},~\wcard,~\var{delegations},~\wcard) & \var{dstate}\\
         (\var{stpools},~\var{poolParams},~\wcard,~\wcard) & \var{pstate}\\
@@ -507,7 +507,7 @@ This transition has no preconditions and results in the following state change:
     \inference[Pool-Reap]
     {
       {
-      \begin{array}{r@{=}l}
+      \begin{array}{r@{~\leteq~}l}
         \var{retired} & \var{retiring}^{-1}~\var{e_{new}} \\
         \var{pr} & \poolRefunds{pp}{retiring}{(\firstSlot{e_{new}})} \\
         \var{rewardAcnts}
@@ -667,15 +667,15 @@ for ease of reading.
     \inference[New-Proto-Param-Accepted]
     {
       {\begin{array}{rcl}
-          \var{slot} & = & \firstSlot{e_{new}} \\
-          \var{oblg_{cur}} & = & \obligation{pp}{stkeys}{stpools}{slot} \\
-          \var{oblg_{new}} & = & \obligation{pp_{new}}{stkeys}{stpools}{slot} \\
-          \var{diff} & = & \var{oblg_{cur}} - \var{oblg_{new}} \\
+          \var{slot} & \leteq & \firstSlot{e_{new}} \\
+          \var{oblg_{cur}} & \leteq & \obligation{pp}{stkeys}{stpools}{slot} \\
+          \var{oblg_{new}} & \leteq & \obligation{pp_{new}}{stkeys}{stpools}{slot} \\
+          \var{diff} & \leteq & \var{oblg_{cur}} - \var{oblg_{new}} \\
           \\
           \var{reserves} + \var{diff} & \geq & 0\\
       \end{array}}\\
       ~\\
-      \var{utxoSt'} =
+      \var{utxoSt'} \leteq
       \left(
         {
           \begin{array}{r}
@@ -686,7 +686,7 @@ for ease of reading.
         }
       \right)
       &
-      \var{acnt'} =
+      \var{acnt'} \leteq
       \left(
         {
           \begin{array}{r}
@@ -730,10 +730,10 @@ for ease of reading.
     \inference[New-Proto-Param-Denied]
     {
       {\begin{array}{rcl}
-          \var{slot} & = & \firstSlot{e_{new}} \\
-          \var{oblg_{cur}} & = & \obligation{pp}{stkeys}{stpools}{slot} \\
-          \var{oblg_{new}} & = & \obligation{pp_{new}}{stkeys}{stpools}{slot} \\
-          \var{diff} & = & \var{oblg_{cur}} - \var{oblg_{new}} \\
+          \var{slot} & \leteq & \firstSlot{e_{new}} \\
+          \var{oblg_{cur}} & \leteq & \obligation{pp}{stkeys}{stpools}{slot} \\
+          \var{oblg_{new}} & \leteq & \obligation{pp_{new}}{stkeys}{stpools}{slot} \\
+          \var{diff} & \leteq & \var{oblg_{cur}} - \var{oblg_{new}} \\
           \\
           \var{reserves} + \var{diff} & < & 0\\
       \end{array}}\\
@@ -1372,7 +1372,7 @@ smaller refunds for deposits than were paid upon depositing.
     \inference[Rewards]
     {
       {
-      \begin{array}{r@{=}l}
+      \begin{array}{r@{~\leteq~}l}
         \left(
           \begin{array}{c}
             \wcard \\

--- a/latex/ledger.tex
+++ b/latex/ledger.tex
@@ -60,9 +60,9 @@ and then calls the $\mathsf{DELEGS}$ transition.
     \label{eq:ledger}
     \inference[ledger]
     {
-      (\var{dstate}, \var{pstate}) = \var{dpstate} \\
-    (\var{stkeys}, \_, \_, \_) = \var{dstate} \\
-    (\_, \_, \var{stpools}, \_) = \var{pstate} \\~\\
+      (\var{dstate}, \var{pstate}) \leteq \var{dpstate} \\
+    (\var{stkeys}, \_, \_, \_) \leteq \var{dstate} \\
+    (\_, \_, \var{stpools}, \_) \leteq \var{pstate} \\~\\
       \left({
         \begin{array}{r}
         \var{slot} \\

--- a/latex/notation.tex
+++ b/latex/notation.tex
@@ -11,12 +11,6 @@ The transition system is explained in \cite{small_step_semantics}.
     denoted by $\epsilon$, and given a sequence $\Lambda$, $\Lambda; \type{x}$ is
     the sequence that results from appending $\type{x} \in \type{X}$ to
     $\Lambda$.
-  \item[Dropping on sequences] Given a sequence $\Lambda$,
-    $\Lambda \shortdownarrow n$ is the sequence that is obtained after removing
-    (dropping) the first $n$ elements from $\Lambda$. If $n \leq 0$ then
-    $\Lambda \shortdownarrow n = \Lambda$.
-  \item[Appending with a moving window] Given a sequence $\Lambda$, we define
-    $$\Lambda ;_w x \leteq (\Lambda; x) \shortdownarrow (\size{\Lambda} + 1 - w)$$
   \item[Functions] $A \to B$ denotes a \textbf{total function} from $A$ to $B$.
     Given a function $f$ we write $f~a$ for the application of $f$ to argument
     $a$.

--- a/latex/utxo.tex
+++ b/latex/utxo.tex
@@ -287,11 +287,11 @@ requests).
       \\
       ~
       \\
-      \var{refunded} = \keyRefunds{pp}{stkeys}~{tx}
+      \var{refunded} \leteq \keyRefunds{pp}{stkeys}~{tx}
       \\
-      \var{decayed} = \decayedTx{pp}{stkeys}~{tx}
+      \var{decayed} \leteq \decayedTx{pp}{stkeys}~{tx}
       \\
-      \var{depositChange} =
+      \var{depositChange} \leteq
         (\deposits{pp}~{stpools}~{\fun{dcerts}~tx}) - (\var{refunded} + \var{decayed})
     }
     {
@@ -559,7 +559,7 @@ If the predicates are satisfied, the state is transitioned by the UTxO transitio
     \label{eq:utxo-witness-inductive-shelley}
     \inference[UTxO-wit]
     {
-      (utxo, \wcard, \wcard) = \var{utxoSt} \\~\\
+      (utxo, \wcard, \wcard) \leteq \var{utxoSt} \\~\\
       \forall \var{vk} \mapsto \sigma \in \txwits{tx},
         \mathcal{V}_{\var{vk}}{\serialised{\txbody{tx}}}_{\sigma} \\
       \fun{witsNeeded}~{utxo}~{tx} = \{ \hashKey \var{vk} \mid \var{vk}\in\dom{(\txwits{tx})} \}\\


### PR DESCRIPTION
Use `:=` notation throughout the Shelley ledger spec for let bindings.  #313